### PR TITLE
Add tests for ContainmentUpdater & EcoreObjectFactory; fix two defects they expose (#52)

### DIFF
--- a/ECoreNetto.Tests/Utils/ContainmentUpdaterTestFixture.cs
+++ b/ECoreNetto.Tests/Utils/ContainmentUpdaterTestFixture.cs
@@ -1,0 +1,201 @@
+// -------------------------------------------------------------------------------------------------
+// <copyright file="ContainmentUpdaterTestFixture.cs" company="Starion Group S.A.">
+//
+//   Copyright 2017-2025 Starion Group S.A.
+//
+//   Licensed under the Apache License, Version 2.0 (the "License");
+//   you may not use this file except in compliance with the License.
+//   You may obtain a copy of the License at
+//
+//       http://www.apache.org/licenses/LICENSE-2.0
+//
+//   Unless required by applicable law or agreed to in writing, software
+//   distributed under the License is distributed on an "AS IS" BASIS,
+//   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+//   See the License for the specific language governing permissions and
+//   limitations under the License.
+//
+// </copyright>
+// ------------------------------------------------------------------------------------------------
+
+namespace ECoreNetto.Tests.Utils
+{
+    using ECoreNetto.Resource;
+    using ECoreNetto.Utils;
+
+    using NUnit.Framework;
+
+    /// <summary>
+    /// Suite of tests for the <see cref="ContainmentUpdater"/> class.
+    /// </summary>
+    [TestFixture]
+    public class ContainmentUpdaterTestFixture
+    {
+        /// <summary>
+        /// The <see cref="Resource"/> used to instantiate the <see cref="EObject"/>s under test
+        /// </summary>
+        private Resource resource;
+
+        [SetUp]
+        public void SetUp()
+        {
+            this.resource = new Resource();
+        }
+
+        [Test]
+        public void Verify_that_RemoveFromContainer_throws_when_object_is_null()
+        {
+            EObject @object = null;
+
+            Assert.That(() => @object.RemoveFromContainer(), Throws.ArgumentNullException);
+        }
+
+        [Test]
+        public void Verify_that_RemoveFromContainer_is_a_noop_when_object_has_no_container()
+        {
+            var eClass = new EClass(this.resource) { Name = "Orphan" };
+
+            Assert.Multiple(() =>
+            {
+                Assert.That(eClass.EContainer, Is.Null);
+                Assert.That(() => eClass.RemoveFromContainer(), Throws.Nothing);
+            });
+        }
+
+        [Test]
+        public void Verify_that_an_EAnnotation_is_removed_from_its_container()
+        {
+            var eClass = new EClass(this.resource) { Name = "WithAnnotation" };
+            var annotation = new EAnnotation(this.resource);
+            eClass.EAnnotations.Add(annotation);
+
+            annotation.RemoveFromContainer();
+
+            Assert.That(eClass.EAnnotations, Does.Not.Contain(annotation));
+        }
+
+        [Test]
+        public void Verify_that_a_sub_EPackage_is_removed_from_its_container()
+        {
+            var parent = new EPackage(this.resource) { Name = "Parent" };
+            var child = new EPackage(this.resource) { Name = "Child" };
+            parent.ESubPackages.Add(child);
+
+            child.RemoveFromContainer();
+
+            Assert.That(parent.ESubPackages, Does.Not.Contain(child));
+        }
+
+        [Test]
+        public void Verify_that_an_EClassifier_is_removed_from_its_container()
+        {
+            var package = new EPackage(this.resource) { Name = "Pkg" };
+            var eClass = new EClass(this.resource) { Name = "SomeClass" };
+            package.EClassifiers.Add(eClass);
+
+            eClass.RemoveFromContainer();
+
+            Assert.That(package.EClassifiers, Does.Not.Contain(eClass));
+        }
+
+        [Test]
+        public void Verify_that_an_EParameter_is_removed_from_its_container()
+        {
+            var operation = new EOperation(this.resource) { Name = "DoWork" };
+            var parameter = new EParameter(this.resource) { Name = "arg" };
+            operation.EParameters.Add(parameter);
+
+            parameter.RemoveFromContainer();
+
+            Assert.That(operation.EParameters, Does.Not.Contain(parameter));
+        }
+
+        [Test]
+        public void Verify_that_an_EOperation_is_removed_from_its_container()
+        {
+            var eClass = new EClass(this.resource) { Name = "Owner" };
+            var operation = new EOperation(this.resource) { Name = "DoWork" };
+            eClass.EOperations.Add(operation);
+
+            operation.RemoveFromContainer();
+
+            Assert.That(eClass.EOperations, Does.Not.Contain(operation));
+        }
+
+        [Test]
+        public void Verify_that_an_EStructuralFeature_is_removed_from_its_container()
+        {
+            var eClass = new EClass(this.resource) { Name = "Owner" };
+            var attribute = new EAttribute(this.resource) { Name = "name" };
+            eClass.EStructuralFeatures.Add(attribute);
+
+            attribute.RemoveFromContainer();
+
+            Assert.That(eClass.EStructuralFeatures, Does.Not.Contain(attribute));
+        }
+
+        [Test]
+        public void Verify_that_an_EEnumLiteral_is_removed_from_its_container()
+        {
+            var eEnum = new EEnum(this.resource) { Name = "Color" };
+            var literal = new EEnumLiteral(this.resource) { Name = "Red" };
+            eEnum.ELiterals.Add(literal);
+
+            literal.RemoveFromContainer();
+
+            Assert.That(eEnum.ELiterals, Does.Not.Contain(literal));
+        }
+
+        [Test]
+        public void Verify_that_adding_to_a_container_moves_the_object_from_its_previous_container()
+        {
+            var packageA = new EPackage(this.resource) { Name = "A" };
+            var packageB = new EPackage(this.resource) { Name = "B" };
+            var eClass = new EClass(this.resource) { Name = "Movable" };
+
+            packageA.EClassifiers.Add(eClass);
+            packageB.EClassifiers.Add(eClass);
+
+            Assert.Multiple(() =>
+            {
+                Assert.That(packageA.EClassifiers, Does.Not.Contain(eClass));
+                Assert.That(packageB.EClassifiers, Does.Contain(eClass));
+                Assert.That(eClass.EContainer, Is.SameAs(packageB));
+            });
+        }
+
+        [Test]
+        public void Verify_that_an_EEnumLiteral_can_be_reparented_between_enums()
+        {
+            var enumA = new EEnum(this.resource) { Name = "EnumA" };
+            var enumB = new EEnum(this.resource) { Name = "EnumB" };
+            var literal = new EEnumLiteral(this.resource) { Name = "Literal" };
+
+            enumA.ELiterals.Add(literal);
+
+            // re-parenting triggers ContainmentUpdater.RemoveFromContainer for an EEnumLiteral
+            // that already has a container; this must not throw (regression guard).
+            Assert.That(() => enumB.ELiterals.Add(literal), Throws.Nothing);
+
+            Assert.Multiple(() =>
+            {
+                Assert.That(enumA.ELiterals, Does.Not.Contain(literal));
+                Assert.That(enumB.ELiterals, Does.Contain(literal));
+                Assert.That(literal.EContainer, Is.SameAs(enumB));
+            });
+        }
+
+        [Test]
+        public void Verify_that_RemoveFromContainer_throws_for_an_unsupported_type()
+        {
+            var package = new EPackage(this.resource) { Name = "Pkg" };
+
+            // EFactory derives from EModelElement and is not handled by RemoveFromContainer
+            var factory = new EFactory(this.resource) { EContainer = package };
+
+            Assert.That(
+                () => factory.RemoveFromContainer(),
+                Throws.ArgumentException.With.Message.Contains(typeof(EFactory).ToString()));
+        }
+    }
+}

--- a/ECoreNetto.Tests/Utils/EcoreObjectFactoryTestFixture.cs
+++ b/ECoreNetto.Tests/Utils/EcoreObjectFactoryTestFixture.cs
@@ -1,0 +1,174 @@
+// -------------------------------------------------------------------------------------------------
+// <copyright file="EcoreObjectFactoryTestFixture.cs" company="Starion Group S.A.">
+//
+//   Copyright 2017-2025 Starion Group S.A.
+//
+//   Licensed under the Apache License, Version 2.0 (the "License");
+//   you may not use this file except in compliance with the License.
+//   You may obtain a copy of the License at
+//
+//       http://www.apache.org/licenses/LICENSE-2.0
+//
+//   Unless required by applicable law or agreed to in writing, software
+//   distributed under the License is distributed on an "AS IS" BASIS,
+//   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+//   See the License for the specific language governing permissions and
+//   limitations under the License.
+//
+// </copyright>
+// ------------------------------------------------------------------------------------------------
+
+namespace ECoreNetto.Tests.Utils
+{
+    using ECoreNetto.Resource;
+    using ECoreNetto.Utils;
+
+    using NUnit.Framework;
+
+    /// <summary>
+    /// Suite of tests for the <see cref="EcoreObjectFactory"/> class.
+    /// </summary>
+    [TestFixture]
+    public class EcoreObjectFactoryTestFixture
+    {
+        /// <summary>
+        /// The <see cref="Resource"/> passed to the factory under test
+        /// </summary>
+        private Resource resource;
+
+        /// <summary>
+        /// The class that is being tested
+        /// </summary>
+        private EcoreObjectFactory factory;
+
+        [SetUp]
+        public void SetUp()
+        {
+            this.resource = new Resource();
+            this.factory = new EcoreObjectFactory(this.resource);
+        }
+
+        [Test]
+        public void Verify_that_factory_can_be_constructed_with_null_logger_factory()
+        {
+            Assert.That(() => new EcoreObjectFactory(new Resource(), null), Throws.Nothing);
+        }
+
+        [Test]
+        public void Verify_that_all_meta_class_instances_are_created_with_expected_names()
+        {
+            Assert.Multiple(() =>
+            {
+                Assert.That(this.factory.EObject?.Name, Is.EqualTo("EObject"));
+                Assert.That(this.factory.EModelElement?.Name, Is.EqualTo("EModelElement"));
+                Assert.That(this.factory.ENamedElement?.Name, Is.EqualTo("ENamedElement"));
+                Assert.That(this.factory.EFactory?.Name, Is.EqualTo("EFactory"));
+                Assert.That(this.factory.EAnnotation?.Name, Is.EqualTo("EAnnotation"));
+                Assert.That(this.factory.EClassifier?.Name, Is.EqualTo("EClassifier"));
+                Assert.That(this.factory.EEnumLiteral?.Name, Is.EqualTo("EEnumLiteral"));
+                Assert.That(this.factory.EPackage?.Name, Is.EqualTo("EPackage"));
+                Assert.That(this.factory.ETypedElement?.Name, Is.EqualTo("ETypedElement"));
+                Assert.That(this.factory.EClass?.Name, Is.EqualTo("EClass"));
+                Assert.That(this.factory.EDataType?.Name, Is.EqualTo("EDataType"));
+                Assert.That(this.factory.EEnum?.Name, Is.EqualTo("EEnum"));
+                Assert.That(this.factory.EOperation?.Name, Is.EqualTo("EOperation"));
+                Assert.That(this.factory.EParameter?.Name, Is.EqualTo("EParameter"));
+                Assert.That(this.factory.EStructuralFeature?.Name, Is.EqualTo("EStructuralFeature"));
+                Assert.That(this.factory.EAttribute?.Name, Is.EqualTo("EAttribute"));
+                Assert.That(this.factory.EReference?.Name, Is.EqualTo("EReference"));
+                Assert.That(this.factory.EStringToStringMapEntry?.Name, Is.EqualTo("EStringToStringMapEntry"));
+                Assert.That(this.factory.EGenericType?.Name, Is.EqualTo("EGenericType"));
+                Assert.That(this.factory.ETypeParameter?.Name, Is.EqualTo("ETypeParameter"));
+            });
+        }
+
+        [Test]
+        public void Verify_that_abstract_meta_classes_are_marked_abstract()
+        {
+            Assert.Multiple(() =>
+            {
+                Assert.That(this.factory.EObject.Abstract, Is.True);
+                Assert.That(this.factory.EModelElement.Abstract, Is.True);
+                Assert.That(this.factory.ENamedElement.Abstract, Is.True);
+                Assert.That(this.factory.EClassifier.Abstract, Is.True);
+                Assert.That(this.factory.ETypedElement.Abstract, Is.True);
+                Assert.That(this.factory.EStructuralFeature.Abstract, Is.True);
+
+                // a representative non-abstract meta class
+                Assert.That(this.factory.EClass.Abstract, Is.False);
+            });
+        }
+
+        [Test]
+        public void Verify_that_the_meta_class_super_type_hierarchy_is_wired()
+        {
+            Assert.Multiple(() =>
+            {
+                Assert.That(this.factory.EModelElement.ESuperTypes, Does.Contain(this.factory.EObject));
+                Assert.That(this.factory.ENamedElement.ESuperTypes, Does.Contain(this.factory.EModelElement));
+                Assert.That(this.factory.EClassifier.ESuperTypes, Does.Contain(this.factory.ENamedElement));
+                Assert.That(this.factory.ETypedElement.ESuperTypes, Does.Contain(this.factory.ENamedElement));
+                Assert.That(this.factory.EClass.ESuperTypes, Does.Contain(this.factory.EClassifier));
+                Assert.That(this.factory.EDataType.ESuperTypes, Does.Contain(this.factory.EClassifier));
+                Assert.That(this.factory.EEnum.ESuperTypes, Does.Contain(this.factory.EClassifier));
+                Assert.That(this.factory.EOperation.ESuperTypes, Does.Contain(this.factory.ETypedElement));
+                Assert.That(this.factory.EParameter.ESuperTypes, Does.Contain(this.factory.ETypedElement));
+                Assert.That(this.factory.EStructuralFeature.ESuperTypes, Does.Contain(this.factory.ETypedElement));
+                Assert.That(this.factory.EAttribute.ESuperTypes, Does.Contain(this.factory.EStructuralFeature));
+                Assert.That(this.factory.EReference.ESuperTypes, Does.Contain(this.factory.EStructuralFeature));
+            });
+        }
+
+        [Test]
+        public void Verify_that_all_data_type_instances_are_created_with_expected_names()
+        {
+            Assert.Multiple(() =>
+            {
+                Assert.That(this.factory.EBigDecimal?.Name, Is.EqualTo("EBigDecimal"));
+                Assert.That(this.factory.EBigInteger?.Name, Is.EqualTo("EBigInteger"));
+                Assert.That(this.factory.EBool?.Name, Is.EqualTo("EBool"));
+                Assert.That(this.factory.EBooleanObject?.Name, Is.EqualTo("EBooleanObject"));
+                Assert.That(this.factory.EByte?.Name, Is.EqualTo("EByte"));
+                Assert.That(this.factory.EByteArray?.Name, Is.EqualTo("EByteArray"));
+                Assert.That(this.factory.EByteObject?.Name, Is.EqualTo("EByteObject"));
+                Assert.That(this.factory.EChar?.Name, Is.EqualTo("EChar"));
+                Assert.That(this.factory.ECharacterObject?.Name, Is.EqualTo("ECharacterObject"));
+                Assert.That(this.factory.EDate?.Name, Is.EqualTo("EDate"));
+                Assert.That(this.factory.EDiagnosticChain?.Name, Is.EqualTo("EDiagnosticChain"));
+                Assert.That(this.factory.EDouble?.Name, Is.EqualTo("EDouble"));
+                Assert.That(this.factory.EDoubleObject?.Name, Is.EqualTo("EDoubleObject"));
+                Assert.That(this.factory.EEList?.Name, Is.EqualTo("EEList"));
+                Assert.That(this.factory.EEnumerator?.Name, Is.EqualTo("EEnumerator"));
+                Assert.That(this.factory.EFeatureMap?.Name, Is.EqualTo("EFeatureMap"));
+                Assert.That(this.factory.EFeatureMapEntry?.Name, Is.EqualTo("EFeatureMapEntry"));
+                Assert.That(this.factory.EFloat?.Name, Is.EqualTo("EFloat"));
+                Assert.That(this.factory.EFloatObject?.Name, Is.EqualTo("EFloatObject"));
+                Assert.That(this.factory.EInt?.Name, Is.EqualTo("EInt"));
+                Assert.That(this.factory.EIntegerObject?.Name, Is.EqualTo("EIntegerObject"));
+                Assert.That(this.factory.EJavaClass?.Name, Is.EqualTo("EJavaClass"));
+                Assert.That(this.factory.EJavaObject?.Name, Is.EqualTo("EJavaObject"));
+                Assert.That(this.factory.ELong?.Name, Is.EqualTo("ELong"));
+                Assert.That(this.factory.ELongObject?.Name, Is.EqualTo("ELongObject"));
+                Assert.That(this.factory.EMap?.Name, Is.EqualTo("EMap"));
+                Assert.That(this.factory.EResource?.Name, Is.EqualTo("EResource"));
+                Assert.That(this.factory.EResourceSet?.Name, Is.EqualTo("EResourceSet"));
+                Assert.That(this.factory.EShort?.Name, Is.EqualTo("EShort"));
+                Assert.That(this.factory.EShortObject?.Name, Is.EqualTo("EShortObject"));
+                Assert.That(this.factory.EString?.Name, Is.EqualTo("EString"));
+                Assert.That(this.factory.ETreeIterator?.Name, Is.EqualTo("ETreeIterator"));
+                Assert.That(this.factory.EInvocationTargetException?.Name, Is.EqualTo("EInvocationTargetException"));
+            });
+        }
+
+        [Test]
+        public void Verify_that_created_instances_reference_the_provided_resource()
+        {
+            Assert.Multiple(() =>
+            {
+                Assert.That(this.factory.EObject.EResource, Is.SameAs(this.resource));
+                Assert.That(this.factory.EString.EResource, Is.SameAs(this.resource));
+                Assert.That(this.factory.EStringToStringMapEntry.EResource, Is.SameAs(this.resource));
+            });
+        }
+    }
+}

--- a/ECoreNetto/Utils/ContainmentUpdater.cs
+++ b/ECoreNetto/Utils/ContainmentUpdater.cs
@@ -84,7 +84,8 @@ namespace ECoreNetto.Utils
 
             if (@object is EEnumLiteral enumLiteral)
             {
-                RemoveFromContainer(enumLiteral);                
+                RemoveFromContainer(enumLiteral);
+                return;
             }
 
             throw new ArgumentException($"The subclass is not supported {@object.GetType()}");

--- a/ECoreNetto/Utils/EcoreObjectFactory.cs
+++ b/ECoreNetto/Utils/EcoreObjectFactory.cs
@@ -95,6 +95,8 @@ namespace ECoreNetto.Utils
             this.EReference = new EClass(resource, loggerFactory) { Name = "EReference" };
             this.EReference.ESuperTypes.Add(this.EStructuralFeature);
 
+            this.EStringToStringMapEntry = new EClass(resource, loggerFactory) { Name = "EStringToStringMapEntry" };
+
             this.EGenericType = new EClass(resource, loggerFactory) { Name = "EGenericType" };
 
             this.ETypeParameter = new EClass(resource, loggerFactory) { Name = "ETypeParameter" };


### PR DESCRIPTION
### Prerequisites

- [x] I have written a descriptive pull-request title
- [x] I have verified that there are no overlapping [pull-requests](https://github.com/STARIONGROUP/EcoreNetto/pulls) open
- [x] I have verified that I am following the EcoreNetto [code style guidelines](https://raw.githubusercontent.com/STARIONGROUP/EcoreNetto/master/.github/CONTRIBUTING.md)
- [x] I have provided test coverage for my change (where applicable)

### Description

Adds unit-test coverage for two previously untested core utilities and fixes two  latent defects the tests revealed.

  Tests (ECoreNetto.Tests/Utils/):
  - ContainmentUpdaterTestFixture — null/no-container guards, removal of every handled containment type, re-parent integration, an EEnumLiteral re-parent regression guard, and the unsupported-type branch (EFactory → ArgumentException).
  - EcoreObjectFactoryTestFixture — meta-class names, abstract flags, super-type wiring, all data-type names, and resource wiring.

  Fixes:
  - ContainmentUpdater.RemoveFromContainer: missing `return` in the EEnumLiteral branch caused re-parenting an enum literal to remove it and then throw ArgumentException.
  - EcoreObjectFactory: EStringToStringMapEntry was declared but never assigned, leaving a null registered in Resource (the type is used by TestData/ecore.ecore).



<!-- Thanks for contributing to EcoreNetto! -->