### PR TITLE
feat: validate SplitToLines arguments

### DIFF
--- a/ECoreNetto.Extensions.Tests/StringExtensionsTestFixture.cs
+++ b/ECoreNetto.Extensions.Tests/StringExtensionsTestFixture.cs
@@ -44,6 +44,14 @@ namespace ECoreNetto.Extensions.Tests
         }
 
         [Test]
+        public void Verify_that_SplitToLines_validates_arguments()
+        {
+            Assert.Throws<ArgumentException>(() => StringExtensions.SplitToLines(null, 1));
+            Assert.Throws<ArgumentException>(() => "".SplitToLines(1));
+            Assert.Throws<ArgumentException>(() => "test".SplitToLines(0));
+        }
+
+        [Test]
         public void Verify_that_CapitalizeFirstLetter_returns_expected_result()
         {
             Assert.Throws<ArgumentException>(() => StringExtensions.CapitalizeFirstLetter(null));

--- a/ECoreNetto.Extensions/StringExtensions.cs
+++ b/ECoreNetto.Extensions/StringExtensions.cs
@@ -44,6 +44,16 @@ namespace ECoreNetto.Extensions
         /// </returns>
         public static IEnumerable<string> SplitToLines(this string input, int maximumLineLength)
         {
+            if (string.IsNullOrWhiteSpace(input))
+            {
+                throw new ArgumentException("string can't be empty!");
+            }
+
+            if (maximumLineLength <= 0)
+            {
+                throw new ArgumentException("maximumLineLength must be greater than zero");
+            }
+
             input = input.Replace("\r\n", " ").Trim();
 
             var words = input.Split(' ');


### PR DESCRIPTION
## Summary
- throw ArgumentException when SplitToLines receives null, empty or invalid line length
- test StringExtensions.SplitToLines for invalid arguments

## Testing
- `dotnet test --no-build` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68b9ae1169688326b2f925ba0efa1dfc