### PR TITLE
Standardize test project framework/LangVersion centrally (#50)

### DIFF
--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -1,11 +1,22 @@
 <Project>
 
     <!--
-      Solution-wide build properties. Currently scoped to enabling nullable
-      reference types consistently across all projects (see issue #49).
+      Solution-wide build properties. Enables nullable reference types
+      consistently across all projects (see issue #49).
     -->
     <PropertyGroup>
         <Nullable>enable</Nullable>
+    </PropertyGroup>
+
+    <!--
+      Shared defaults for all test projects, standardized centrally so the five
+      *.Tests projects stay consistent (see issue #50). Keyed on the '.Tests'
+      project-name suffix; production projects are unaffected.
+    -->
+    <PropertyGroup Condition="$(MSBuildProjectName.EndsWith('.Tests'))">
+        <TargetFramework>net10.0</TargetFramework>
+        <LangVersion>latest</LangVersion>
+        <IsPackable>false</IsPackable>
     </PropertyGroup>
 
 </Project>

--- a/ECoreNetto.Extensions.Tests/ECoreNetto.Extensions.Tests.csproj
+++ b/ECoreNetto.Extensions.Tests/ECoreNetto.Extensions.Tests.csproj
@@ -1,7 +1,6 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-	  <TargetFramework>net10.0</TargetFramework>
 	  <Company>Starion Group S.A.</Company>
 	  <Authors>Sam Gerene</Authors>
 	  <AssemblyName>ECoreNetto.Extensions.Tests</AssemblyName>
@@ -10,7 +9,6 @@
 	  <PackageLicenseExpression>Apache-2.0</PackageLicenseExpression>
 	  <RepositoryUrl>https://github.com/STARIONGROUP/EcoreNetto.git</RepositoryUrl>
 	  <RepositoryType>Git</RepositoryType>
-	  <IsPackable>false</IsPackable>
   </PropertyGroup>
 
     <ItemGroup>

--- a/ECoreNetto.HandleBars.Tests/ECoreNetto.HandleBars.Tests.csproj
+++ b/ECoreNetto.HandleBars.Tests/ECoreNetto.HandleBars.Tests.csproj
@@ -1,7 +1,6 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
     <PropertyGroup>
-        <TargetFramework>net10.0</TargetFramework>
         <Company>Starion Group S.A.</Company>
         <Authors>Sam Gerene</Authors>
         <AssemblyName>ECoreNetto.HandleBars.Tests</AssemblyName>
@@ -10,7 +9,6 @@
         <PackageLicenseExpression>Apache-2.0</PackageLicenseExpression>
         <RepositoryUrl>https://github.com/STARIONGROUP/EcoreNetto.git</RepositoryUrl>
         <RepositoryType>Git</RepositoryType>
-        <IsPackable>false</IsPackable>
     </PropertyGroup>
 
     <ItemGroup>

--- a/ECoreNetto.Reporting.Tests/ECoreNetto.Reporting.Tests.csproj
+++ b/ECoreNetto.Reporting.Tests/ECoreNetto.Reporting.Tests.csproj
@@ -1,8 +1,6 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
     <PropertyGroup>
-        <TargetFramework>net10.0</TargetFramework>
-        <IsPackable>false</IsPackable>
         <Company>Starion Group S.A.</Company>
         <Authors>Sam Gerené</Authors>
         <Copyright>Copyright © Starion Group S.A.</Copyright>

--- a/ECoreNetto.Tests/ECoreNetto.Tests.csproj
+++ b/ECoreNetto.Tests/ECoreNetto.Tests.csproj
@@ -1,7 +1,6 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
     <PropertyGroup>
-        <TargetFramework>net10.0</TargetFramework>
         <Company>Starion Group S.A.</Company>
         <Authors>Sam Gerene, Naron Phou, Merlin Bieze</Authors>
         <AssemblyName>ECoreNetto.Tests</AssemblyName>
@@ -10,7 +9,6 @@
         <PackageLicenseExpression>Apache-2.0</PackageLicenseExpression>
         <RepositoryUrl>https://github.com/STARIONGROUP/EcoreNetto.git</RepositoryUrl>
         <RepositoryType>Git</RepositoryType>
-        <IsPackable>false</IsPackable>
     </PropertyGroup>
 
     <ItemGroup>

--- a/ECoreNetto.Tools.Tests/ECoreNetto.Tools.Tests.csproj
+++ b/ECoreNetto.Tools.Tests/ECoreNetto.Tools.Tests.csproj
@@ -1,8 +1,6 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
     <PropertyGroup>
-        <TargetFramework>net10.0</TargetFramework>
-        <IsPackable>false</IsPackable>
         <Company>Starion Group S.A.</Company>
         <Authors>Sam Gerené</Authors>
         <Copyright>Copyright © Starion Group S.A.</Copyright>


### PR DESCRIPTION
### Prerequisites

- [x] I have written a descriptive pull-request title
- [x] I have verified that there are no overlapping [pull-requests](https://github.com/STARIONGROUP/EcoreNetto/pulls) open
- [x] I have verified that I am following the EcoreNetto [code style guidelines](https://raw.githubusercontent.com/STARIONGROUP/EcoreNetto/master/.github/CONTRIBUTING.md)
- [x] I have provided test coverage for my change (where applicable)

### Description

  Consolidates the five test projects' framework / language-version / nullable settings into the root Directory.Build.props so they stay consistent.
  - Directory.Build.props: adds a test-scoped PropertyGroup (Condition="$(MSBuildProjectName.EndsWith('.Tests'))") setting TargetFramework=net10.0, LangVersion=latest, IsPackable=false. Nullable is already centralized there (#49). Production projects are unaffected by the condition.
  - Removes the now-duplicated <TargetFramework> and <IsPackable> from each of the 5 *.Tests csproj. LangVersion was previously unset in every test project and is now provided centrally and uniformly.


<!-- Thanks for contributing to EcoreNetto! -->