### PR TITLE
Add model-element unit tests to improve core coverage

### DIFF
--- a/ECoreNetto.Tests/ModelElement/OperationAndFactoryTestFixture.cs
+++ b/ECoreNetto.Tests/ModelElement/OperationAndFactoryTestFixture.cs
@@ -1,0 +1,145 @@
+﻿// -------------------------------------------------------------------------------------------------
+// <copyright file="OperationAndFactoryTestFixture.cs" company="Starion Group S.A.">
+//
+//   Copyright 2017-2025 Starion Group S.A.
+//
+//   Licensed under the Apache License, Version 2.0 (the "License");
+//   you may not use this file except in compliance with the License.
+//   You may obtain a copy of the License at
+//
+//       http://www.apache.org/licenses/LICENSE-2.0
+//
+//   Unless required by applicable law or agreed to in writing, software
+//   distributed under the License is distributed on an "AS IS" BASIS,
+//   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+//   See the License for the specific language governing permissions and
+//   limitations under the License.
+//
+// </copyright>
+// ------------------------------------------------------------------------------------------------
+
+namespace ECoreNetto.Tests.ModelElement
+{
+    using System;
+    using System.Xml;
+
+    using ECoreNetto.Resource;
+
+    using NUnit.Framework;
+
+    [TestFixture]
+    public class OperationAndFactoryTestFixture
+    {
+        [Test]
+        public void Verify_that_diagnostic_properties_are_set_by_constructor()
+        {
+            var diagnostic = new Diagnostic(8, 12, "test-location", "test message");
+
+            Assert.Multiple(() =>
+            {
+                Assert.That(diagnostic.Column, Is.EqualTo(8));
+                Assert.That(diagnostic.Line, Is.EqualTo(12));
+                Assert.That(diagnostic.Location, Is.EqualTo("test-location"));
+                Assert.That(diagnostic.Message, Is.EqualTo("test message"));
+            });
+        }
+
+        [Test]
+        public void Verify_that_efactory_can_be_constructed()
+        {
+            var resource = new Resource();
+
+            var eFactory = new EFactory(resource);
+
+            Assert.Multiple(() =>
+            {
+                Assert.That(eFactory.EResource, Is.EqualTo(resource));
+                Assert.That(eFactory.EPackage, Is.Null);
+            });
+        }
+
+        [Test]
+        public void Verify_that_eoperation_DeserializeChildNode_throws_for_null_reader()
+        {
+            var resource = new Resource();
+            var operation = new TestableEOperation(resource);
+
+            Assert.That(() => operation.ExposeDeserializeChildNode(null), Throws.ArgumentNullException);
+        }
+
+        [Test]
+        public void Verify_that_eoperation_DeserializeChildNode_adds_parameter()
+        {
+            var resource = new Resource();
+            var package = new EPackage(resource)
+            {
+                Name = "Pkg"
+            };
+
+            var eClass = new EClass(resource)
+            {
+                Name = "SampleClass"
+            };
+
+            package.EClassifiers.Add(eClass);
+
+            var operation = new TestableEOperation(resource)
+            {
+                Name = "DoWork"
+            };
+
+            eClass.EOperations.Add(operation);
+
+            var xmlDocument = new XmlDocument();
+            xmlDocument.LoadXml("<eParameters name=\"parameterOne\" />");
+
+            operation.ExposeDeserializeChildNode(xmlDocument.DocumentElement);
+
+            Assert.Multiple(() =>
+            {
+                Assert.That(operation.EParameters.Count, Is.EqualTo(1));
+                Assert.That(operation.EParameters[0].Name, Is.EqualTo("parameterOne"));
+                Assert.That(operation.EParameters[0].EOperation, Is.SameAs(operation));
+            });
+        }
+
+        [Test]
+        public void Verify_that_eoperation_identifier_contains_containing_class_identifier_and_name()
+        {
+            var resource = new Resource();
+            var package = new EPackage(resource)
+            {
+                Name = "Pkg"
+            };
+
+            var eClass = new EClass(resource)
+            {
+                Name = "SampleClass"
+            };
+
+            package.EClassifiers.Add(eClass);
+
+            var operation = new TestableEOperation(resource)
+            {
+                Name = "DoWork"
+            };
+
+            eClass.EOperations.Add(operation);
+
+            Assert.That(operation.Identifier, Is.EqualTo($"EOperation::{eClass.Identifier}/DoWork"));
+        }
+
+        private class TestableEOperation : EOperation
+        {
+            public TestableEOperation(Resource resource)
+                : base(resource)
+            {
+            }
+
+            public void ExposeDeserializeChildNode(XmlNode node)
+            {
+                this.DeserializeChildNode(node);
+            }
+        }
+    }
+}


### PR DESCRIPTION
### Motivation
- Increase automated test coverage for core model/resource types that were previously untested, specifically covering `Diagnostic`, `EFactory`, and `EOperation` behaviors.

### Description
- Add `ECoreNetto.Tests/ModelElement/OperationAndFactoryTestFixture.cs` containing tests for `Diagnostic` constructor property mapping and `EFactory` construction behavior.
- Add tests that validate `EOperation.DeserializeChildNode` null-argument guard and deserialization of an `<eParameters/>` child into the `EParameters` collection.
- Add a test that verifies `EOperation.Identifier` composition when an operation is attached to an `EClass` and include a small `TestableEOperation` helper to expose protected behavior for unit testing.

### Testing
- Ran `dotnet test ECoreNetto.Tests/ECoreNetto.Tests.csproj --nologo` and all tests passed (`Passed: 17, Failed: 0`).
- Ran coverage collection with `dotnet test ECoreNetto.Tests/ECoreNetto.Tests.csproj --nologo /p:CollectCoverage=true /p:CoverletOutputFormat=json` and generated `coverage.json`, reporting `ECoreNetto` at `77.51%` line coverage.
- Ran `dotnet test EcoreNetto.sln --nologo` to validate the full solution; all test projects completed successfully in the environment used.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69a3226f31308326b50dc208a2f3db85)