### PR TITLE
Add guard/null checks in HandleBars helpers & extensions; fix NameEqualsEnclosingType arity (#45)

### DIFF
--- a/ECoreNetto.Extensions.Tests/StringExtensionsTestFixture.cs
+++ b/ECoreNetto.Extensions.Tests/StringExtensionsTestFixture.cs
@@ -44,6 +44,15 @@ namespace ECoreNetto.Extensions.Tests
         }
 
         [Test]
+        public void Verify_that_SplitToLines_throws_for_null_or_empty_input()
+        {
+            // validation is eager: the exception is thrown on the call, not on enumeration
+            Assert.Throws<ArgumentException>(() => StringExtensions.SplitToLines(null, 10));
+
+            Assert.Throws<ArgumentException>(() => "".SplitToLines(10));
+        }
+
+        [Test]
         public void Verify_that_CapitalizeFirstLetter_returns_expected_result()
         {
             Assert.Throws<ArgumentException>(() => StringExtensions.CapitalizeFirstLetter(null));

--- a/ECoreNetto.Extensions/StringExtensions.cs
+++ b/ECoreNetto.Extensions/StringExtensions.cs
@@ -44,6 +44,28 @@ namespace ECoreNetto.Extensions
         /// </returns>
         public static IEnumerable<string> SplitToLines(this string input, int maximumLineLength)
         {
+            if (string.IsNullOrEmpty(input))
+            {
+                throw new ArgumentException("The input string may not be null or empty", nameof(input));
+            }
+
+            return SplitToLinesIterator(input, maximumLineLength);
+        }
+
+        /// <summary>
+        /// splits a string into multiple lines
+        /// </summary>
+        /// <param name="input">
+        /// the subject input string
+        /// </param>
+        /// <param name="maximumLineLength">
+        /// the maximum length of a line
+        /// </param>
+        /// <returns>
+        /// an <see cref="IEnumerable{String}"/>
+        /// </returns>
+        private static IEnumerable<string> SplitToLinesIterator(string input, int maximumLineLength)
+        {
             input = input.Replace("\r\n", " ").Trim();
 
             var words = input.Split(' ');

--- a/ECoreNetto.HandleBars.Tests/GeneralizationHelperTestFixture.cs
+++ b/ECoreNetto.HandleBars.Tests/GeneralizationHelperTestFixture.cs
@@ -80,5 +80,19 @@ namespace ECoreNetto.HandleBars.Tests
 
             Assert.That(result, Is.EqualTo(": Relation, IContainmentRelation"));
         }
+
+        [Test]
+        public void Verify_that_GeneralizationClasses_returns_interface_for_class_without_supertypes()
+        {
+            var template = "{{ #Generalization.Classes this }}";
+
+            var action = this.handlebarsContenxt.Compile(template);
+
+            var eClass = this.root.EClassifiers.Single(x => x.Name == "Relation");
+
+            var result = action(eClass);
+
+            Assert.That(result, Is.EqualTo(": IRelation"));
+        }
     }
 }

--- a/ECoreNetto.HandleBars.Tests/StringHelperTestFixture.cs
+++ b/ECoreNetto.HandleBars.Tests/StringHelperTestFixture.cs
@@ -86,5 +86,25 @@ namespace ECoreNetto.HandleBars.Tests
 
             Assert.Throws<HandlebarsException>(() => action("uppercase"));
         }
+
+        [Test]
+        public void Verify_that_CapitalizeFirstLetter_throws_exception_when_argument_is_not_a_string()
+        {
+            var template = "{{ #String.CapitalizeFirstLetter this }}";
+
+            var action = this.handlebarsContenxt.Compile(template);
+
+            Assert.Throws<HandlebarsException>(() => action(42));
+        }
+
+        [Test]
+        public void Verify_that_LowerCaseFirstLetter_throws_exception_when_argument_is_not_a_string()
+        {
+            var template = "{{ #String.LowerCaseFirstLetter this }}";
+
+            var action = this.handlebarsContenxt.Compile(template);
+
+            Assert.Throws<HandlebarsException>(() => action(42));
+        }
     }
 }

--- a/ECoreNetto.HandleBars.Tests/StructuralFeatureHelperTestFixture.cs
+++ b/ECoreNetto.HandleBars.Tests/StructuralFeatureHelperTestFixture.cs
@@ -177,5 +177,48 @@ namespace ECoreNetto.HandleBars.Tests
 
             Assert.That(result, Is.EqualTo("False"));
         }
+
+        [Test]
+        public void Verify_that_StructuralFeature_NameEqualsEnclosingType_renders_when_names_match()
+        {
+            var template = "{{#StructuralFeature.NameEqualsEnclosingType feature eClass}}MATCH{{/StructuralFeature.NameEqualsEnclosingType}}";
+
+            var action = this.handlebarsContenxt.Compile(template);
+
+            var eClass = this.root.EClassifiers.OfType<EClass>().Single(x => x.Name == "Amount");
+            var eStructuralFeature = eClass.EStructuralFeatures.Single(x => x.Name == "amount");
+
+            var result = action(new { feature = eStructuralFeature, eClass });
+
+            Assert.That(result, Is.EqualTo("MATCH"));
+        }
+
+        [Test]
+        public void Verify_that_StructuralFeature_NameEqualsEnclosingType_does_not_render_when_names_differ()
+        {
+            var template = "{{#StructuralFeature.NameEqualsEnclosingType feature eClass}}MATCH{{/StructuralFeature.NameEqualsEnclosingType}}";
+
+            var action = this.handlebarsContenxt.Compile(template);
+
+            var eClass = this.root.EClassifiers.OfType<EClass>().Single(x => x.Name == "Amount");
+            var eStructuralFeature = eClass.EStructuralFeatures.Single(x => x.Name == "unit");
+
+            var result = action(new { feature = eStructuralFeature, eClass });
+
+            Assert.That(result, Is.Empty);
+        }
+
+        [Test]
+        public void Verify_that_StructuralFeature_NameEqualsEnclosingType_throws_when_not_exactly_two_arguments()
+        {
+            var template = "{{#StructuralFeature.NameEqualsEnclosingType feature}}MATCH{{/StructuralFeature.NameEqualsEnclosingType}}";
+
+            var action = this.handlebarsContenxt.Compile(template);
+
+            var eClass = this.root.EClassifiers.OfType<EClass>().Single(x => x.Name == "Amount");
+            var eStructuralFeature = eClass.EStructuralFeatures.Single(x => x.Name == "amount");
+
+            Assert.Throws<HandlebarsException>(() => action(new { feature = eStructuralFeature }));
+        }
     }
 }

--- a/ECoreNetto.HandleBars/StringHelper.cs
+++ b/ECoreNetto.HandleBars/StringHelper.cs
@@ -44,7 +44,10 @@ namespace ECoreNetto.HandleBars
                     throw new HandlebarsException("{{#String.CapitalizeFirstLetter}} helper must have exactly one argument");
                 }
 
-                var value = parameters[0] as string;
+                if (!(parameters[0] is string value))
+                {
+                    throw new HandlebarsException("{{#String.CapitalizeFirstLetter}} helper requires a single string argument");
+                }
 
                 writer.WriteSafeString(value.CapitalizeFirstLetter());
             });
@@ -56,7 +59,10 @@ namespace ECoreNetto.HandleBars
                     throw new HandlebarsException("{{#String.LowerCaseFirstLetter}} helper must have exactly one argument");
                 }
 
-                var value = parameters[0] as string;
+                if (!(parameters[0] is string value))
+                {
+                    throw new HandlebarsException("{{#String.LowerCaseFirstLetter}} helper requires a single string argument");
+                }
 
                 writer.WriteSafeString(value.LowerCaseFirstLetter());
             });

--- a/ECoreNetto.HandleBars/StructuralFeatureHelper.cs
+++ b/ECoreNetto.HandleBars/StructuralFeatureHelper.cs
@@ -143,13 +143,13 @@ namespace ECoreNetto.HandleBars
 
             handlebars.RegisterHelper("StructuralFeature.NameEqualsEnclosingType", (output, options, context, arguments) =>
             {
-                if (arguments.Length != 1)
+                if (arguments.Length != 2)
                 {
                     throw new HandlebarsException("{{#StructuralFeature.NameEqualsEnclosingType}} helper must have exactly two arguments");
                 }
 
-                var eStructuralFeature = arguments.Single() as EStructuralFeature;
-                var eClass = arguments.Last() as EClass;
+                var eStructuralFeature = arguments[0] as EStructuralFeature;
+                var eClass = arguments[1] as EClass;
 
                 var nameEqualsEnclosingType = eStructuralFeature.QueryStructuralFeatureNameEqualsEnclosingType(eClass);
 


### PR DESCRIPTION
### Prerequisites

- [x] I have written a descriptive pull-request title
- [x] I have verified that there are no overlapping [pull-requests](https://github.com/STARIONGROUP/EcoreNetto/pulls) open
- [x] I have verified that I am following the EcoreNetto [code style guidelines](https://raw.githubusercontent.com/STARIONGROUP/EcoreNetto/master/.github/CONTRIBUTING.md)
- [x] I have provided test coverage for my change (where applicable)

### Description

  Adds descriptive input validation to helper code that previously threw low-level  exceptions (or silently misbehaved), plus tests for the invalid-input paths.

  - StringHelper: CapitalizeFirstLetter/LowerCaseFirstLetter now throw a descriptive HandlebarsException when the argument is not a string.
  - StructuralFeatureHelper.NameEqualsEnclosingType: now requires two arguments (feature + enclosing EClass) and reads arguments[0]/[1], matching its Query sibling; it previously validated for one argument and read the same element twice, so it could not perform its comparison. The "two arguments" message is now accurate.
  - StringExtensions.SplitToLines: eagerly throws ArgumentException on null/empty input (split into a validating wrapper + private iterator).

<!-- Thanks for contributing to EcoreNetto! -->