### PR TITLE
Add unit tests for ContainmentUpdater, ContainerList, and StructuralFeatureHelper

### DIFF
--- a/ECoreNetto.HandleBars.Tests/StructuralFeatureHelperTestFixture.cs
+++ b/ECoreNetto.HandleBars.Tests/StructuralFeatureHelperTestFixture.cs
@@ -177,5 +177,47 @@ namespace ECoreNetto.HandleBars.Tests
 
             Assert.That(result, Is.EqualTo("False"));
         }
+
+        [Test]
+        public void Verify_that_StructuralFeature_IsEnumerable_block_helper_writes_content_only_when_true()
+        {
+            var template = "{{#StructuralFeature.IsEnumerable this}}Enumerable{{/StructuralFeature.IsEnumerable}}";
+            var action = this.handlebarsContenxt.Compile(template);
+
+            var recipeClass = this.root.EClassifiers.OfType<EClass>().Single(x => x.Name == "Recipe");
+            var enumerableFeature = recipeClass.EStructuralFeatures.Single(x => x.Name == "ingredients");
+
+            var timeTriggerClass = this.root.EClassifiers.OfType<EClass>().Single(x => x.Name == "TimeTrigger");
+            var nonEnumerableFeature = timeTriggerClass.EStructuralFeatures.Single(x => x.Name == "minutes");
+
+            Assert.Multiple(() =>
+            {
+                Assert.That(action(enumerableFeature), Is.EqualTo("Enumerable"));
+                Assert.That(action(nonEnumerableFeature), Is.EqualTo(string.Empty));
+            });
+        }
+
+        [Test]
+        public void Verify_that_StructuralFeature_QueryTypeName_returns_expected_result()
+        {
+            var template = "{{#with this}}{{StructuralFeature.QueryTypeName}}{{/with}}";
+            var action = this.handlebarsContenxt.Compile(template);
+
+            var recipeClass = this.root.EClassifiers.OfType<EClass>().Single(x => x.Name == "Recipe");
+            var eStructuralFeature = recipeClass.EStructuralFeatures.Single(x => x.Name == "name");
+
+            var result = action(eStructuralFeature);
+
+            Assert.That(result, Is.EqualTo("string"));
+        }
+
+        [Test]
+        public void Verify_that_StructuralFeature_QueryTypeName_throws_when_context_is_not_a_structural_feature()
+        {
+            var template = "{{StructuralFeature.QueryTypeName}}";
+            var action = this.handlebarsContenxt.Compile(template);
+
+            Assert.That(() => action(new object()), Throws.TypeOf<ArgumentException>());
+        }
     }
 }

--- a/ECoreNetto.Tests/ModelElement/ContainerListTestFixture.cs
+++ b/ECoreNetto.Tests/ModelElement/ContainerListTestFixture.cs
@@ -1,0 +1,139 @@
+﻿// -------------------------------------------------------------------------------------------------
+// <copyright file="ContainerListTestFixture.cs" company="Starion Group S.A.">
+//
+//   Copyright 2017-2025 Starion Group S.A.
+//
+//   Licensed under the Apache License, Version 2.0 (the "License");
+//   you may not use this file except in compliance with the License.
+//   You may obtain a copy of the License at
+//
+//       http://www.apache.org/licenses/LICENSE-2.0
+//
+//   Unless required by applicable law or agreed to in writing, software
+//   distributed under the License is distributed on an "AS IS" BASIS,
+//   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+//   See the License for the specific language governing permissions and
+//   limitations under the License.
+//
+// </copyright>
+// ------------------------------------------------------------------------------------------------
+
+namespace ECoreNetto.Tests.ModelElement
+{
+    using System;
+
+    using NUnit.Framework;
+
+    [TestFixture]
+    public class ContainerListTestFixture
+    {
+        [Test]
+        public void Verify_that_Add_sets_container_and_reparents_element()
+        {
+            var resource = new Resource.Resource();
+            var sourceContainer = new EPackage(resource);
+            var targetContainer = new EPackage(resource);
+            var subject = new EPackage(resource)
+            {
+                Name = "MovedPackage"
+            };
+
+            sourceContainer.ESubPackages.Add(subject);
+
+            targetContainer.ESubPackages.Add(subject);
+
+            Assert.Multiple(() =>
+            {
+                Assert.That(sourceContainer.ESubPackages, Has.Count.EqualTo(0));
+                Assert.That(targetContainer.ESubPackages, Has.Count.EqualTo(1));
+                Assert.That(targetContainer.ESubPackages[0], Is.SameAs(subject));
+                Assert.That(subject.EContainer, Is.SameAs(targetContainer));
+            });
+        }
+
+        [Test]
+        public void Verify_that_Add_throws_when_item_is_null_or_duplicate()
+        {
+            var resource = new Resource.Resource();
+            var container = new EPackage(resource);
+            var subject = new EPackage(resource)
+            {
+                Name = "SubPackage"
+            };
+
+            Assert.That(() => container.ESubPackages.Add(null), Throws.ArgumentNullException);
+
+            container.ESubPackages.Add(subject);
+
+            Assert.That(() => container.ESubPackages.Add(subject), Throws.TypeOf<InvalidOperationException>());
+        }
+
+        [Test]
+        public void Verify_that_AddRange_throws_for_null_and_assigns_container_to_all_items()
+        {
+            var resource = new Resource.Resource();
+            var container = new EPackage(resource);
+
+            Assert.That(() => container.EClassifiers.AddRange(null), Throws.ArgumentNullException);
+
+            var classA = new EClass(resource)
+            {
+                Name = "A"
+            };
+
+            var classB = new EClass(resource)
+            {
+                Name = "B"
+            };
+
+            container.EClassifiers.AddRange(new[] { classA, classB });
+
+            Assert.Multiple(() =>
+            {
+                Assert.That(container.EClassifiers, Has.Count.EqualTo(2));
+                Assert.That(classA.EContainer, Is.SameAs(container));
+                Assert.That(classB.EContainer, Is.SameAs(container));
+            });
+        }
+
+        [Test]
+        public void Verify_that_indexer_setter_validates_input_and_reparents_item()
+        {
+            var resource = new Resource.Resource();
+            var sourceContainer = new EPackage(resource);
+            var targetContainer = new EPackage(resource);
+
+            var first = new EClass(resource)
+            {
+                Name = "First"
+            };
+
+            var second = new EClass(resource)
+            {
+                Name = "Second"
+            };
+
+            var replacement = new EClass(resource)
+            {
+                Name = "Replacement"
+            };
+
+            sourceContainer.EClassifiers.Add(replacement);
+            targetContainer.EClassifiers.AddRange(new[] { first, second });
+
+            Assert.That(() => targetContainer.EClassifiers[-1], Throws.ArgumentOutOfRangeException);
+            Assert.That(() => targetContainer.EClassifiers[2], Throws.ArgumentOutOfRangeException);
+            Assert.That(() => targetContainer.EClassifiers[0] = null, Throws.ArgumentNullException);
+            Assert.That(() => targetContainer.EClassifiers[0] = second, Throws.TypeOf<InvalidOperationException>());
+
+            targetContainer.EClassifiers[0] = replacement;
+
+            Assert.Multiple(() =>
+            {
+                Assert.That(sourceContainer.EClassifiers, Has.Count.EqualTo(0));
+                Assert.That(targetContainer.EClassifiers[0], Is.SameAs(replacement));
+                Assert.That(replacement.EContainer, Is.SameAs(targetContainer));
+            });
+        }
+    }
+}

--- a/ECoreNetto.Tests/Utils/ContainmentUpdaterTestFixture.cs
+++ b/ECoreNetto.Tests/Utils/ContainmentUpdaterTestFixture.cs
@@ -1,0 +1,140 @@
+﻿// -------------------------------------------------------------------------------------------------
+// <copyright file="ContainmentUpdaterTestFixture.cs" company="Starion Group S.A.">
+//
+//   Copyright 2017-2025 Starion Group S.A.
+//
+//   Licensed under the Apache License, Version 2.0 (the "License");
+//   you may not use this file except in compliance with the License.
+//   You may obtain a copy of the License at
+//
+//       http://www.apache.org/licenses/LICENSE-2.0
+//
+//   Unless required by applicable law or agreed to in writing, software
+//   distributed under the License is distributed on an "AS IS" BASIS,
+//   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+//   See the License for the specific language governing permissions and
+//   limitations under the License.
+//
+// </copyright>
+// ------------------------------------------------------------------------------------------------
+
+namespace ECoreNetto.Tests.Utils
+{
+    using System;
+
+    using ECoreNetto.Utils;
+
+    using NUnit.Framework;
+
+    [TestFixture]
+    public class ContainmentUpdaterTestFixture
+    {
+        [Test]
+        public void Verify_that_RemoveFromContainer_throws_for_null_subject()
+        {
+            Assert.That(() => ContainmentUpdater.RemoveFromContainer(null), Throws.ArgumentNullException);
+        }
+
+        [Test]
+        public void Verify_that_RemoveFromContainer_returns_when_subject_has_no_container()
+        {
+            var resource = new Resource.Resource();
+            var subject = new EClass(resource);
+
+            Assert.That(() => subject.RemoveFromContainer(), Throws.Nothing);
+        }
+
+        [Test]
+        public void Verify_that_RemoveFromContainer_removes_supported_types_from_their_parent_collections()
+        {
+            var resource = new Resource.Resource();
+            var parentPackage = new EPackage(resource)
+            {
+                Name = "Parent"
+            };
+
+            var subPackage = new EPackage(resource)
+            {
+                Name = "Child"
+            };
+
+            var classifier = new EClass(resource)
+            {
+                Name = "Classifier"
+            };
+
+            var annotation = new EAnnotation(resource);
+            var operation = new EOperation(resource)
+            {
+                Name = "Operation"
+            };
+
+            var parameter = new EParameter(resource)
+            {
+                Name = "Parameter"
+            };
+
+            var attribute = new EAttribute(resource)
+            {
+                Name = "Attribute"
+            };
+
+            var eEnum = new EEnum(resource)
+            {
+                Name = "Enum"
+            };
+
+            var literal = new EEnumLiteral(resource)
+            {
+                Name = "Literal"
+            };
+
+            parentPackage.ESubPackages.Add(subPackage);
+            parentPackage.EClassifiers.Add(classifier);
+            classifier.EAnnotations.Add(annotation);
+            classifier.EOperations.Add(operation);
+            operation.EParameters.Add(parameter);
+            classifier.EStructuralFeatures.Add(attribute);
+            eEnum.ELiterals.Add(literal);
+
+            subPackage.RemoveFromContainer();
+            classifier.RemoveFromContainer();
+            annotation.RemoveFromContainer();
+            operation.RemoveFromContainer();
+            parameter.RemoveFromContainer();
+            attribute.RemoveFromContainer();
+            literal.RemoveFromContainer();
+
+            Assert.Multiple(() =>
+            {
+                Assert.That(parentPackage.ESubPackages, Is.Empty);
+                Assert.That(parentPackage.EClassifiers, Is.Empty);
+                Assert.That(((EClass)classifier).EAnnotations, Is.Empty);
+                Assert.That(((EClass)classifier).EOperations, Is.Empty);
+                Assert.That(operation.EParameters, Is.Empty);
+                Assert.That(((EClass)classifier).EStructuralFeatures, Is.Empty);
+                Assert.That(eEnum.ELiterals, Is.Empty);
+            });
+        }
+
+        [Test]
+        public void Verify_that_RemoveFromContainer_throws_for_unsupported_type()
+        {
+            var resource = new Resource.Resource();
+            var unsupported = new TestEObject(resource)
+            {
+                EContainer = new EPackage(resource)
+            };
+
+            Assert.That(() => unsupported.RemoveFromContainer(), Throws.TypeOf<ArgumentException>());
+        }
+
+        private class TestEObject : EObject
+        {
+            public TestEObject(Resource.Resource resource)
+                : base(resource)
+            {
+            }
+        }
+    }
+}


### PR DESCRIPTION
### Motivation

- Improve unit-test coverage around containment semantics and container collections to prevent regressions in reparenting and removal behavior.
- Validate Handlebars helpers for `EStructuralFeature` to ensure block-helper rendering and type-name resolution behave as expected.

### Description

- Added `ECoreNetto.Tests/ModelElement/ContainerListTestFixture.cs` which tests `ContainerList<T>` behavior including `Add`, `AddRange`, and indexer setter validations and re-parenting.
- Added `ECoreNetto.Tests/Utils/ContainmentUpdaterTestFixture.cs` which tests `ContainmentUpdater.RemoveFromContainer` for null input, no-container no-op, supported-type removals, and unsupported-type exception path.
- Extended `ECoreNetto.HandleBars.Tests/StructuralFeatureHelperTestFixture.cs` with tests for the `StructuralFeature.IsEnumerable` block helper and `StructuralFeature.QueryTypeName` success and invalid-context exception cases.

### Testing

- Attempted to run the test project with `dotnet test ECoreNetto.Tests/ECoreNetto.Tests.csproj --no-restore` but execution failed because `dotnet` is not installed in this environment (`bash: command not found: dotnet`).
- No automated tests were executed here; the added tests should be run by CI or a local environment with the .NET SDK to verify success.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69a32e3a98c08326a02e8ac78d5e600e)