### PR TITLE
Enable nullable reference types solution-wide (#49)

### DIFF
--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -1,0 +1,11 @@
+<Project>
+
+    <!--
+      Solution-wide build properties. Currently scoped to enabling nullable
+      reference types consistently across all projects (see issue #49).
+    -->
+    <PropertyGroup>
+        <Nullable>enable</Nullable>
+    </PropertyGroup>
+
+</Project>

--- a/ECoreNetto.Extensions.Tests/ClassExtensionsTestFixture.cs
+++ b/ECoreNetto.Extensions.Tests/ClassExtensionsTestFixture.cs
@@ -36,8 +36,8 @@ namespace ECoreNetto.Extensions.Tests
     [TestFixture]
     public class ClassExtensionsTestFixture
     {
-        private EPackage rootPackage;
-        private ILoggerFactory loggerFactory;
+        private EPackage rootPackage = null!;
+        private ILoggerFactory loggerFactory = null!;
 
         [OneTimeSetUp]
         public void OneTimeSetUp()
@@ -85,9 +85,9 @@ namespace ECoreNetto.Extensions.Tests
         [Test]
         public void Verify_that_QuerySpecializations_throws_exception_when_argument_is_null()
         {
-            EClass @class = null;
+            EClass? @class = null;
 
-            Assert.That(() =>ClassExtensions.QuerySpecializations(@class, new List<EClass>()), Throws.ArgumentNullException);
+            Assert.That(() =>ClassExtensions.QuerySpecializations(@class!, new List<EClass>()), Throws.ArgumentNullException);
 
         }
 
@@ -106,9 +106,9 @@ namespace ECoreNetto.Extensions.Tests
         [Test]
         public void Verify_that_QueryTypeHierarchy_throws_exception_when_argument_is_null()
         {
-            EClass @class = null;
+            EClass? @class = null;
 
-            Assert.That(() => ClassExtensions.QueryTypeHierarchy(@class), Throws.ArgumentNullException);
+            Assert.That(() => ClassExtensions.QueryTypeHierarchy(@class!), Throws.ArgumentNullException);
 
         }
     }

--- a/ECoreNetto.Extensions.Tests/ModelElementExtensionsTestFixture.cs
+++ b/ECoreNetto.Extensions.Tests/ModelElementExtensionsTestFixture.cs
@@ -36,8 +36,8 @@ namespace ECoreNetto.Extensions.Tests
     [TestFixture]
     public class ModelElementExtensionsTestFixture
     {
-        private EPackage rootPackage;
-        private ILoggerFactory loggerFactory; 
+        private EPackage rootPackage = null!;
+        private ILoggerFactory loggerFactory = null!;
         
         [OneTimeSetUp]
         public void OneTimeSetUp()
@@ -85,25 +85,25 @@ namespace ECoreNetto.Extensions.Tests
         [Test]
         public void Verify_that_QueryDocumentation_throws_Exception_when_argument_null()
         {
-            EModelElement eModelElement = null;
+            EModelElement? eModelElement = null;
 
-            Assert.That(() => ModelElementExtensions.QueryDocumentation(eModelElement), Throws.ArgumentNullException);
+            Assert.That(() => ModelElementExtensions.QueryDocumentation(eModelElement!), Throws.ArgumentNullException);
         }
 
         [Test]
         public void Verify_that_QueryRawDocumentation_throws_Exception_when_argument_null()
         {
-            EModelElement eModelElement = null;
+            EModelElement? eModelElement = null;
 
-            Assert.That(() => ModelElementExtensions.QueryRawDocumentation(eModelElement), Throws.ArgumentNullException);
+            Assert.That(() => ModelElementExtensions.QueryRawDocumentation(eModelElement!), Throws.ArgumentNullException);
         }
 
         [Test]
         public void Verify_that_RemoveUnwantedHtmlTags_throws_Exception_when_argument_null()
         {
-            string html = null;
+            string? html = null;
 
-            Assert.That(() => ModelElementExtensions.RemoveUnwantedHtmlTags(html, new List<string>()), Throws.ArgumentException);
+            Assert.That(() => ModelElementExtensions.RemoveUnwantedHtmlTags(html!, new List<string>()), Throws.ArgumentException);
         }
 
         [Test]

--- a/ECoreNetto.Extensions.Tests/PackageExtensionsTestFixture.cs
+++ b/ECoreNetto.Extensions.Tests/PackageExtensionsTestFixture.cs
@@ -35,9 +35,9 @@ namespace ECoreNetto.Extensions.Tests
     [TestFixture]
     public class PackageExtensionsTestFixture
     {
-        private EPackage rootPackage;
+        private EPackage rootPackage = null!;
 
-        private ILoggerFactory loggerFactory;
+        private ILoggerFactory loggerFactory = null!;
 
         [OneTimeSetUp]
         public void OneTimeSetUp()
@@ -80,9 +80,9 @@ namespace ECoreNetto.Extensions.Tests
         [Test]
         public void Verify_that_when_root_is_null_result_is_empty()
         {
-            EPackage package = null;
+            EPackage? package = null;
 
-            var packages = PackageExtensions.QueryPackages(package);
+            var packages = PackageExtensions.QueryPackages(package!);
 
             Assert.That(packages, Is.Empty);
         }

--- a/ECoreNetto.Extensions.Tests/StringExtensionsTestFixture.cs
+++ b/ECoreNetto.Extensions.Tests/StringExtensionsTestFixture.cs
@@ -47,7 +47,7 @@ namespace ECoreNetto.Extensions.Tests
         public void Verify_that_SplitToLines_throws_for_null_or_empty_input()
         {
             // validation is eager: the exception is thrown on the call, not on enumeration
-            Assert.Throws<ArgumentException>(() => StringExtensions.SplitToLines(null, 10));
+            Assert.Throws<ArgumentException>(() => StringExtensions.SplitToLines(null!, 10));
 
             Assert.Throws<ArgumentException>(() => "".SplitToLines(10));
         }
@@ -55,7 +55,7 @@ namespace ECoreNetto.Extensions.Tests
         [Test]
         public void Verify_that_CapitalizeFirstLetter_returns_expected_result()
         {
-            Assert.Throws<ArgumentException>(() => StringExtensions.CapitalizeFirstLetter(null));
+            Assert.Throws<ArgumentException>(() => StringExtensions.CapitalizeFirstLetter(null!));
 
             Assert.Throws<ArgumentException>(() => "".CapitalizeFirstLetter());
             
@@ -65,7 +65,7 @@ namespace ECoreNetto.Extensions.Tests
         [Test]
         public void Verify_that_LowerCaseFirstLetter_returns_expected_result()
         {
-            Assert.Throws<ArgumentException>(() => StringExtensions.LowerCaseFirstLetter(null));
+            Assert.Throws<ArgumentException>(() => StringExtensions.LowerCaseFirstLetter(null!));
 
             Assert.Throws<ArgumentException>(() => "".LowerCaseFirstLetter());
 

--- a/ECoreNetto.Extensions.Tests/StructuralFeatureExtensionsTestFixture.cs
+++ b/ECoreNetto.Extensions.Tests/StructuralFeatureExtensionsTestFixture.cs
@@ -35,9 +35,9 @@ namespace ECoreNetto.Extensions.Tests
     [TestFixture]
     public class StructuralFeatureExtensionsTestFixture
     {
-        private EPackage rootPackage;
+        private EPackage rootPackage = null!;
 
-        private ILoggerFactory loggerFactory;
+        private ILoggerFactory loggerFactory = null!;
 
         [OneTimeSetUp]
         public void OneTimeSetUp()
@@ -153,7 +153,7 @@ namespace ECoreNetto.Extensions.Tests
 
             var capacityClass = capacityStructuralFeature.QueryClass();
 
-            Assert.That(capacityClass.Name, Is.EqualTo("Amount"));
+            Assert.That(capacityClass!.Name, Is.EqualTo("Amount"));
 
             var timeTriggerClass = this.rootPackage.EClassifiers.OfType<EClass>().Single(x => x.Name == "TimeTrigger");
 

--- a/ECoreNetto.Extensions/StructuralFeatureExtensions.cs
+++ b/ECoreNetto.Extensions/StructuralFeatureExtensions.cs
@@ -62,7 +62,7 @@ namespace ECoreNetto.Extensions
         /// An instance of <see cref="EClass"/> when the <see cref="EStructuralFeature"/> is
         /// an <see cref="EReference"/>, null in case it is not.
         /// </returns>
-        public static EClass QueryClass(this EStructuralFeature eStructuralFeature)
+        public static EClass? QueryClass(this EStructuralFeature eStructuralFeature)
         {
             if (eStructuralFeature == null)
             {
@@ -214,7 +214,7 @@ namespace ECoreNetto.Extensions
         /// <returns>
         /// the name of the type
         /// </returns>
-        public static string QueryTypeName(this EStructuralFeature eStructuralFeature)
+        public static string? QueryTypeName(this EStructuralFeature eStructuralFeature)
         {
             if (eStructuralFeature == null)
             {

--- a/ECoreNetto.HandleBars.Tests/BooleanHelperTestFixture.cs
+++ b/ECoreNetto.HandleBars.Tests/BooleanHelperTestFixture.cs
@@ -32,7 +32,7 @@ namespace ECoreNetto.HandleBars.Tests
     [TestFixture]
     public class BooleanHelperTestFixture
     {
-        private IHandlebars handlebarsContenxt;
+        private IHandlebars handlebarsContenxt = null!;
 
         [SetUp]
         public void SetUp()

--- a/ECoreNetto.HandleBars.Tests/GeneralizationHelperTestFixture.cs
+++ b/ECoreNetto.HandleBars.Tests/GeneralizationHelperTestFixture.cs
@@ -36,9 +36,9 @@ namespace ECoreNetto.HandleBars.Tests
     [TestFixture]
     public class GeneralizationHelperTestFixture
     {
-        private IHandlebars handlebarsContenxt;
+        private IHandlebars handlebarsContenxt = null!;
 
-        private EPackage root;
+        private EPackage root = null!;
 
         [SetUp]
         public void Setup()

--- a/ECoreNetto.HandleBars.Tests/StringHelperTestFixture.cs
+++ b/ECoreNetto.HandleBars.Tests/StringHelperTestFixture.cs
@@ -32,7 +32,7 @@ namespace ECoreNetto.HandleBars.Tests
     [TestFixture]
     public class StringHelperTestFixture
     {
-        private IHandlebars handlebarsContenxt;
+        private IHandlebars handlebarsContenxt = null!;
 
         [SetUp]
         public void SetUp()

--- a/ECoreNetto.HandleBars.Tests/StructuralFeatureHelperTestFixture.cs
+++ b/ECoreNetto.HandleBars.Tests/StructuralFeatureHelperTestFixture.cs
@@ -36,9 +36,9 @@ namespace ECoreNetto.HandleBars.Tests
     [TestFixture]
     public class StructuralFeatureHelperTestFixture
     {
-        private IHandlebars handlebarsContenxt;
+        private IHandlebars handlebarsContenxt = null!;
 
-        private EPackage root;
+        private EPackage root = null!;
 
         [SetUp]
         public void Setup()

--- a/ECoreNetto.HandleBars/StructuralFeatureHelper.cs
+++ b/ECoreNetto.HandleBars/StructuralFeatureHelper.cs
@@ -48,7 +48,7 @@ namespace ECoreNetto.HandleBars
                     throw new HandlebarsException("{{#StructuralFeature.QueryIsEnumerable}} helper must have exactly one argument");
                 }
 
-                var eStructuralFeature = arguments.Single() as EStructuralFeature;
+                var eStructuralFeature = (EStructuralFeature)arguments.Single()!;
 
                 return eStructuralFeature.QueryIsEnumerable();
             });
@@ -60,7 +60,7 @@ namespace ECoreNetto.HandleBars
                     throw new HandlebarsException("{{#StructuralFeature.IsEnumerable}} helper must have exactly one argument");
                 }
 
-                var eStructuralFeature = arguments.Single() as EStructuralFeature;
+                var eStructuralFeature = (EStructuralFeature)arguments.Single()!;
 
                 var isEnumerable = eStructuralFeature.QueryIsEnumerable();
 
@@ -77,7 +77,7 @@ namespace ECoreNetto.HandleBars
                     throw new HandlebarsException("{{#StructuralFeature.QueryIsAttribute}} helper must have exactly one argument");
                 }
 
-                var eStructuralFeature = arguments.Single() as EStructuralFeature;
+                var eStructuralFeature = (EStructuralFeature)arguments.Single()!;
 
                 return eStructuralFeature.QueryIsAttribute();
             });
@@ -89,7 +89,7 @@ namespace ECoreNetto.HandleBars
                     throw new HandlebarsException("{{#StructuralFeature.IsAttribute}} helper must have exactly one argument");
                 }
 
-                var eStructuralFeature = arguments.Single() as EStructuralFeature;
+                var eStructuralFeature = (EStructuralFeature)arguments.Single()!;
 
                 var isAttribute = eStructuralFeature.QueryIsAttribute();
 
@@ -106,7 +106,7 @@ namespace ECoreNetto.HandleBars
                     throw new HandlebarsException("{{#StructuralFeature.QueryIsReference}} helper must have exactly one argument");
                 }
 
-                var eStructuralFeature = arguments.Single() as EStructuralFeature;
+                var eStructuralFeature = (EStructuralFeature)arguments.Single()!;
 
                 return eStructuralFeature.QueryIsReference();
             });
@@ -118,7 +118,7 @@ namespace ECoreNetto.HandleBars
                     throw new HandlebarsException("{{#StructuralFeature.IsReference}} helper must have exactly one argument");
                 }
 
-                var eStructuralFeature = arguments.Single() as EStructuralFeature;
+                var eStructuralFeature = (EStructuralFeature)arguments.Single()!;
 
                 var isReference = eStructuralFeature.QueryIsReference();
 
@@ -135,8 +135,8 @@ namespace ECoreNetto.HandleBars
                     throw new HandlebarsException("{{#StructuralFeature.QueryStructuralFeatureNameEqualsEnclosingType}} helper must have exactly two arguments");
                 }
 
-                var eStructuralFeature = arguments[0] as EStructuralFeature;
-                var eClass = arguments[1] as EClass;
+                var eStructuralFeature = (EStructuralFeature)arguments[0]!;
+                var eClass = (EClass)arguments[1]!;
 
                 return eStructuralFeature.QueryStructuralFeatureNameEqualsEnclosingType(eClass);
             });
@@ -148,8 +148,8 @@ namespace ECoreNetto.HandleBars
                     throw new HandlebarsException("{{#StructuralFeature.NameEqualsEnclosingType}} helper must have exactly two arguments");
                 }
 
-                var eStructuralFeature = arguments[0] as EStructuralFeature;
-                var eClass = arguments[1] as EClass;
+                var eStructuralFeature = (EStructuralFeature)arguments[0]!;
+                var eClass = (EClass)arguments[1]!;
 
                 var nameEqualsEnclosingType = eStructuralFeature.QueryStructuralFeatureNameEqualsEnclosingType(eClass);
 
@@ -166,7 +166,7 @@ namespace ECoreNetto.HandleBars
                     throw new HandlebarsException("{{#StructuralFeature.QueryIsEnum}} helper must have exactly one argument");
                 }
 
-                var eStructuralFeature = arguments.Single() as EStructuralFeature;
+                var eStructuralFeature = (EStructuralFeature)arguments.Single()!;
 
                 return eStructuralFeature.QueryIsEnum();
             });
@@ -178,7 +178,7 @@ namespace ECoreNetto.HandleBars
                     throw new HandlebarsException("{{#StructuralFeature.IsEnum}} helper must have exactly one argument");
                 }
 
-                var eStructuralFeature = arguments.Single() as EStructuralFeature;
+                var eStructuralFeature = (EStructuralFeature)arguments.Single()!;
 
                 var isEnum = eStructuralFeature.QueryIsEnum();
 
@@ -195,7 +195,7 @@ namespace ECoreNetto.HandleBars
                     throw new HandlebarsException("{{#StructuralFeature.QueryHasDefaultValue}} helper must have exactly one argument");
                 }
 
-                var eStructuralFeature = arguments.Single() as EStructuralFeature;
+                var eStructuralFeature = (EStructuralFeature)arguments.Single()!;
 
                 return eStructuralFeature.QueryHasDefaultValue();
             });
@@ -207,7 +207,7 @@ namespace ECoreNetto.HandleBars
                     throw new HandlebarsException("{{#StructuralFeature.QueryIsContainment}} helper must have exactly one argument");
                 }
 
-                var eStructuralFeature = arguments.Single() as EStructuralFeature;
+                var eStructuralFeature = (EStructuralFeature)arguments.Single()!;
 
                 return eStructuralFeature.QueryIsContainment();
             });

--- a/ECoreNetto.Reporting.Tests/ECoreNetto.Reporting.Tests.csproj
+++ b/ECoreNetto.Reporting.Tests/ECoreNetto.Reporting.Tests.csproj
@@ -2,7 +2,6 @@
 
     <PropertyGroup>
         <TargetFramework>net10.0</TargetFramework>
-        <Nullable>enable</Nullable>
         <IsPackable>false</IsPackable>
         <Company>Starion Group S.A.</Company>
         <Authors>Sam Gerené</Authors>

--- a/ECoreNetto.Reporting.Tests/Generators/HtmlReportGeneratorTestFixture.cs
+++ b/ECoreNetto.Reporting.Tests/Generators/HtmlReportGeneratorTestFixture.cs
@@ -36,7 +36,7 @@ namespace ECoreNetto.Tools.Tests.Generators
     [TestFixture]
     public class HtmlReportGeneratorTestFixture
     {
-        private HtmlReportGenerator htmlReportGenerator;
+        private HtmlReportGenerator htmlReportGenerator = null!;
 
         private ILoggerFactory? loggerFactory;
 
@@ -76,24 +76,24 @@ namespace ECoreNetto.Tools.Tests.Generators
         [Test]
         public void Verify_that_when_modelpath_is_null_exception_is_thrown()
         {
-            FileInfo modelFileInfo = null;
-            
-            Assert.That(() => this.htmlReportGenerator.GenerateReport(modelFileInfo), Throws.ArgumentNullException);
-            
-            var reportFileInfo = new FileInfo(Path.Combine(TestContext.CurrentContext.TestDirectory, "html-report.ecore.html"));
-            
-            Assert.That(() => this.htmlReportGenerator.GenerateReport(modelFileInfo, reportFileInfo), Throws.ArgumentNullException);
+            FileInfo? modelFileInfo = null;
+
+            Assert.That(() => this.htmlReportGenerator.GenerateReport(modelFileInfo!), Throws.ArgumentNullException);
+
+            FileInfo? reportFileInfo = new FileInfo(Path.Combine(TestContext.CurrentContext.TestDirectory, "html-report.ecore.html"));
+
+            Assert.That(() => this.htmlReportGenerator.GenerateReport(modelFileInfo!, reportFileInfo!), Throws.ArgumentNullException);
 
             modelFileInfo = new FileInfo(Path.Combine(TestContext.CurrentContext.TestDirectory, "Data", "recipe.ecore"));
             reportFileInfo = null;
-            
-            Assert.That(() => this.htmlReportGenerator.GenerateReport(modelFileInfo, reportFileInfo), Throws.ArgumentNullException);
+
+            Assert.That(() => this.htmlReportGenerator.GenerateReport(modelFileInfo!, reportFileInfo!), Throws.ArgumentNullException);
         }
 
         [Test]
         public void Verify_That_when_outputpath_is_null_exception_is_thrown()
         {
-            Assert.That(() => this.htmlReportGenerator.IsValidReportExtension(null), Throws.ArgumentNullException);
+            Assert.That(() => this.htmlReportGenerator.IsValidReportExtension(null!), Throws.ArgumentNullException);
         }
     }
 }

--- a/ECoreNetto.Reporting.Tests/Generators/MarkdownReportGeneratorTestFixture.cs
+++ b/ECoreNetto.Reporting.Tests/Generators/MarkdownReportGeneratorTestFixture.cs
@@ -36,7 +36,7 @@ namespace ECoreNetto.Tools.Tests.Generators
     [TestFixture]
     public class MarkdownReportGeneratorTestFixture
     {
-        private MarkdownReportGenerator markdownReportGenerator;
+        private MarkdownReportGenerator markdownReportGenerator = null!;
 
         private ILoggerFactory? loggerFactory;
 

--- a/ECoreNetto.Reporting.Tests/Generators/ModelInspectorTestFixture.cs
+++ b/ECoreNetto.Reporting.Tests/Generators/ModelInspectorTestFixture.cs
@@ -35,15 +35,15 @@ namespace ECoreNetto.Tools.Tests.Generators
     [TestFixture]
     public class ModelInspectorTestFixture
     {
-        private FileInfo modelFileInfo;
+        private FileInfo modelFileInfo = null!;
 
-        private FileInfo reportFileInfo;
+        private FileInfo reportFileInfo = null!;
 
-        private EPackage rootPackage;
+        private EPackage rootPackage = null!;
 
-        private ModelInspector modelInspector;
+        private ModelInspector modelInspector = null!;
 
-        private ILoggerFactory loggerFactory;
+        private ILoggerFactory loggerFactory = null!;
 
         [OneTimeSetUp]
         public void OneTimeSetUp()

--- a/ECoreNetto.Reporting.Tests/Generators/ReportGeneratorTestFixture.cs
+++ b/ECoreNetto.Reporting.Tests/Generators/ReportGeneratorTestFixture.cs
@@ -36,13 +36,13 @@ namespace ECoreNetto.Tools.Tests.Generators
     [TestFixture]
     public class XlReportGeneratorTestFixture
     {
-        private FileInfo modelFileInfo;
+        private FileInfo modelFileInfo = null!;
 
-        private FileInfo reportFileInfo;
+        private FileInfo reportFileInfo = null!;
 
-        private XlReportGenerator xlXlReportGenerator;
+        private XlReportGenerator xlXlReportGenerator = null!;
 
-        private ILoggerFactory loggerFactory;
+        private ILoggerFactory loggerFactory = null!;
 
         [OneTimeSetUp]
         public void OneTimeSetUp()

--- a/ECoreNetto.Reporting/Generators/HandleBarsReportGenerator.cs
+++ b/ECoreNetto.Reporting/Generators/HandleBarsReportGenerator.cs
@@ -49,7 +49,7 @@ namespace ECoreNetto.Reporting.Generators
         /// <param name="loggerFactory">
         /// The (injected) <see cref="ILoggerFactory"/> used to set up logging
         /// </param>
-        protected HandleBarsReportGenerator(ILoggerFactory loggerFactory = null) : base (loggerFactory)
+        protected HandleBarsReportGenerator(ILoggerFactory? loggerFactory = null) : base (loggerFactory)
         {
             this.Templates = new Dictionary<string, HandlebarsTemplate<object, object>>();
 

--- a/ECoreNetto.Reporting/Generators/HtmlReportGenerator.cs
+++ b/ECoreNetto.Reporting/Generators/HtmlReportGenerator.cs
@@ -44,7 +44,7 @@ namespace ECoreNetto.Reporting.Generators
         /// <param name="loggerFactory">
         /// The (injected) <see cref="ILoggerFactory"/> used to set up logging
         /// </param>
-        public HtmlReportGenerator(ILoggerFactory loggerFactory = null) : base(loggerFactory)
+        public HtmlReportGenerator(ILoggerFactory? loggerFactory = null) : base(loggerFactory)
         {
             this.logger = loggerFactory == null ? NullLogger<HtmlReportGenerator>.Instance : loggerFactory.CreateLogger<HtmlReportGenerator>();
         }

--- a/ECoreNetto.Reporting/Generators/MarkdownReportGenerator.cs
+++ b/ECoreNetto.Reporting/Generators/MarkdownReportGenerator.cs
@@ -44,7 +44,7 @@ namespace ECoreNetto.Reporting.Generators
         /// <param name="loggerFactory">
         /// The (injected) <see cref="ILoggerFactory"/> used to set up logging
         /// </param>
-        public MarkdownReportGenerator(ILoggerFactory loggerFactory = null) : base(loggerFactory)
+        public MarkdownReportGenerator(ILoggerFactory? loggerFactory = null) : base(loggerFactory)
         {
             this.logger = loggerFactory == null ? NullLogger<MarkdownReportGenerator>.Instance : loggerFactory.CreateLogger<MarkdownReportGenerator>();
         }

--- a/ECoreNetto.Reporting/Generators/ModelInspector.cs
+++ b/ECoreNetto.Reporting/Generators/ModelInspector.cs
@@ -57,7 +57,7 @@ namespace ECoreNetto.Reporting.Generators
         /// <param name="loggerFactory">
         /// The (injected) <see cref="ILoggerFactory"/> used to set up logging
         /// </param>
-        public ModelInspector(ILoggerFactory loggerFactory = null) : base(loggerFactory)
+        public ModelInspector(ILoggerFactory? loggerFactory = null) : base(loggerFactory)
         {
             this.logger = loggerFactory == null ? NullLogger<ModelInspector>.Instance : loggerFactory.CreateLogger<ModelInspector>();
         }
@@ -215,7 +215,7 @@ namespace ECoreNetto.Reporting.Generators
                         }
                         else
                         {
-                            var valueType = $"{attribute.EType.Name}:{attribute.LowerBound}:{attribute.UpperBound}";
+                            var valueType = $"{attribute.EType!.Name}:{attribute.LowerBound}:{attribute.UpperBound}";
 
                             if (!this.valueTypes.Contains(valueType))
                             {
@@ -289,11 +289,11 @@ namespace ECoreNetto.Reporting.Generators
                     string referenceType;
                     if (reference.IsContainment)
                     {
-                        referenceType = $"{reference.Name}:{reference.EType.Name} [{reference.LowerBound}..{reference.UpperBound}] - CONTAINED REFERENCE TYPE";
+                        referenceType = $"{reference.Name}:{reference.EType!.Name} [{reference.LowerBound}..{reference.UpperBound}] - CONTAINED REFERENCE TYPE";
                     }
                     else
                     {
-                        referenceType = $"{reference.Name}:{reference.EType.Name} [{reference.LowerBound}..{reference.UpperBound}] - REFERENCE TYPE";
+                        referenceType = $"{reference.Name}:{reference.EType!.Name} [{reference.LowerBound}..{reference.UpperBound}] - REFERENCE TYPE";
                     }
                     
                     sb.AppendLine(referenceType);
@@ -303,12 +303,12 @@ namespace ECoreNetto.Reporting.Generators
                 {
                     if (structuralFeature.QueryIsEnum())
                     {
-                        var @enum = $"{attribute.Name}:{attribute.EType.Name} [{attribute.LowerBound}..{attribute.UpperBound}] - ENUM TYPE";
+                        var @enum = $"{attribute.Name}:{attribute.EType!.Name} [{attribute.LowerBound}..{attribute.UpperBound}] - ENUM TYPE";
                         sb.AppendLine(@enum);
                     }
                     else
                     {
-                        var valueType = $"{attribute.Name}:{attribute.EType.Name} [{attribute.LowerBound}..{attribute.UpperBound}] - VALUETYPE";
+                        var valueType = $"{attribute.Name}:{attribute.EType!.Name} [{attribute.LowerBound}..{attribute.UpperBound}] - VALUETYPE";
                         sb.AppendLine(valueType);
                     }
                 }
@@ -321,7 +321,7 @@ namespace ECoreNetto.Reporting.Generators
                 {
                     if (structuralFeature is EReference reference)
                     {
-                        var referenceType = $"{reference.Name}:{reference.EType.Name} [{reference.LowerBound}..{reference.UpperBound}] - REFERENCE TYPE";
+                        var referenceType = $"{reference.Name}:{reference.EType!.Name} [{reference.LowerBound}..{reference.UpperBound}] - REFERENCE TYPE";
                         sb.AppendLine(referenceType);
                     }
 
@@ -329,12 +329,12 @@ namespace ECoreNetto.Reporting.Generators
                     {
                         if (structuralFeature.QueryIsEnum())
                         {
-                            var @enum = $"{attribute.Name}:{attribute.EType.Name} [{attribute.LowerBound}..{attribute.UpperBound}] - ENUM TYPE";
+                            var @enum = $"{attribute.Name}:{attribute.EType!.Name} [{attribute.LowerBound}..{attribute.UpperBound}] - ENUM TYPE";
                             sb.AppendLine(@enum);
                         }
                         else
                         {
-                            var valueType = $"{attribute.Name}:{attribute.EType.Name} [{attribute.LowerBound}..{attribute.UpperBound}] - VALUETYPE";
+                            var valueType = $"{attribute.Name}:{attribute.EType!.Name} [{attribute.LowerBound}..{attribute.UpperBound}] - VALUETYPE";
                             sb.AppendLine(valueType);
                         }
                     }

--- a/ECoreNetto.Reporting/Generators/ReportGenerator.cs
+++ b/ECoreNetto.Reporting/Generators/ReportGenerator.cs
@@ -37,7 +37,7 @@ namespace ECoreNetto.Reporting.Generators
         /// <summary>
         /// The (injected) <see cref="ILoggerFactory"/> used to set up logging
         /// </summary>
-        private readonly ILoggerFactory loggerFactory;
+        private readonly ILoggerFactory? loggerFactory;
 
         /// <summary>
         /// The <see cref="ILogger"/> used to log
@@ -50,7 +50,7 @@ namespace ECoreNetto.Reporting.Generators
         /// <param name="loggerFactory">
         /// The (injected) <see cref="ILoggerFactory"/> used to set up logging
         /// </param>
-        protected ReportGenerator(ILoggerFactory loggerFactory = null)
+        protected ReportGenerator(ILoggerFactory? loggerFactory = null)
         {
             this.loggerFactory = loggerFactory;
 

--- a/ECoreNetto.Reporting/Generators/XlReportGenerator.cs
+++ b/ECoreNetto.Reporting/Generators/XlReportGenerator.cs
@@ -52,7 +52,7 @@ namespace ECoreNetto.Reporting.Generators
         /// <param name="loggerFactory">
         /// The (injected) <see cref="ILoggerFactory"/> used to set up logging
         /// </param>
-        public XlReportGenerator(ILoggerFactory loggerFactory = null) : base(loggerFactory)
+        public XlReportGenerator(ILoggerFactory? loggerFactory = null) : base(loggerFactory)
         {
             this.logger = loggerFactory == null ? NullLogger<XlReportGenerator>.Instance : loggerFactory.CreateLogger<XlReportGenerator>();
         }
@@ -196,7 +196,7 @@ namespace ECoreNetto.Reporting.Generators
                         var structuralFeatureDataRow = dataTable.NewRow();
                         structuralFeatureDataRow["Class"] = eClass.Name;
                         structuralFeatureDataRow["Feature"] = structuralFeature.Name;
-                        structuralFeatureDataRow["EType"] = structuralFeature.EType.Name;
+                        structuralFeatureDataRow["EType"] = structuralFeature.EType!.Name;
                         structuralFeatureDataRow["Multiplicity"] = $"{structuralFeature.LowerBound}:{structuralFeature.UpperBound}";
                         structuralFeatureDataRow["IsContainment"] = structuralFeature.QueryIsContainment();
                         structuralFeatureDataRow["Documentation"] = structuralFeature.QueryRawDocumentation();

--- a/ECoreNetto.Reporting/Payload/HandlebarsPayload.cs
+++ b/ECoreNetto.Reporting/Payload/HandlebarsPayload.cs
@@ -78,6 +78,6 @@ namespace ECoreNetto.Reporting.Payload
         /// <summary>
         /// Gets the version of the reporting library
         /// </summary>
-        public string Version => Assembly.GetExecutingAssembly().GetName().Version?.ToString();
+        public string? Version => Assembly.GetExecutingAssembly().GetName().Version?.ToString();
     }
 }

--- a/ECoreNetto.Tests/ModelElement/OperationAndFactoryTestFixture.cs
+++ b/ECoreNetto.Tests/ModelElement/OperationAndFactoryTestFixture.cs
@@ -64,7 +64,7 @@ namespace ECoreNetto.Tests.ModelElement
             var resource = new Resource();
             var operation = new TestableEOperation(resource);
 
-            Assert.That(() => operation.ExposeDeserializeChildNode(null), Throws.ArgumentNullException);
+            Assert.That(() => operation.ExposeDeserializeChildNode(null!), Throws.ArgumentNullException);
         }
 
         [Test]
@@ -93,7 +93,7 @@ namespace ECoreNetto.Tests.ModelElement
             var xmlDocument = new XmlDocument();
             xmlDocument.LoadXml("<eParameters name=\"parameterOne\" />");
 
-            operation.ExposeDeserializeChildNode(xmlDocument.DocumentElement);
+            operation.ExposeDeserializeChildNode(xmlDocument.DocumentElement!);
 
             Assert.Multiple(() =>
             {

--- a/ECoreNetto.Tests/Resource/RecipeEcoreFileTestFixture.cs
+++ b/ECoreNetto.Tests/Resource/RecipeEcoreFileTestFixture.cs
@@ -37,12 +37,12 @@ namespace ECoreNetto.Tests.Resource
     [TestFixture]
     public class RecipeEcoreFileTestFixture
     {
-        private string filePath;
-        private Uri uri;
-        private Resource resource;
-        private ResourceSet resourceSet;
+        private string filePath = null!;
+        private Uri uri = null!;
+        private Resource resource = null!;
+        private ResourceSet resourceSet = null!;
 
-        private ILoggerFactory loggerFactory;
+        private ILoggerFactory loggerFactory = null!;
         
         [OneTimeSetUp]
         public void OneTimeSetUp()
@@ -72,11 +72,11 @@ namespace ECoreNetto.Tests.Resource
             this.resourceSet = new ResourceSet(this.loggerFactory);
             this.resource = this.resourceSet.CreateResource(this.uri);
 
-            EPackage rootPackage = null;
+            EPackage? rootPackage = null;
 
             Assert.DoesNotThrow(() => rootPackage = this.resource.Load(null));
 
-            var eEnum = rootPackage.EClassifiers.OfType<EEnum>().Single(x => x.Name == "Unit");
+            var eEnum = rootPackage!.EClassifiers.OfType<EEnum>().Single(x => x.Name == "Unit");
 
             var decagram = eEnum.ELiterals.Single(x => x.Name == "DECAGRAM");
             Assert.That(decagram.Value, Is.EqualTo(0));

--- a/ECoreNetto.Tests/Resource/ResourceSetTestFixture.cs
+++ b/ECoreNetto.Tests/Resource/ResourceSetTestFixture.cs
@@ -36,14 +36,14 @@ namespace ECoreNetto.Tests.Resource
         /// <summary>
         /// the path to the file that is the resource
         /// </summary>
-        private string filePath;
+        private string filePath = null!;
 
         /// <summary>
         /// the class that is being tested
         /// </summary>
-        private ResourceSet resourceSet;
+        private ResourceSet resourceSet = null!;
 
-        private ILoggerFactory loggerFactory;
+        private ILoggerFactory loggerFactory = null!;
 
         [OneTimeSetUp]
         public void OneTimeSetUp()
@@ -71,7 +71,7 @@ namespace ECoreNetto.Tests.Resource
         [Test]
         public void Verify_that_when_uri_is_null_exception_is_thrown()
         {
-            Assert.That(() => this.resourceSet.CreateResource(null), Throws.ArgumentNullException);
+            Assert.That(() => this.resourceSet.CreateResource(null!), Throws.ArgumentNullException);
         }
 
         [Test]
@@ -127,7 +127,7 @@ namespace ECoreNetto.Tests.Resource
         [Test]
         public void VerifyThat_when_resource_is_called_with_null_uri_exception_is_thrown()
         {
-            Assert.That(() => this.resourceSet.Resource(null, false), Throws.ArgumentNullException);
+            Assert.That(() => this.resourceSet.Resource(null!, false), Throws.ArgumentNullException);
         }
     }
 }

--- a/ECoreNetto.Tests/Resource/ResourceTestFixture.cs
+++ b/ECoreNetto.Tests/Resource/ResourceTestFixture.cs
@@ -34,10 +34,10 @@ namespace ECoreNetto.Tests.Resource
     [TestFixture]
     public class ResourceTestFixture
     {
-        private string filePath;
-        private Resource resource;
-        private ResourceSet resourceSet;
-        private ILoggerFactory loggerFactory;
+        private string filePath = null!;
+        private Resource resource = null!;
+        private ResourceSet resourceSet = null!;
+        private ILoggerFactory loggerFactory = null!;
 
         [OneTimeSetUp]
         public void OneTimeSetUp()
@@ -78,7 +78,7 @@ namespace ECoreNetto.Tests.Resource
         {
             Assert.That(() => this.resource.GetEObject(""), Throws.ArgumentException);
 
-            Assert.That(() => this.resource.GetEObject(null), Throws.ArgumentException);
+            Assert.That(() => this.resource.GetEObject(null!), Throws.ArgumentException);
         }
 
         [Test]

--- a/ECoreNetto.Tests/Resource/WizardEcoreFileTestFixture.cs
+++ b/ECoreNetto.Tests/Resource/WizardEcoreFileTestFixture.cs
@@ -34,11 +34,11 @@ namespace ECoreNetto.Tests.Resource
     [TestFixture]
     public class WizardEcoreFileTestFixture
     {
-        private string filePath;
-        private Uri uri;
-        private Resource resource;
-        private ResourceSet resourceSet;
-        private ILoggerFactory loggerFactory;
+        private string filePath = null!;
+        private Uri uri = null!;
+        private Resource resource = null!;
+        private ResourceSet resourceSet = null!;
+        private ILoggerFactory loggerFactory = null!;
 
         [OneTimeSetUp]
         public void OneTimeSetUp()

--- a/ECoreNetto.Tests/Utils/ContainmentUpdaterTestFixture.cs
+++ b/ECoreNetto.Tests/Utils/ContainmentUpdaterTestFixture.cs
@@ -34,7 +34,7 @@ namespace ECoreNetto.Tests.Utils
         /// <summary>
         /// The <see cref="Resource"/> used to instantiate the <see cref="EObject"/>s under test
         /// </summary>
-        private Resource resource;
+        private Resource resource = null!;
 
         [SetUp]
         public void SetUp()
@@ -45,9 +45,9 @@ namespace ECoreNetto.Tests.Utils
         [Test]
         public void Verify_that_RemoveFromContainer_throws_when_object_is_null()
         {
-            EObject @object = null;
+            EObject? @object = null;
 
-            Assert.That(() => @object.RemoveFromContainer(), Throws.ArgumentNullException);
+            Assert.That(() => @object!.RemoveFromContainer(), Throws.ArgumentNullException);
         }
 
         [Test]

--- a/ECoreNetto.Tests/Utils/EcoreObjectFactoryTestFixture.cs
+++ b/ECoreNetto.Tests/Utils/EcoreObjectFactoryTestFixture.cs
@@ -34,12 +34,12 @@ namespace ECoreNetto.Tests.Utils
         /// <summary>
         /// The <see cref="Resource"/> passed to the factory under test
         /// </summary>
-        private Resource resource;
+        private Resource resource = null!;
 
         /// <summary>
         /// The class that is being tested
         /// </summary>
-        private EcoreObjectFactory factory;
+        private EcoreObjectFactory factory = null!;
 
         [SetUp]
         public void SetUp()

--- a/ECoreNetto.Tools.Tests/Commands/HtmlReportCommandTestFixture.cs
+++ b/ECoreNetto.Tools.Tests/Commands/HtmlReportCommandTestFixture.cs
@@ -39,15 +39,15 @@ namespace ECoreNetto.Tools.Tests.Commands
     [TestFixture]
     public class HtmlReportCommandTestFixture
     {
-        private RootCommand rootCommand;
+        private RootCommand rootCommand = null!;
 
-        private Mock<IHtmlReportGenerator> htmlReportGenerator;
+        private Mock<IHtmlReportGenerator> htmlReportGenerator = null!;
 
-        private Mock<IVersionChecker> versionChecker;
+        private Mock<IVersionChecker> versionChecker = null!;
 
-        private HtmlReportCommand.Handler handler;
+        private HtmlReportCommand.Handler handler = null!;
 
-        private CancellationTokenSource cts;
+        private CancellationTokenSource cts = null!;
 
         [SetUp]
         public void SetUp()

--- a/ECoreNetto.Tools.Tests/Commands/MarkdownReportCommandTestFixture.cs
+++ b/ECoreNetto.Tools.Tests/Commands/MarkdownReportCommandTestFixture.cs
@@ -39,15 +39,15 @@ namespace ECoreNetto.Tools.Tests.Commands
     [TestFixture]
     public class MarkdownReportCommandTestFixture
     {
-        private RootCommand rootCommand;
+        private RootCommand rootCommand = null!;
 
-        private Mock<IMarkdownReportGenerator> markdownReportGenerator;
+        private Mock<IMarkdownReportGenerator> markdownReportGenerator = null!;
 
-        private Mock<IVersionChecker> versionChecker;
+        private Mock<IVersionChecker> versionChecker = null!;
 
-        private MarkdownReportCommand.Handler handler;
+        private MarkdownReportCommand.Handler handler = null!;
 
-        private CancellationTokenSource cts;
+        private CancellationTokenSource cts = null!;
 
         [SetUp]
         public void SetUp()

--- a/ECoreNetto.Tools.Tests/Commands/ModelInspectionCommandTestFixture.cs
+++ b/ECoreNetto.Tools.Tests/Commands/ModelInspectionCommandTestFixture.cs
@@ -39,15 +39,15 @@ namespace ECoreNetto.Tools.Tests.Commands
     [TestFixture]
     public class ModelInspectionCommandTestFixture
     {
-        private RootCommand rootCommand;
+        private RootCommand rootCommand = null!;
 
-        private Mock<IModelInspector> modelInspector;
+        private Mock<IModelInspector> modelInspector = null!;
 
-        private Mock<IVersionChecker> versionChecker;
+        private Mock<IVersionChecker> versionChecker = null!;
 
-        private ModelInspectionCommand.Handler handler;
+        private ModelInspectionCommand.Handler handler = null!;
 
-        private CancellationTokenSource cts;
+        private CancellationTokenSource cts = null!;
 
         [SetUp]
         public void SetUp()

--- a/ECoreNetto.Tools.Tests/Commands/XlReportCommandTestFixture.cs
+++ b/ECoreNetto.Tools.Tests/Commands/XlReportCommandTestFixture.cs
@@ -39,15 +39,15 @@ namespace ECoreNetto.Tools.Tests.Commands
     [TestFixture]
     public class XlReportCommandTestFixture
     {
-        private RootCommand rootCommand;
+        private RootCommand rootCommand = null!;
 
-        private Mock<IXlReportGenerator> reportGenerator;
+        private Mock<IXlReportGenerator> reportGenerator = null!;
 
-        private Mock<IVersionChecker> versionChecker;
+        private Mock<IVersionChecker> versionChecker = null!;
 
-        private XlReportCommand.Handler handler;
+        private XlReportCommand.Handler handler = null!;
 
-        private CancellationTokenSource cts;
+        private CancellationTokenSource cts = null!;
 
         [SetUp]
         public void SetUp()

--- a/ECoreNetto.Tools.Tests/ECoreNetto.Tools.Tests.csproj
+++ b/ECoreNetto.Tools.Tests/ECoreNetto.Tools.Tests.csproj
@@ -2,7 +2,6 @@
 
     <PropertyGroup>
         <TargetFramework>net10.0</TargetFramework>
-        <Nullable>enable</Nullable>
         <IsPackable>false</IsPackable>
         <Company>Starion Group S.A.</Company>
         <Authors>Sam Gerené</Authors>

--- a/ECoreNetto.Tools.Tests/ProgramTestFixture.cs
+++ b/ECoreNetto.Tools.Tests/ProgramTestFixture.cs
@@ -29,7 +29,7 @@ namespace ECoreNetto.Tools.Tests
     [TestFixture]
     public class ProgramTestFixture
     {
-        private string inputModel;
+        private string inputModel = null!;
 
         [SetUp]
         public void Setup()

--- a/ECoreNetto.Tools.Tests/Services/VersionCheckerTestFixture.cs
+++ b/ECoreNetto.Tools.Tests/Services/VersionCheckerTestFixture.cs
@@ -32,13 +32,13 @@ namespace ECoreNetto.Tools.Tests.Services
     [TestFixture]
     public class VersionCheckerTestFixture
     {
-        private VersionChecker versionChecker;
+        private VersionChecker versionChecker = null!;
 
         private ILoggerFactory? loggerFactory;
 
-        private TestHttpClientFactory httpClientFactory;
+        private TestHttpClientFactory httpClientFactory = null!;
 
-        private TestTimeOutHttpClientFactory timeOutHttpClientFactory;
+        private TestTimeOutHttpClientFactory timeOutHttpClientFactory = null!;
 
         [OneTimeSetUp]
         public void OneTimeSetUp()

--- a/ECoreNetto.Tools/Commands/ReportCommand.cs
+++ b/ECoreNetto.Tools/Commands/ReportCommand.cs
@@ -35,7 +35,7 @@ namespace ECoreNetto.Tools.Commands
         /// </summary>
         /// <param name="name">The name of the command.</param>
         /// <param name="description">The description of the command, shown in help.</param>
-        protected ReportCommand(string name, string description = null) : base(name, description)
+        protected ReportCommand(string name, string? description = null) : base(name, description)
         {
             var noLogoOption = new Option<bool>(name: "--no-logo")
             {

--- a/ECoreNetto.Tools/Commands/ReportHandler.cs
+++ b/ECoreNetto.Tools/Commands/ReportHandler.cs
@@ -73,12 +73,12 @@ namespace ECoreNetto.Tools.Commands
         /// <summary>
         /// The <see cref="FileInfo"/> where the ecore model is located that is to be read
         /// </summary>
-        private FileInfo inputModel;
+        private FileInfo inputModel = null!;
 
         /// <summary>
         /// The <see cref="FileInfo"/> where the inspection report is to be generated
         /// </summary>
-        private FileInfo outputReport;
+        private FileInfo outputReport = null!;
 
         /// <summary>
         /// The value indicating whether the generated report needs to be automatically be
@@ -187,9 +187,9 @@ namespace ECoreNetto.Tools.Commands
         private void ProcessParseResult(ParseResult parseResult)
         {
             this.noLogo = parseResult.GetValue<bool>("--no-logo");
-            this.inputModel = parseResult.GetValue<FileInfo>("--input-model");
+            this.inputModel = parseResult.GetValue<FileInfo>("--input-model")!;
             this.autoOpenReport = parseResult.GetValue<bool>("--auto-open-report");
-            this.outputReport = parseResult.GetValue<FileInfo>("--output-report");
+            this.outputReport = parseResult.GetValue<FileInfo>("--output-report")!;
         }
 
         /// <summary>

--- a/ECoreNetto.Tools/Program.cs
+++ b/ECoreNetto.Tools/Program.cs
@@ -128,8 +128,8 @@ namespace ECoreNetto.Tools
                 ApplyLogLevel(parseResult);
 
                 using var scope = host.Services.CreateScope();
-                var generator = scope.ServiceProvider.GetService<IXlReportGenerator>();
-                var versionChecker = scope.ServiceProvider.GetService<IVersionChecker>();
+                var generator = scope.ServiceProvider.GetRequiredService<IXlReportGenerator>();
+                var versionChecker = scope.ServiceProvider.GetRequiredService<IVersionChecker>();
                 var handler = new XlReportCommand.Handler(generator, versionChecker);
                 return handler.InvokeAsync(parseResult, cancellationToken);
             });
@@ -142,8 +142,8 @@ namespace ECoreNetto.Tools
                 ApplyLogLevel(parseResult);
 
                 using var scope = host.Services.CreateScope();
-                var generator = scope.ServiceProvider.GetService<IModelInspector>();
-                var versionChecker = scope.ServiceProvider.GetService<IVersionChecker>();
+                var generator = scope.ServiceProvider.GetRequiredService<IModelInspector>();
+                var versionChecker = scope.ServiceProvider.GetRequiredService<IVersionChecker>();
                 var handler = new ModelInspectionCommand.Handler(generator, versionChecker);
                 return handler.InvokeAsync(parseResult, cancellationToken);
             });
@@ -155,8 +155,8 @@ namespace ECoreNetto.Tools
                 ApplyLogLevel(parseResult);
 
                 using var scope = host.Services.CreateScope();
-                var generator = scope.ServiceProvider.GetService<IHtmlReportGenerator>();
-                var versionChecker = scope.ServiceProvider.GetService<IVersionChecker>();
+                var generator = scope.ServiceProvider.GetRequiredService<IHtmlReportGenerator>();
+                var versionChecker = scope.ServiceProvider.GetRequiredService<IVersionChecker>();
                 var handler = new HtmlReportCommand.Handler(generator, versionChecker);
                 return handler.InvokeAsync(parseResult, cancellationToken);
             });
@@ -168,8 +168,8 @@ namespace ECoreNetto.Tools
                 ApplyLogLevel(parseResult);
 
                 using var scope = host.Services.CreateScope();
-                var generator = scope.ServiceProvider.GetService<IMarkdownReportGenerator>();
-                var versionChecker = scope.ServiceProvider.GetService<IVersionChecker>();
+                var generator = scope.ServiceProvider.GetRequiredService<IMarkdownReportGenerator>();
+                var versionChecker = scope.ServiceProvider.GetRequiredService<IVersionChecker>();
                 var handler = new MarkdownReportCommand.Handler(generator, versionChecker);
                 return handler.InvokeAsync(parseResult, cancellationToken);
             });

--- a/ECoreNetto.Tools/Resources/ResourceLoader.cs
+++ b/ECoreNetto.Tools/Resources/ResourceLoader.cs
@@ -55,7 +55,7 @@ namespace ECoreNetto.Tools.Resources
         /// <returns>
         /// a string representation of the version of the application
         /// </returns>
-        public static string QueryVersion()
+        public static string? QueryVersion()
         {
             var assembly = Assembly.GetExecutingAssembly();
             return assembly.GetName().Version?.ToString();

--- a/ECoreNetto.Tools/Services/GitHubRelease.cs
+++ b/ECoreNetto.Tools/Services/GitHubRelease.cs
@@ -31,18 +31,18 @@ namespace ECoreNetto.Tools.Services
         /// Gets or sets the url of the release page
         /// </summary>
         [JsonPropertyName("html_url")]
-        public string HtmlUrl { get; set; }
+        public string HtmlUrl { get; set; } = null!;
 
         /// <summary>
         /// Gets or sets the name of the tag
         /// </summary>
         [JsonPropertyName("tag_name")]
-        public string TagName{ get; set; }
+        public string TagName { get; set; } = null!;
 
         /// <summary>
         /// Gets or sets the description of the release
         /// </summary>
         [JsonPropertyName("body")]
-        public string Body { get; set; }
+        public string Body { get; set; } = null!;
     }
 }

--- a/ECoreNetto.Tools/Services/VersionChecker.cs
+++ b/ECoreNetto.Tools/Services/VersionChecker.cs
@@ -56,7 +56,7 @@ namespace ECoreNetto.Tools.Services
         /// <param name="loggerFactory">
         /// The (injected) <see cref="ILoggerFactory"/> used to set up logging
         /// </param>
-        public VersionChecker(IHttpClientFactory httpClientFactory, ILoggerFactory loggerFactory = null)
+        public VersionChecker(IHttpClientFactory httpClientFactory, ILoggerFactory? loggerFactory = null)
         {
             this.httpClientFactory = httpClientFactory;
             this.logger = loggerFactory == null ? NullLogger<VersionChecker>.Instance : loggerFactory.CreateLogger<VersionChecker>();
@@ -117,7 +117,7 @@ namespace ECoreNetto.Tools.Services
         /// an instance of <see cref="GitHubRelease"/> or null if not found or a connection
         /// error occured
         /// </returns>
-        public async Task<GitHubRelease> QueryLatestReleaseAsync(CancellationToken cancellationToken)
+        public async Task<GitHubRelease?> QueryLatestReleaseAsync(CancellationToken cancellationToken)
         {
             var httpClient = this.httpClientFactory.CreateClient();
             httpClient.Timeout = TimeSpan.FromSeconds(2);

--- a/ECoreNetto/ECoreParser.cs
+++ b/ECoreNetto/ECoreParser.cs
@@ -36,7 +36,7 @@ namespace ECoreNetto
         /// <summary>
         /// The (injected) <see cref="ILoggerFactory"/> used to set up logging
         /// </summary>
-        private readonly ILoggerFactory loggerFactory;
+        private readonly ILoggerFactory? loggerFactory;
 
         /// <summary>
         /// The <see cref="ILogger"/> used to log
@@ -57,7 +57,7 @@ namespace ECoreNetto
         /// <param name="loggerFactory">
         /// The (injected) <see cref="ILoggerFactory"/> used to set up logging
         /// </param>
-        internal ECoreParser(Resource.Resource resource, ILoggerFactory loggerFactory = null)
+        internal ECoreParser(Resource.Resource resource, ILoggerFactory? loggerFactory = null)
         {
             this.loggerFactory = loggerFactory;
 

--- a/ECoreNetto/ModelElement/EAnnotation.cs
+++ b/ECoreNetto/ModelElement/EAnnotation.cs
@@ -46,7 +46,7 @@ namespace ECoreNetto
         /// <param name="loggerFactory">
         /// The (injected) <see cref="ILoggerFactory"/> used to set up logging
         /// </param>
-        public EAnnotation(Resource.Resource resource, ILoggerFactory loggerFactory = null) : base(resource, loggerFactory)
+        public EAnnotation(Resource.Resource resource, ILoggerFactory? loggerFactory = null) : base(resource, loggerFactory)
         {
             this.logger = loggerFactory == null ? NullLogger<EAnnotation>.Instance : loggerFactory.CreateLogger<EAnnotation>();
 
@@ -56,7 +56,7 @@ namespace ECoreNetto
         /// <summary>
         /// Gets the source of this <see cref="EAnnotation"/>
         /// </summary>
-        public string Source { get; private set; }
+        public string? Source { get; private set; }
 
         /// <summary>
         /// Gets the 
@@ -66,7 +66,7 @@ namespace ECoreNetto
         /// <summary>
         /// Gets the <see cref="EModelElement"/> that is annotated by the current <see cref="EAnnotation"/>
         /// </summary>
-        public EModelElement EModelElement => (EModelElement)this.EContainer;
+        public EModelElement EModelElement => (EModelElement)this.EContainer!;
 
         /// <summary>
         /// Set the properties of this <see cref="EModelElement"/>

--- a/ECoreNetto/ModelElement/EFactory.cs
+++ b/ECoreNetto/ModelElement/EFactory.cs
@@ -36,13 +36,13 @@ namespace ECoreNetto
         /// <param name="loggerFactory">
         /// The (injected) <see cref="ILoggerFactory"/> used to set up logging
         /// </param>
-        public EFactory(Resource.Resource resource, ILoggerFactory loggerFactory = null) : base(resource, loggerFactory)
+        public EFactory(Resource.Resource resource, ILoggerFactory? loggerFactory = null) : base(resource, loggerFactory)
         {
         }
 
         /// <summary>
         /// Gets the <see cref="EPackage"/>
         /// </summary>
-        public EPackage EPackage { get; private set; }
+        public EPackage? EPackage { get; private set; }
     }
 }

--- a/ECoreNetto/ModelElement/EModelElement.cs
+++ b/ECoreNetto/ModelElement/EModelElement.cs
@@ -34,7 +34,7 @@ namespace ECoreNetto
         /// <summary>
         /// The (injected) <see cref="ILoggerFactory"/> used to set up logging
         /// </summary>
-        private readonly ILoggerFactory loggerFactory;
+        private readonly ILoggerFactory? loggerFactory;
 
         /// <summary>
         /// The <see cref="ILogger"/> used to log
@@ -55,7 +55,7 @@ namespace ECoreNetto
         /// <param name="loggerFactory">
         /// The (injected) <see cref="ILoggerFactory"/> used to set up logging
         /// </param>
-        protected EModelElement(Resource.Resource resource, ILoggerFactory loggerFactory = null) : base(resource, loggerFactory)
+        protected EModelElement(Resource.Resource resource, ILoggerFactory? loggerFactory = null) : base(resource, loggerFactory)
         {
             this.loggerFactory = loggerFactory;
 

--- a/ECoreNetto/ModelElement/ENamedElement.cs
+++ b/ECoreNetto/ModelElement/ENamedElement.cs
@@ -33,7 +33,7 @@ namespace ECoreNetto
         /// <summary>
         /// Backing field for <see cref="Identifier"/>
         /// </summary>
-        private string identifier;
+        private string? identifier;
 
         /// <summary>
         /// Initializes a new instance of the <see cref="ENamedElement"/> class
@@ -44,14 +44,14 @@ namespace ECoreNetto
         /// <param name="loggerFactory">
         /// The (injected) <see cref="ILoggerFactory"/> used to set up logging
         /// </param>
-        protected ENamedElement(Resource.Resource resource, ILoggerFactory loggerFactory = null) : base(resource)
+        protected ENamedElement(Resource.Resource resource, ILoggerFactory? loggerFactory = null) : base(resource)
         {
         }
 
         /// <summary>
         /// Gets the name of this <see cref="ENamedElement"/>
         /// </summary>
-        public string Name { get; internal set; }
+        public string Name { get; internal set; } = null!;
 
         /// <summary>
         /// Gets the identifier for this <see cref="ENamedElement"/>
@@ -65,7 +65,7 @@ namespace ECoreNetto
                     this.identifier = this.BuildIdentifier();
                 }
 
-                return this.identifier;
+                return this.identifier!;
             }
         }
 

--- a/ECoreNetto/ModelElement/EObject.cs
+++ b/ECoreNetto/ModelElement/EObject.cs
@@ -43,7 +43,7 @@ namespace ECoreNetto
         /// <param name="loggerFactory">
         /// The (injected) <see cref="ILoggerFactory"/> used to set up logging
         /// </param>
-        protected EObject(Resource.Resource resource, ILoggerFactory loggerFactory = null)
+        protected EObject(Resource.Resource resource, ILoggerFactory? loggerFactory = null)
         {
             this.EResource = resource;
             this.Attributes = new Dictionary<string, string>();
@@ -61,12 +61,12 @@ namespace ECoreNetto
         /// <summary>
         /// Gets or sets the current top package name used during .
         /// </summary>
-        internal static string TopPackageName { get; set; }
+        internal static string? TopPackageName { get; set; }
 
         /// <summary>
         /// Gets the identifier for this <see cref="EModelElement"/>
         /// </summary>
-        public virtual string Identifier { get; set; }
+        public virtual string Identifier { get; set; } = null!;
 
         /// <summary>
         /// Gets the collection of xml-attributes of this object that are present
@@ -100,7 +100,7 @@ namespace ECoreNetto
         /// <returns>
         /// The containing <see cref="EObject"/>, or null.
         /// </returns>
-        public EObject EContainer { get; internal set; }
+        public EObject? EContainer { get; internal set; }
 
         /// <summary>
         /// Returns the particular <see cref="EStructuralFeature"/> of the container that actually holds the object, or null, if there is no container. 

--- a/ECoreNetto/ModelElement/NamedElement/Classifier/EClass.cs
+++ b/ECoreNetto/ModelElement/NamedElement/Classifier/EClass.cs
@@ -40,7 +40,7 @@ namespace ECoreNetto
         /// <summary>
         /// The (injected) <see cref="ILoggerFactory"/> used to set up logging
         /// </summary>
-        private readonly ILoggerFactory loggerFactory;
+        private readonly ILoggerFactory? loggerFactory;
 
         /// <summary>
         /// The <see cref="ILogger"/> used to log
@@ -71,7 +71,7 @@ namespace ECoreNetto
         /// <param name="loggerFactory">
         /// The (injected) <see cref="ILoggerFactory"/> used to set up logging
         /// </param>
-        public EClass(Resource.Resource resource, ILoggerFactory loggerFactory = null) : base(resource, loggerFactory)
+        public EClass(Resource.Resource resource, ILoggerFactory? loggerFactory = null) : base(resource, loggerFactory)
         {
             this.loggerFactory = loggerFactory;
 

--- a/ECoreNetto/ModelElement/NamedElement/Classifier/EDataType.cs
+++ b/ECoreNetto/ModelElement/NamedElement/Classifier/EDataType.cs
@@ -47,7 +47,7 @@ namespace ECoreNetto
         /// <param name="loggerFactory">
         /// The (injected) <see cref="ILoggerFactory"/> used to set up logging
         /// </param>
-        public EDataType(Resource.Resource resource, ILoggerFactory loggerFactory = null) : base(resource, loggerFactory)
+        public EDataType(Resource.Resource resource, ILoggerFactory? loggerFactory = null) : base(resource, loggerFactory)
         {
             this.logger = loggerFactory == null ? NullLogger<EDataType>.Instance : loggerFactory.CreateLogger<EDataType>();
 

--- a/ECoreNetto/ModelElement/NamedElement/Classifier/EEnum.cs
+++ b/ECoreNetto/ModelElement/NamedElement/Classifier/EEnum.cs
@@ -34,7 +34,7 @@ namespace ECoreNetto
         /// <summary>
         /// The (injected) <see cref="ILoggerFactory"/> used to set up logging
         /// </summary>
-        private readonly ILoggerFactory loggerFactory;
+        private readonly ILoggerFactory? loggerFactory;
 
         /// <summary>
         /// The <see cref="ILogger"/> used to log
@@ -50,7 +50,7 @@ namespace ECoreNetto
         /// <param name="loggerFactory">
         /// The (injected) <see cref="ILoggerFactory"/> used to set up logging
         /// </param>
-        public EEnum(Resource.Resource resource, ILoggerFactory loggerFactory = null) : base(resource, loggerFactory)
+        public EEnum(Resource.Resource resource, ILoggerFactory? loggerFactory = null) : base(resource, loggerFactory)
         {
             this.loggerFactory = loggerFactory;
 

--- a/ECoreNetto/ModelElement/NamedElement/EClassifier.cs
+++ b/ECoreNetto/ModelElement/NamedElement/EClassifier.cs
@@ -44,7 +44,7 @@ namespace ECoreNetto
         /// <param name="loggerFactory">
         /// The (injected) <see cref="ILoggerFactory"/> used to set up logging
         /// </param>
-        protected EClassifier(Resource.Resource resource, ILoggerFactory loggerFactory = null) : base(resource, loggerFactory)
+        protected EClassifier(Resource.Resource resource, ILoggerFactory? loggerFactory = null) : base(resource, loggerFactory)
         {
             this.logger = loggerFactory == null ? NullLogger<EClassifier>.Instance : loggerFactory.CreateLogger<EClassifier>();
         }
@@ -52,12 +52,12 @@ namespace ECoreNetto
         /// <summary>
         /// Gets the instance class name.
         /// </summary>
-        public string InstanceClassName { get; private set; }
+        public string? InstanceClassName { get; private set; }
 
         /// <summary>
         /// Gets the containing <see cref="EPackage"/>
         /// </summary>
-        public EPackage EPackage => (EPackage)this.EContainer;
+        public EPackage EPackage => (EPackage)this.EContainer!;
 
         /// <summary>
         /// Gets the hierarchy of  containing <see cref="EPackage"/>

--- a/ECoreNetto/ModelElement/NamedElement/EEnumLiteral.cs
+++ b/ECoreNetto/ModelElement/NamedElement/EEnumLiteral.cs
@@ -42,7 +42,7 @@ namespace ECoreNetto
         /// <param name="loggerFactory">
         /// The (injected) <see cref="ILoggerFactory"/> used to set up logging
         /// </param>
-        public EEnumLiteral(Resource.Resource resource, ILoggerFactory loggerFactory = null) : base(resource, loggerFactory)
+        public EEnumLiteral(Resource.Resource resource, ILoggerFactory? loggerFactory = null) : base(resource, loggerFactory)
         {
             this.logger = loggerFactory == null ? NullLogger<EEnumLiteral>.Instance : loggerFactory.CreateLogger<EEnumLiteral>();
         }
@@ -50,7 +50,7 @@ namespace ECoreNetto
         /// <summary>
         /// Gets the containing <see cref="EEnum"/>
         /// </summary>
-        public EEnum EEnum => (EEnum)this.EContainer;
+        public EEnum EEnum => (EEnum)this.EContainer!;
 
         /// <summary>
         /// Gets or sets int value of an enumerator. 

--- a/ECoreNetto/ModelElement/NamedElement/EPackage.cs
+++ b/ECoreNetto/ModelElement/NamedElement/EPackage.cs
@@ -36,7 +36,7 @@ namespace ECoreNetto
         /// <summary>
         /// The (injected) <see cref="ILoggerFactory"/> used to set up logging
         /// </summary>
-        private readonly ILoggerFactory loggerFactory;
+        private readonly ILoggerFactory? loggerFactory;
 
         /// <summary>
         /// The <see cref="ILogger"/> used to log
@@ -72,7 +72,7 @@ namespace ECoreNetto
         /// <param name="loggerFactory">
         /// The (injected) <see cref="ILoggerFactory"/> used to set up logging
         /// </param>
-        public EPackage(Resource.Resource resource, ILoggerFactory loggerFactory = null) : base(resource, loggerFactory)
+        public EPackage(Resource.Resource resource, ILoggerFactory? loggerFactory = null) : base(resource, loggerFactory)
         {
             this.loggerFactory = loggerFactory;
 
@@ -85,17 +85,17 @@ namespace ECoreNetto
         /// <summary>
         /// Gets the URI
         /// </summary>
-        public string NsUri { get; private set; }
+        public string? NsUri { get; private set; }
 
         /// <summary>
         /// Gets the prefix
         /// </summary>
-        public string NsPrefix { get; private set; }
+        public string? NsPrefix { get; private set; }
 
         /// <summary>
         /// Gets the <see cref="EFactoryInstance"/>
         /// </summary>
-        public EFactory EFactoryInstance { get; private set; }
+        public EFactory? EFactoryInstance { get; private set; }
 
         /// <summary>
         /// Gets the collection of sub <see cref="EPackage"/>
@@ -113,7 +113,7 @@ namespace ECoreNetto
         /// <remarks>
         /// This may be null if this is the top <see cref="EPackage"/>
         /// </remarks>
-        public EPackage ESuperPackage => (EPackage)this.EContainer;
+        public EPackage ESuperPackage => (EPackage)this.EContainer!;
 
         /// <summary>
         /// Read the attributes of the current node

--- a/ECoreNetto/ModelElement/NamedElement/ETypedElement.cs
+++ b/ECoreNetto/ModelElement/NamedElement/ETypedElement.cs
@@ -44,7 +44,7 @@ namespace ECoreNetto
         /// <param name="loggerFactory">
         /// The (injected) <see cref="ILoggerFactory"/> used to set up logging
         /// </param>
-        protected ETypedElement(Resource.Resource resource, ILoggerFactory loggerFactory = null) : base(resource, loggerFactory)
+        protected ETypedElement(Resource.Resource resource, ILoggerFactory? loggerFactory = null) : base(resource, loggerFactory)
         {
             this.logger = loggerFactory == null ? NullLogger<ETypedElement>.Instance : loggerFactory.CreateLogger<ETypedElement>();
 
@@ -90,7 +90,7 @@ namespace ECoreNetto
         /// <summary>
         /// Gets the type of this <see cref="ETypedElement"/>
         /// </summary>
-        public EClassifier EType { get; private set; }
+        public EClassifier? EType { get; private set; }
 
         /// <summary>
         /// Read the attributes of the current node

--- a/ECoreNetto/ModelElement/NamedElement/TypedElement/EOperation.cs
+++ b/ECoreNetto/ModelElement/NamedElement/TypedElement/EOperation.cs
@@ -35,7 +35,7 @@ namespace ECoreNetto
         /// <summary>
         /// The (injected) <see cref="ILoggerFactory"/> used to set up logging
         /// </summary>
-        private readonly ILoggerFactory loggerFactory;
+        private readonly ILoggerFactory? loggerFactory;
 
         /// <summary>
         /// The <see cref="ILogger"/> used to log
@@ -51,7 +51,7 @@ namespace ECoreNetto
         /// <param name="loggerFactory">
         /// The (injected) <see cref="ILoggerFactory"/> used to set up logging
         /// </param>
-        public EOperation(Resource.Resource resource, ILoggerFactory loggerFactory = null) : base(resource, loggerFactory)
+        public EOperation(Resource.Resource resource, ILoggerFactory? loggerFactory = null) : base(resource, loggerFactory)
         {
             this.loggerFactory = loggerFactory;
 
@@ -74,7 +74,7 @@ namespace ECoreNetto
         /// <summary>
         /// Gets the containing <see cref="EClass"/>
         /// </summary>
-        public EClass EContainingClass => (EClass)this.EContainer;
+        public EClass EContainingClass => (EClass)this.EContainer!;
 
         /// <summary>
         /// Returns whether this operation is an override of some other operation

--- a/ECoreNetto/ModelElement/NamedElement/TypedElement/EParameter.cs
+++ b/ECoreNetto/ModelElement/NamedElement/TypedElement/EParameter.cs
@@ -36,14 +36,14 @@ namespace ECoreNetto
         /// <param name="loggerFactory">
         /// The (injected) <see cref="ILoggerFactory"/> used to set up logging
         /// </param>
-        public EParameter(Resource.Resource resource, ILoggerFactory loggerFactory = null) : base(resource, loggerFactory)
+        public EParameter(Resource.Resource resource, ILoggerFactory? loggerFactory = null) : base(resource, loggerFactory)
         {
         }
 
         /// <summary>
         /// Gets the containing <see cref="EOperation"/>
         /// </summary>
-        public EOperation EOperation => (EOperation)this.EContainer;
+        public EOperation EOperation => (EOperation)this.EContainer!;
 
         /// <summary>
         /// Build the EModelElement.Identifier property

--- a/ECoreNetto/ModelElement/NamedElement/TypedElement/EStructuralFeature.cs
+++ b/ECoreNetto/ModelElement/NamedElement/TypedElement/EStructuralFeature.cs
@@ -42,7 +42,7 @@ namespace ECoreNetto
         /// <param name="loggerFactory">
         /// The (injected) <see cref="ILoggerFactory"/> used to set up logging
         /// </param>
-        protected EStructuralFeature(Resource.Resource resource, ILoggerFactory loggerFactory = null) : base(resource, loggerFactory)
+        protected EStructuralFeature(Resource.Resource resource, ILoggerFactory? loggerFactory = null) : base(resource, loggerFactory)
         {
             this.logger = loggerFactory == null ? NullLogger<EStructuralFeature>.Instance : loggerFactory.CreateLogger<EStructuralFeature>();
 
@@ -117,12 +117,12 @@ namespace ECoreNetto
         /// <summary>
         /// Gets the default value literal.
         /// </summary>
-        public string DefaultValueLiteral { get; private set; }
+        public string? DefaultValueLiteral { get; private set; }
 
         /// <summary>
         /// Gets the containing <see cref="EClass"/>
         /// </summary>
-        public EClass EContainingClass => (EClass)this.EContainer;
+        public EClass EContainingClass => (EClass)this.EContainer!;
 
         /// <summary>
         /// Read the attributes of the current node

--- a/ECoreNetto/ModelElement/NamedElement/TypedElement/StructuralFeature/EAttribute.cs
+++ b/ECoreNetto/ModelElement/NamedElement/TypedElement/StructuralFeature/EAttribute.cs
@@ -46,7 +46,7 @@ namespace ECoreNetto
         /// <param name="loggerFactory">
         /// The (injected) <see cref="ILoggerFactory"/> used to set up logging
         /// </param>
-        public EAttribute(Resource.Resource resource, ILoggerFactory loggerFactory = null) : base(resource, loggerFactory)
+        public EAttribute(Resource.Resource resource, ILoggerFactory? loggerFactory = null) : base(resource, loggerFactory)
         {
             this.logger = loggerFactory == null ? NullLogger<EAttribute>.Instance : loggerFactory.CreateLogger<EAttribute>();
         }

--- a/ECoreNetto/ModelElement/NamedElement/TypedElement/StructuralFeature/EReference.cs
+++ b/ECoreNetto/ModelElement/NamedElement/TypedElement/StructuralFeature/EReference.cs
@@ -47,7 +47,7 @@ namespace ECoreNetto
         /// <param name="loggerFactory">
         /// The (injected) <see cref="ILoggerFactory"/> used to set up logging
         /// </param>
-        public EReference(Resource.Resource resource, ILoggerFactory loggerFactory = null) : base(resource, loggerFactory)
+        public EReference(Resource.Resource resource, ILoggerFactory? loggerFactory = null) : base(resource, loggerFactory)
         {
             this.logger = loggerFactory == null ? NullLogger<EReference>.Instance : loggerFactory.CreateLogger<EReference>();
 
@@ -90,7 +90,7 @@ namespace ECoreNetto
         /// <summary>
         /// Gets the e opposite.
         /// </summary>
-        public EReference EOpposite { get; private set; }
+        public EReference? EOpposite { get; private set; }
 
         /// <summary>
         /// Read the attributes of the current node

--- a/ECoreNetto/Resource/Resource.cs
+++ b/ECoreNetto/Resource/Resource.cs
@@ -48,7 +48,7 @@ namespace ECoreNetto.Resource
         /// <summary>
         /// The (injected) <see cref="ILoggerFactory"/> used to set up logging
         /// </summary>
-        private readonly ILoggerFactory loggerFactory;
+        private readonly ILoggerFactory? loggerFactory;
 
         /// <summary>
         /// The <see cref="ILogger"/> used to log
@@ -81,7 +81,7 @@ namespace ECoreNetto.Resource
         /// <param name="loggerFactory">
         /// The (injected) <see cref="ILoggerFactory"/> used to set up logging
         /// </param>
-        public Resource(ILoggerFactory loggerFactory = null)
+        public Resource(ILoggerFactory? loggerFactory = null)
         {
             this.loggerFactory = loggerFactory;
 
@@ -160,12 +160,12 @@ namespace ECoreNetto.Resource
         /// Gets the containing resource set. A resource is contained by a resource set if it appears in the resources, i.e., the contents, of that resource set.
         /// This reference can only be modified by altering the contents of the resource set directly. 
         /// </summary>
-        public ResourceSet ResourceSet { get; internal set; }
+        public ResourceSet? ResourceSet { get; internal set; }
 
         /// <summary>
         /// Gets or sets the <see cref="Uri"/> of this resource. The URI is normally expected to be absolute and hierarchical; document-relative references will not be serialized and will not be resolved, if this is not the case.
         /// </summary>
-        public Uri URI { get; set; }
+        public Uri URI { get; set; } = null!;
 
         /// <summary>
         /// Gets or sets the cached value of the time stamp when this resource was last loaded or saved, or NULL_TIME_STAMP if the resource is not 
@@ -267,7 +267,7 @@ namespace ECoreNetto.Resource
 
             this.logger.LogTrace("EObject not found in current resource, loading other resources: {0}", resourceUri);
 
-            var resource = this.ResourceSet.Resources.SingleOrDefault(x => x.URI == resourceUri);
+            var resource = this.ResourceSet!.Resources.SingleOrDefault(x => x.URI == resourceUri);
             if (resource == null)
             {
                 resource = this.ResourceSet.CreateResource(resourceUri);
@@ -286,7 +286,7 @@ namespace ECoreNetto.Resource
         /// <param name="options">
         /// The save options.
         /// </param>
-        public void Save(Dictionary<object, object> options)
+        public void Save(Dictionary<object, object>? options)
         {
             this.logger.LogWarning("Saving an Ecore model to file is not yet supported");
 
@@ -305,7 +305,7 @@ namespace ECoreNetto.Resource
         /// <returns>
         /// The top-level <see cref="EPackage"/> contained by the resource.
         /// </returns>
-        public EPackage Load(Dictionary<object, object> options)
+        public EPackage Load(Dictionary<object, object>? options)
         {
             var sw = Stopwatch.StartNew();
 

--- a/ECoreNetto/Resource/ResourceSet.cs
+++ b/ECoreNetto/Resource/ResourceSet.cs
@@ -42,7 +42,7 @@ namespace ECoreNetto.Resource
         /// <summary>
         /// The (injected) <see cref="ILoggerFactory"/> used to set up logging
         /// </summary>
-        private readonly ILoggerFactory loggerFactory;
+        private readonly ILoggerFactory? loggerFactory;
 
         /// <summary>
         /// The <see cref="ILogger"/> used to log
@@ -55,7 +55,7 @@ namespace ECoreNetto.Resource
         /// <param name="loggerFactory">
         /// The (injected) <see cref="ILoggerFactory"/> used to set up logging
         /// </param>
-        public ResourceSet(ILoggerFactory loggerFactory = null)
+        public ResourceSet(ILoggerFactory? loggerFactory = null)
         {
             this.loggerFactory = loggerFactory;
 
@@ -143,7 +143,7 @@ namespace ECoreNetto.Resource
         /// <returns>
         /// the resource resolved by the URI, or null if there isn't one, and it's not being demand loaded.
         /// </returns>
-        public Resource Resource(Uri uri, bool loadOnDemand)
+        public Resource? Resource(Uri uri, bool loadOnDemand)
         {
             if (uri == null)
             {

--- a/ECoreNetto/Utils/ContainmentUpdater.cs
+++ b/ECoreNetto/Utils/ContainmentUpdater.cs
@@ -99,7 +99,7 @@ namespace ECoreNetto.Utils
         /// </param>
         private static void RemoveFromContainer(EAnnotation annotation)
         {
-            var container = (EModelElement)annotation.EContainer;
+            var container = (EModelElement)annotation.EContainer!;
             container.EAnnotations.Remove(annotation);
         }
 
@@ -111,7 +111,7 @@ namespace ECoreNetto.Utils
         /// </param>
         private static void RemoveFromContainer(EPackage package)
         {
-            var container = (EPackage)package.EContainer;
+            var container = (EPackage)package.EContainer!;
             container.ESubPackages.Remove(package);
         }
 
@@ -123,7 +123,7 @@ namespace ECoreNetto.Utils
         /// </param>
         private static void RemoveFromContainer(EClassifier classifier)
         {
-            var container = (EPackage)classifier.EContainer;
+            var container = (EPackage)classifier.EContainer!;
             container.EClassifiers.Remove(classifier);
         }
 
@@ -135,7 +135,7 @@ namespace ECoreNetto.Utils
         /// </param>
         private static void RemoveFromContainer(EParameter parameter)
         {
-            var container = (EOperation)parameter.EContainer;
+            var container = (EOperation)parameter.EContainer!;
             container.EParameters.Remove(parameter);
         }
 
@@ -147,7 +147,7 @@ namespace ECoreNetto.Utils
         /// </param>
         private static void RemoveFromContainer(EOperation operation)
         {
-            var container = (EClass)operation.EContainer;
+            var container = (EClass)operation.EContainer!;
             container.EOperations.Remove(operation);
         }
 
@@ -159,7 +159,7 @@ namespace ECoreNetto.Utils
         /// </param>
         private static void RemoveFromContainer(EStructuralFeature structuralFeature)
         {
-            var container = (EClass)structuralFeature.EContainer;
+            var container = (EClass)structuralFeature.EContainer!;
             container.EStructuralFeatures.Remove(structuralFeature);
         }
 
@@ -171,7 +171,7 @@ namespace ECoreNetto.Utils
         /// </param>
         private static void RemoveFromContainer(EEnumLiteral enumLiteral)
         {
-            var container = (EEnum)enumLiteral.EContainer;
+            var container = (EEnum)enumLiteral.EContainer!;
             container.ELiterals.Remove(enumLiteral);
         }
     }

--- a/ECoreNetto/Utils/EcoreObjectFactory.cs
+++ b/ECoreNetto/Utils/EcoreObjectFactory.cs
@@ -39,7 +39,7 @@ namespace ECoreNetto.Utils
         /// <param name="loggerFactory">
         /// The (injected) <see cref="ILoggerFactory"/> used to set up logging
         /// </param>
-        public EcoreObjectFactory(Resource resource, ILoggerFactory loggerFactory = null)
+        public EcoreObjectFactory(Resource resource, ILoggerFactory? loggerFactory = null)
         {
             var logger = loggerFactory == null ? NullLogger<EcoreObjectFactory>.Instance : loggerFactory.CreateLogger<EcoreObjectFactory>();
 


### PR DESCRIPTION
### Prerequisites

- [x] I have written a descriptive pull-request title
- [x] I have verified that there are no overlapping [pull-requests](https://github.com/STARIONGROUP/EcoreNetto/pulls) open
- [x] I have verified that I am following the EcoreNetto [code style guidelines](https://raw.githubusercontent.com/STARIONGROUP/EcoreNetto/master/.github/CONTRIBUTING.md)
- [x] I have provided test coverage for my change (where applicable)

### Description

 Enables C# nullable reference types across the whole solution and resolves everyresulting warning (416 → 0), with all 127 tests still passing. Behavior is unchanged, this is annotations plus a few guard/`!` assertions.

  - Adds root Directory.Build.props with <Nullable>enable</Nullable>; Removes the redundant per-project<Nullable> from the two test projects that had it.
  - Core model API annotated truthfully: genuinely-optional members become nullable  (EType, EContainer, EOpposite, NsUri/NsPrefix, DefaultValueLiteral, ResourceSet, EType-returning lookups, ResourceSet.Resource → Resource?, Load/Save options).
    Always-present-after-parse members (Name, Identifier, Resource.URI) and the deserialized GitHubRelease DTO keep non-null public types via `= null!`.
  - Tools uses GetRequiredService for DI; helpers/extensions annotated; reporting derefs guarded.
  - Test fixtures: [SetUp] fields use `= null!`; deliberate null-argument tests pass `null!` so the expected exceptions still fire.

  Nullable annotations are advisory metadata, so the public API change is source/binary compatible for consumers.

<!-- Thanks for contributing to EcoreNetto! -->