### PR TITLE
Centralize package versions and shared csproj metadata (#46, #47)

### DIFF
--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -19,4 +19,55 @@
         <IsPackable>false</IsPackable>
     </PropertyGroup>
 
+    <!--
+      Shared metadata for all projects (see issue #46). Harmless on test
+      projects (they are not packable).
+    -->
+    <PropertyGroup>
+        <Company>Starion Group S.A.</Company>
+        <Copyright>Copyright © Starion Group S.A.</Copyright>
+        <Authors>Sam Gerene</Authors>
+        <PackageProjectUrl>https://ecorenetto.org</PackageProjectUrl>
+        <PackageLicenseExpression>Apache-2.0</PackageLicenseExpression>
+        <RepositoryUrl>https://github.com/STARIONGROUP/EcoreNetto</RepositoryUrl>
+        <RepositoryType>Git</RepositoryType>
+        <NeutralLanguage>en-US</NeutralLanguage>
+        <SatelliteResourceLanguages>en-US</SatelliteResourceLanguages>
+    </PropertyGroup>
+
+    <!--
+      Shared packaging configuration for the publishable (non-test) projects:
+      the four libraries and ECoreNetto.Tools.
+    -->
+    <PropertyGroup Condition="!$(MSBuildProjectName.EndsWith('.Tests'))">
+        <PackageRequireLicenseAcceptance>true</PackageRequireLicenseAcceptance>
+        <PackageIcon>ecorenetto-Icon.png</PackageIcon>
+        <PackageReadmeFile>README.md</PackageReadmeFile>
+        <GenerateDocumentationFile>true</GenerateDocumentationFile>
+        <GenerateSBOM>true</GenerateSBOM>
+    </PropertyGroup>
+
+    <ItemGroup Condition="!$(MSBuildProjectName.EndsWith('.Tests'))">
+        <PackageReference Include="Microsoft.Sbom.Targets" PrivateAssets="all" />
+        <None Include="$(MSBuildThisFileDirectory)ecorenetto-Icon.png" Pack="true" PackagePath="" />
+        <None Include="$(MSBuildThisFileDirectory)README.md" Pack="true" PackagePath="\" />
+        <None Include="$(MSBuildThisFileDirectory)LICENSE" Pack="true" PackagePath="\" />
+        <None Include="$(MSBuildThisFileDirectory)NOTICE" Pack="true" PackagePath="\" />
+    </ItemGroup>
+
+    <!--
+      SourceLink and symbol settings for the four libraries only. ECoreNetto.Tools
+      (an executable / dotnet tool) intentionally does not ship SourceLink/symbols.
+    -->
+    <PropertyGroup Condition="!$(MSBuildProjectName.EndsWith('.Tests')) AND '$(MSBuildProjectName)' != 'ECoreNetto.Tools'">
+        <IncludeSymbols>true</IncludeSymbols>
+        <SymbolPackageFormat>snupkg</SymbolPackageFormat>
+        <PublishRepositoryUrl>true</PublishRepositoryUrl>
+        <EmbedUntrackedSources>true</EmbedUntrackedSources>
+    </PropertyGroup>
+
+    <ItemGroup Condition="!$(MSBuildProjectName.EndsWith('.Tests')) AND '$(MSBuildProjectName)' != 'ECoreNetto.Tools'">
+        <PackageReference Include="Microsoft.SourceLink.GitHub" PrivateAssets="All" />
+    </ItemGroup>
+
 </Project>

--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -1,0 +1,37 @@
+<Project>
+
+    <!--
+      Central Package Management: all NuGet package versions are defined here
+      (see issue #47). Projects reference packages without a Version attribute.
+    -->
+    <PropertyGroup>
+        <ManagePackageVersionsCentrally>true</ManagePackageVersionsCentrally>
+    </PropertyGroup>
+
+    <ItemGroup>
+        <PackageVersion Include="Autofac.Extensions.DependencyInjection" Version="11.0.0" />
+        <PackageVersion Include="ClosedXML" Version="0.105.0" />
+        <PackageVersion Include="coverlet.collector" Version="10.0.1" />
+        <PackageVersion Include="coverlet.msbuild" Version="10.0.1" />
+        <PackageVersion Include="Handlebars.Net.Helpers" Version="2.5.5" />
+        <PackageVersion Include="HtmlAgilityPack" Version="1.12.4" />
+        <PackageVersion Include="Microsoft.Extensions.Hosting" Version="10.0.8" />
+        <PackageVersion Include="Microsoft.Extensions.Http" Version="10.0.8" />
+        <PackageVersion Include="Microsoft.Extensions.Logging.Abstractions" Version="10.0.8" />
+        <PackageVersion Include="Microsoft.NET.Test.Sdk" Version="18.6.0" />
+        <PackageVersion Include="Microsoft.Sbom.Targets" Version="4.1.5" />
+        <PackageVersion Include="Microsoft.SourceLink.GitHub" Version="10.0.300" />
+        <PackageVersion Include="Moq" Version="4.20.72" />
+        <PackageVersion Include="NUnit" Version="4.6.1" />
+        <PackageVersion Include="NUnit.Console" Version="3.22.0" />
+        <PackageVersion Include="NUnit3TestAdapter" Version="6.2.0" />
+        <PackageVersion Include="Serilog" Version="4.3.1" />
+        <PackageVersion Include="Serilog.Extensions.Logging" Version="10.0.0" />
+        <PackageVersion Include="Serilog.Sinks.Console" Version="6.1.1" />
+        <PackageVersion Include="Serilog.Sinks.File" Version="7.0.0" />
+        <PackageVersion Include="Spectre.Console" Version="0.55.2" />
+        <PackageVersion Include="System.CommandLine" Version="2.0.8" />
+        <PackageVersion Include="System.IO.Packaging" Version="10.0.8" />
+    </ItemGroup>
+
+</Project>

--- a/ECoreNetto.Extensions.Tests/ECoreNetto.Extensions.Tests.csproj
+++ b/ECoreNetto.Extensions.Tests/ECoreNetto.Extensions.Tests.csproj
@@ -1,39 +1,32 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-	  <Company>Starion Group S.A.</Company>
-	  <Authors>Sam Gerene</Authors>
 	  <AssemblyName>ECoreNetto.Extensions.Tests</AssemblyName>
-	  <Copyright>Starion Group S.A.</Copyright>
-	  <PackageProjectUrl>https://ecorenetto.org</PackageProjectUrl>
-	  <PackageLicenseExpression>Apache-2.0</PackageLicenseExpression>
-	  <RepositoryUrl>https://github.com/STARIONGROUP/EcoreNetto.git</RepositoryUrl>
-	  <RepositoryType>Git</RepositoryType>
   </PropertyGroup>
 
     <ItemGroup>
-        <PackageReference Include="Microsoft.NET.Test.Sdk" Version="18.6.0" />
-        <PackageReference Include="Moq" Version="4.20.72" />
-        <PackageReference Include="NUnit" Version="4.6.1" />
-        <PackageReference Include="NUnit.Console" Version="3.22.0" />
-        <PackageReference Include="NUnit3TestAdapter" Version="6.2.0">
+        <PackageReference Include="Microsoft.NET.Test.Sdk" />
+        <PackageReference Include="Moq" />
+        <PackageReference Include="NUnit" />
+        <PackageReference Include="NUnit.Console" />
+        <PackageReference Include="NUnit3TestAdapter">
             <PrivateAssets>all</PrivateAssets>
             <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
         </PackageReference>
-        <PackageReference Include="coverlet.collector" Version="10.0.1">
+        <PackageReference Include="coverlet.collector">
             <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
             <PrivateAssets>all</PrivateAssets>
         </PackageReference>
-        <PackageReference Include="coverlet.msbuild" Version="10.0.1">
+        <PackageReference Include="coverlet.msbuild">
             <PrivateAssets>all</PrivateAssets>
             <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
         </PackageReference>
     </ItemGroup>
 
     <ItemGroup>
-        <PackageReference Include="Serilog" Version="4.3.1" />
-        <PackageReference Include="Serilog.Extensions.Logging" Version="10.0.0" />
-        <PackageReference Include="Serilog.Sinks.Console" Version="6.1.1" />
+        <PackageReference Include="Serilog" />
+        <PackageReference Include="Serilog.Extensions.Logging" />
+        <PackageReference Include="Serilog.Sinks.Console" />
     </ItemGroup>
 
   <ItemGroup>

--- a/ECoreNetto.Extensions/ECoreNetto.Extensions.csproj
+++ b/ECoreNetto.Extensions/ECoreNetto.Extensions.csproj
@@ -3,34 +3,16 @@
     <PropertyGroup>
         <TargetFramework>netstandard2.0</TargetFramework>
         <LangVersion>10.0</LangVersion>
-        <Company>Starion Group S.A.</Company>
-        <Copyright>Copyright © Starion Group S.A.</Copyright>
         <Title>ECoreNetto.Extensions</Title>
         <Version>7.0.9</Version>
         <Description>Extension methods for the ECoreNetto library that are typically used to support code generation</Description>
         <PackageId>ECoreNetto.Extensions</PackageId>
-        <PackageRequireLicenseAcceptance>true</PackageRequireLicenseAcceptance>
-        <PackageProjectUrl>https://ecorenetto.org</PackageProjectUrl>
-        <PackageLicenseExpression>Apache-2.0</PackageLicenseExpression>
-        <IncludeSymbols>true</IncludeSymbols>
-        <SymbolPackageFormat>snupkg</SymbolPackageFormat>
-        <PublishRepositoryUrl>true</PublishRepositoryUrl>
-        <EmbedUntrackedSources>true</EmbedUntrackedSources>
-        <RepositoryUrl>https://github.com/STARIONGROUP/EcoreNetto</RepositoryUrl>
-        <RepositoryType>Git</RepositoryType>
-        <PackageIcon>ecorenetto-Icon.png</PackageIcon>
         <AssemblyTitle>EcoreNetto.Extensions</AssemblyTitle>
-        <NeutralLanguage>en-US</NeutralLanguage>
-        <SatelliteResourceLanguages>en-US</SatelliteResourceLanguages>
-        <Authors>Sam Gerene</Authors>
         <PackageTags>Ecore modeltopia</PackageTags>
-        <GenerateDocumentationFile>true</GenerateDocumentationFile>
-        <GenerateSBOM>true</GenerateSBOM>
         <PackageReleaseNotes>
             [Update] to ECoreNetto version 7.0.9
             [Update] Microsoft.SourceLink.GitHub to version 10.0.203
         </PackageReleaseNotes>
-        <PackageReadmeFile>README.md</PackageReadmeFile>
     </PropertyGroup>
 
     <ItemGroup>
@@ -38,16 +20,7 @@
     </ItemGroup>
 
     <ItemGroup>
-        <PackageReference Include="HtmlAgilityPack" Version="1.12.4" />
-        <PackageReference Include="Microsoft.Sbom.Targets" Version="4.1.5" PrivateAssets="all" />
-        <PackageReference Include="Microsoft.SourceLink.GitHub" Version="10.0.300" PrivateAssets="All" />
-    </ItemGroup>
-
-    <ItemGroup>
-        <None Include="..\ecorenetto-Icon.png" Pack="true" PackagePath="" />
-        <None Include="..\README.md" Pack="true" PackagePath="\" />
-        <None Include="..\LICENSE" Pack="true" PackagePath="\" />
-        <None Include="..\NOTICE" Pack="true" PackagePath="\" />
+        <PackageReference Include="HtmlAgilityPack" />
     </ItemGroup>
 
     <ItemGroup>

--- a/ECoreNetto.HandleBars.Tests/ECoreNetto.HandleBars.Tests.csproj
+++ b/ECoreNetto.HandleBars.Tests/ECoreNetto.HandleBars.Tests.csproj
@@ -1,35 +1,28 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
     <PropertyGroup>
-        <Company>Starion Group S.A.</Company>
-        <Authors>Sam Gerene</Authors>
         <AssemblyName>ECoreNetto.HandleBars.Tests</AssemblyName>
-        <Copyright>Starion Group S.A.</Copyright>
-        <PackageProjectUrl>https://ecorenetto.org</PackageProjectUrl>
-        <PackageLicenseExpression>Apache-2.0</PackageLicenseExpression>
-        <RepositoryUrl>https://github.com/STARIONGROUP/EcoreNetto.git</RepositoryUrl>
-        <RepositoryType>Git</RepositoryType>
     </PropertyGroup>
 
     <ItemGroup>
-        <PackageReference Include="Microsoft.NET.Test.Sdk" Version="18.6.0" />
-        <PackageReference Include="NUnit" Version="4.6.1" />
-        <PackageReference Include="NUnit.Console" Version="3.22.0" />
-        <PackageReference Include="NUnit3TestAdapter" Version="6.2.0">
+        <PackageReference Include="Microsoft.NET.Test.Sdk" />
+        <PackageReference Include="NUnit" />
+        <PackageReference Include="NUnit.Console" />
+        <PackageReference Include="NUnit3TestAdapter">
             <PrivateAssets>all</PrivateAssets>
             <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
         </PackageReference>
-        <PackageReference Include="coverlet.collector" Version="10.0.1">
+        <PackageReference Include="coverlet.collector">
             <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
             <PrivateAssets>all</PrivateAssets>
         </PackageReference>
-        <PackageReference Include="coverlet.msbuild" Version="10.0.1">
+        <PackageReference Include="coverlet.msbuild">
             <PrivateAssets>all</PrivateAssets>
             <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
         </PackageReference>
-        <PackageReference Include="Serilog" Version="4.3.1" />
-        <PackageReference Include="Serilog.Extensions.Logging" Version="10.0.0" />
-        <PackageReference Include="Serilog.Sinks.Console" Version="6.1.1" />
+        <PackageReference Include="Serilog" />
+        <PackageReference Include="Serilog.Extensions.Logging" />
+        <PackageReference Include="Serilog.Sinks.Console" />
     </ItemGroup>
 
     <ItemGroup>

--- a/ECoreNetto.HandleBars/ECoreNetto.HandleBars.csproj
+++ b/ECoreNetto.HandleBars/ECoreNetto.HandleBars.csproj
@@ -1,54 +1,27 @@
-﻿<Project Sdk="Microsoft.NET.Sdk">
+<Project Sdk="Microsoft.NET.Sdk">
 
     <PropertyGroup>
         <TargetFramework>netstandard2.0</TargetFramework>
         <LangVersion>10.0</LangVersion>
-        <Company>Starion Group S.A.</Company>
-        <Copyright>Copyright © Starion Group S.A.</Copyright>
         <Title>ECoreNetto.HandleBars</Title>
         <Version>7.0.9</Version>
         <Description>HandleBarHelpers for use in combination with the ECoreNetto library to support HandleBarHelpers based code generation</Description>
         <PackageId>ECoreNetto.HandleBars</PackageId>
-        <PackageRequireLicenseAcceptance>true</PackageRequireLicenseAcceptance>
-        <PackageProjectUrl>https://ecorenetto.org</PackageProjectUrl>
-        <PackageLicenseExpression>Apache-2.0</PackageLicenseExpression>
-        <IncludeSymbols>true</IncludeSymbols>
-        <SymbolPackageFormat>snupkg</SymbolPackageFormat>
-        <PublishRepositoryUrl>true</PublishRepositoryUrl>
-        <EmbedUntrackedSources>true</EmbedUntrackedSources>
-        <RepositoryUrl>https://github.com/STARIONGROUP/EcoreNetto</RepositoryUrl>
-        <RepositoryType>Git</RepositoryType>
-        <PackageIcon>ecorenetto-Icon.png</PackageIcon>
         <AssemblyTitle>EcoreNetto.HandleBars</AssemblyTitle>
-        <NeutralLanguage>en-US</NeutralLanguage>
-        <SatelliteResourceLanguages>en-US</SatelliteResourceLanguages>
-        <Authors>Sam Gerene</Authors>
         <PackageTags>Ecore HandleBars modeltopia</PackageTags>
-        <GenerateDocumentationFile>true</GenerateDocumentationFile>
-        <GenerateSBOM>true</GenerateSBOM>
         <PackageReleaseNotes>
             [Update] ECoreNetto.Extensions to version 7.0.9
             [Update] Microsoft.SourceLink.GitHub to version 10.0.103
             [Update] Handlebars.Net.Helpers to version 2.5.5
         </PackageReleaseNotes>
-        <PackageReadmeFile>README.md</PackageReadmeFile>
     </PropertyGroup>
 
     <ItemGroup>
-        <PackageReference Include="Handlebars.Net.Helpers" Version="2.5.5" />
-        <PackageReference Include="Microsoft.Sbom.Targets" Version="4.1.5" PrivateAssets="all" />
-        <PackageReference Include="Microsoft.SourceLink.GitHub" Version="10.0.300" PrivateAssets="All" />
+        <PackageReference Include="Handlebars.Net.Helpers" />
     </ItemGroup>
 
     <ItemGroup>
         <ProjectReference Include="..\ECoreNetto.Extensions\ECoreNetto.Extensions.csproj" />
-    </ItemGroup>
-
-    <ItemGroup>
-        <None Include="..\ecorenetto-Icon.png" Pack="true" PackagePath="" />
-        <None Include="..\README.md" Pack="true" PackagePath="\" />
-        <None Include="..\LICENSE" Pack="true" PackagePath="\" />
-        <None Include="..\NOTICE" Pack="true" PackagePath="\" />
     </ItemGroup>
 
     <ItemGroup>

--- a/ECoreNetto.Reporting.Tests/ECoreNetto.Reporting.Tests.csproj
+++ b/ECoreNetto.Reporting.Tests/ECoreNetto.Reporting.Tests.csproj
@@ -1,31 +1,25 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
-    <PropertyGroup>
-        <Company>Starion Group S.A.</Company>
-        <Authors>Sam Gerené</Authors>
-        <Copyright>Copyright © Starion Group S.A.</Copyright>
-    </PropertyGroup>
-
     <ItemGroup>
-        <PackageReference Include="Moq" Version="4.20.72" />
-        <PackageReference Include="Microsoft.NET.Test.Sdk" Version="18.6.0" />
-        <PackageReference Include="NUnit" Version="4.6.1" />
-        <PackageReference Include="NUnit.Console" Version="3.22.0" />
-        <PackageReference Include="NUnit3TestAdapter" Version="6.2.0">
+        <PackageReference Include="Moq" />
+        <PackageReference Include="Microsoft.NET.Test.Sdk" />
+        <PackageReference Include="NUnit" />
+        <PackageReference Include="NUnit.Console" />
+        <PackageReference Include="NUnit3TestAdapter">
             <PrivateAssets>all</PrivateAssets>
             <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
         </PackageReference>
-        <PackageReference Include="coverlet.collector" Version="10.0.1">
+        <PackageReference Include="coverlet.collector">
             <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
             <PrivateAssets>all</PrivateAssets>
         </PackageReference>
-        <PackageReference Include="coverlet.msbuild" Version="10.0.1">
+        <PackageReference Include="coverlet.msbuild">
             <PrivateAssets>all</PrivateAssets>
             <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
         </PackageReference>
-        <PackageReference Include="Serilog" Version="4.3.1" />
-        <PackageReference Include="Serilog.Extensions.Logging" Version="10.0.0" />
-        <PackageReference Include="Serilog.Sinks.Console" Version="6.1.1" />
+        <PackageReference Include="Serilog" />
+        <PackageReference Include="Serilog.Extensions.Logging" />
+        <PackageReference Include="Serilog.Sinks.Console" />
     </ItemGroup>
 
     <ItemGroup>

--- a/ECoreNetto.Reporting/ECoreNetto.Reporting.csproj
+++ b/ECoreNetto.Reporting/ECoreNetto.Reporting.csproj
@@ -1,37 +1,19 @@
-﻿<Project Sdk="Microsoft.NET.Sdk">
+<Project Sdk="Microsoft.NET.Sdk">
 
     <PropertyGroup>
         <TargetFramework>netstandard2.0</TargetFramework>
         <LangVersion>10.0</LangVersion>
-        <Company>Starion Group S.A.</Company>
-        <Copyright>Copyright © Starion Group S.A.</Copyright>
         <Title>ECoreNetto.Reporting</Title>
         <Version>7.0.9</Version>
         <Description>Ecore Reporting use in combination with the ECoreNetto library generate reports</Description>
         <PackageId>ECoreNetto.Reporting</PackageId>
-        <PackageRequireLicenseAcceptance>true</PackageRequireLicenseAcceptance>
-        <PackageProjectUrl>https://ecorenetto.org</PackageProjectUrl>
-        <PackageLicenseExpression>Apache-2.0</PackageLicenseExpression>
-        <IncludeSymbols>true</IncludeSymbols>
-        <SymbolPackageFormat>snupkg</SymbolPackageFormat>
-        <PublishRepositoryUrl>true</PublishRepositoryUrl>
-        <EmbedUntrackedSources>true</EmbedUntrackedSources>
-        <RepositoryUrl>https://github.com/STARIONGROUP/EcoreNetto</RepositoryUrl>
-        <RepositoryType>Git</RepositoryType>
-        <PackageIcon>ecorenetto-Icon.png</PackageIcon>
         <AssemblyTitle>EcoreNetto.Reporting</AssemblyTitle>
-        <NeutralLanguage>en-US</NeutralLanguage>
-        <SatelliteResourceLanguages>en-US</SatelliteResourceLanguages>
-        <Authors>Sam Gerene</Authors>
         <PackageTags>Ecore HandleBars Reporting modeltopia</PackageTags>
-        <GenerateDocumentationFile>true</GenerateDocumentationFile>
-        <GenerateSBOM>true</GenerateSBOM>
         <PackageReleaseNotes>
             [Update] ECoreNetto.HandleBars version 7.0.9
             [Update] System.IO.Packaging version 10.0.7
             [Update] Microsoft.SourceLink.GitHub to version 10.0.203
         </PackageReleaseNotes>
-        <PackageReadmeFile>README.md</PackageReadmeFile>
     </PropertyGroup>
 
     <ItemGroup>
@@ -53,20 +35,11 @@
     </ItemGroup>
 
     <ItemGroup>
-        <PackageReference Include="ClosedXML" Version="0.105.0" />
-        <PackageReference Include="Microsoft.Sbom.Targets" Version="4.1.5" PrivateAssets="all" />
-        <PackageReference Include="Microsoft.SourceLink.GitHub" Version="10.0.300" PrivateAssets="All" />
+        <PackageReference Include="ClosedXML" />
     </ItemGroup>
 
     <ItemGroup Label="Transitive Dependency overrides">
-        <PackageReference Include="System.IO.Packaging" Version="10.0.8" />
-    </ItemGroup>
-
-    <ItemGroup>
-        <None Include="..\ecorenetto-Icon.png" Pack="true" PackagePath="" />
-        <None Include="..\README.md" Pack="true" PackagePath="\" />
-        <None Include="..\LICENSE" Pack="true" PackagePath="\" />
-        <None Include="..\NOTICE" Pack="true" PackagePath="\" />
+        <PackageReference Include="System.IO.Packaging" />
     </ItemGroup>
 
     <ItemGroup>

--- a/ECoreNetto.Tests/ECoreNetto.Tests.csproj
+++ b/ECoreNetto.Tests/ECoreNetto.Tests.csproj
@@ -1,39 +1,32 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
     <PropertyGroup>
-        <Company>Starion Group S.A.</Company>
-        <Authors>Sam Gerene, Naron Phou, Merlin Bieze</Authors>
         <AssemblyName>ECoreNetto.Tests</AssemblyName>
-        <Copyright>Copyright © Starion Group S.A.</Copyright>
-        <PackageProjectUrl>https://ecorenetto.org</PackageProjectUrl>
-        <PackageLicenseExpression>Apache-2.0</PackageLicenseExpression>
-        <RepositoryUrl>https://github.com/STARIONGROUP/EcoreNetto.git</RepositoryUrl>
-        <RepositoryType>Git</RepositoryType>
     </PropertyGroup>
 
     <ItemGroup>
-        <PackageReference Include="Microsoft.NET.Test.Sdk" Version="18.6.0" />
-        <PackageReference Include="Moq" Version="4.20.72" />
-        <PackageReference Include="NUnit" Version="4.6.1" />
-        <PackageReference Include="NUnit.Console" Version="3.22.0" />
-        <PackageReference Include="NUnit3TestAdapter" Version="6.2.0">
+        <PackageReference Include="Microsoft.NET.Test.Sdk" />
+        <PackageReference Include="Moq" />
+        <PackageReference Include="NUnit" />
+        <PackageReference Include="NUnit.Console" />
+        <PackageReference Include="NUnit3TestAdapter">
             <PrivateAssets>all</PrivateAssets>
             <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
         </PackageReference>
-        <PackageReference Include="coverlet.collector" Version="10.0.1">
+        <PackageReference Include="coverlet.collector">
             <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
             <PrivateAssets>all</PrivateAssets>
         </PackageReference>
-        <PackageReference Include="coverlet.msbuild" Version="10.0.1">
+        <PackageReference Include="coverlet.msbuild">
             <PrivateAssets>all</PrivateAssets>
             <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
         </PackageReference>
     </ItemGroup>
 
     <ItemGroup>
-        <PackageReference Include="Serilog" Version="4.3.1" />
-        <PackageReference Include="Serilog.Extensions.Logging" Version="10.0.0" />
-        <PackageReference Include="Serilog.Sinks.Console" Version="6.1.1" />
+        <PackageReference Include="Serilog" />
+        <PackageReference Include="Serilog.Extensions.Logging" />
+        <PackageReference Include="Serilog.Sinks.Console" />
     </ItemGroup>
 
     <ItemGroup>

--- a/ECoreNetto.Tools.Tests/ECoreNetto.Tools.Tests.csproj
+++ b/ECoreNetto.Tools.Tests/ECoreNetto.Tools.Tests.csproj
@@ -1,31 +1,25 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
-    <PropertyGroup>
-        <Company>Starion Group S.A.</Company>
-        <Authors>Sam Gerené</Authors>
-        <Copyright>Copyright © Starion Group S.A.</Copyright>
-    </PropertyGroup>
-
     <ItemGroup>
-        <PackageReference Include="Moq" Version="4.20.72" />
-        <PackageReference Include="Microsoft.NET.Test.Sdk" Version="18.6.0" />
-        <PackageReference Include="NUnit" Version="4.6.1" />
-        <PackageReference Include="NUnit.Console" Version="3.22.0" />
-        <PackageReference Include="NUnit3TestAdapter" Version="6.2.0">
+        <PackageReference Include="Moq" />
+        <PackageReference Include="Microsoft.NET.Test.Sdk" />
+        <PackageReference Include="NUnit" />
+        <PackageReference Include="NUnit.Console" />
+        <PackageReference Include="NUnit3TestAdapter">
             <PrivateAssets>all</PrivateAssets>
             <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
         </PackageReference>
-        <PackageReference Include="coverlet.collector" Version="10.0.1">
+        <PackageReference Include="coverlet.collector">
             <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
             <PrivateAssets>all</PrivateAssets>
         </PackageReference>
-        <PackageReference Include="coverlet.msbuild" Version="10.0.1">
+        <PackageReference Include="coverlet.msbuild">
             <PrivateAssets>all</PrivateAssets>
             <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
         </PackageReference>
-        <PackageReference Include="Serilog" Version="4.3.1" />
-        <PackageReference Include="Serilog.Extensions.Logging" Version="10.0.0" />
-        <PackageReference Include="Serilog.Sinks.Console" Version="6.1.1" />
+        <PackageReference Include="Serilog" />
+        <PackageReference Include="Serilog.Extensions.Logging" />
+        <PackageReference Include="Serilog.Sinks.Console" />
     </ItemGroup>
 
     <ItemGroup>

--- a/ECoreNetto.Tools/ECoreNetto.Tools.csproj
+++ b/ECoreNetto.Tools/ECoreNetto.Tools.csproj
@@ -1,4 +1,4 @@
-﻿<Project Sdk="Microsoft.NET.Sdk">
+<Project Sdk="Microsoft.NET.Sdk">
 
     <PropertyGroup Label="Package">
         <LangVersion>14.0</LangVersion>
@@ -11,14 +11,8 @@
         <ToolCommandName>ecoretools</ToolCommandName>
         <Version>8.0.1</Version>
         <ImplicitUsings>disable</ImplicitUsings>
-        <PackageReadmeFile>README.md</PackageReadmeFile>
-        <PackageIcon>ecorenetto-Icon.png</PackageIcon>
         <ApplicationIcon>icon.ico</ApplicationIcon>
-        <NeutralLanguage>en-US</NeutralLanguage>
-        <SatelliteResourceLanguages>en-US</SatelliteResourceLanguages>
         <PackageTags>Ecore HandleBars Reporting modeltopia</PackageTags>
-        <GenerateDocumentationFile>true</GenerateDocumentationFile>
-        <GenerateSBOM>true</GenerateSBOM>
         <PackageReleaseNotes>
             [Update] ECoreNetto.Reporting to version 7.0.9
             [Update] Autofac.Extensions.DependencyInjection to version 11.0.0
@@ -27,19 +21,6 @@
             [Update] System.CommandLine to version 2.0.7
             [Update] Spectre.Console to version 0.54.0
         </PackageReleaseNotes>
-    </PropertyGroup>
-
-    <PropertyGroup Label="Copyright">
-        <Company>Starion Group S.A.</Company>
-        <Copyright>Copyright © Starion Group S.A.</Copyright>
-        <Authors>Sam Gerené</Authors>
-        <PackageLicenseExpression>Apache-2.0</PackageLicenseExpression>
-        <RequireLicenseAcceptance>true</RequireLicenseAcceptance>
-    </PropertyGroup>
-
-    <PropertyGroup Label="Repository">
-        <RepositoryUrl>https://github.com/STARIONGROUP/EcoreNetto</RepositoryUrl>
-        <RepositoryType>Git</RepositoryType>
     </PropertyGroup>
 
     <ItemGroup>
@@ -53,21 +34,16 @@
     </ItemGroup>
 
     <ItemGroup>
-        <PackageReference Include="Autofac.Extensions.DependencyInjection" Version="11.0.0" />
-        <PackageReference Include="Microsoft.Extensions.Http" Version="10.0.8" />
-        <PackageReference Include="Microsoft.Extensions.Hosting" Version="10.0.8" />
-        <PackageReference Include="Serilog.Extensions.Logging" Version="10.0.0" />
-        <PackageReference Include="Serilog.Sinks.File" Version="7.0.0" />
-        <PackageReference Include="System.CommandLine" Version="2.0.8" />
-        <PackageReference Include="Spectre.Console" Version="0.55.2" />
-        <PackageReference Include="Microsoft.Sbom.Targets" Version="4.1.5" PrivateAssets="all" />
+        <PackageReference Include="Autofac.Extensions.DependencyInjection" />
+        <PackageReference Include="Microsoft.Extensions.Http" />
+        <PackageReference Include="Microsoft.Extensions.Hosting" />
+        <PackageReference Include="Serilog.Extensions.Logging" />
+        <PackageReference Include="Serilog.Sinks.File" />
+        <PackageReference Include="System.CommandLine" />
+        <PackageReference Include="Spectre.Console" />
     </ItemGroup>
 
     <ItemGroup>
-        <None Include="..\ecorenetto-Icon.png" Pack="true" PackagePath="" />
-        <None Include="..\README.md" Pack="true" PackagePath="\" />
-        <None Include="..\LICENSE" Pack="true" PackagePath="\" />
-        <None Include="..\NOTICE" Pack="true" PackagePath="\" />
         <Content Include="icon.ico" />
     </ItemGroup>
 

--- a/ECoreNetto/ECoreNetto.csproj
+++ b/ECoreNetto/ECoreNetto.csproj
@@ -1,52 +1,25 @@
-﻿<?xml version="1.0" encoding="utf-8"?>
+<?xml version="1.0" encoding="utf-8"?>
 
 <Project Sdk="Microsoft.NET.Sdk">
 
     <PropertyGroup>
         <TargetFramework>netstandard2.0</TargetFramework>
         <LangVersion>10.0</LangVersion>
-        <Company>Starion Group S.A.</Company>
         <Title>EcoreNetto</Title>
         <Version>7.0.9</Version>
         <Description>ECoreNetto is a dotnet core library that is used to deserialize an Ecore meta-model for the purpose of code generation. Ecore is a meta-model used to represent models in the Eclipse Modelling Framework. EMF is a powerful framework and code generation facility for building Java applications based on simple model definitions. The intention of ECoreNetto is not to be a port of EMF, it aims at bridging the gap to the .NET world to facilitate code generation of C# class libraries based on an Ecore model using the .NET code available tooling and libraries.</Description>
         <PackageId>ECoreNetto</PackageId>
         <GeneratePackageOnBuild>False</GeneratePackageOnBuild>
-        <Copyright>Copyright © Starion Group S.A.</Copyright>
-        <PackageRequireLicenseAcceptance>true</PackageRequireLicenseAcceptance>
-        <PackageProjectUrl>https://ecorenetto.org</PackageProjectUrl>
-        <PackageLicenseExpression>Apache-2.0</PackageLicenseExpression>
-        <IncludeSymbols>true</IncludeSymbols>
-        <SymbolPackageFormat>snupkg</SymbolPackageFormat>
-        <PublishRepositoryUrl>true</PublishRepositoryUrl>
-        <EmbedUntrackedSources>true</EmbedUntrackedSources>
-        <RepositoryUrl>https://github.com/STARIONGROUP/EcoreNetto</RepositoryUrl>
-        <RepositoryType>Git</RepositoryType>
-        <PackageIcon>ecorenetto-Icon.png</PackageIcon>
         <AssemblyTitle>EcoreNetto</AssemblyTitle>
-        <NeutralLanguage>en-US</NeutralLanguage>
-        <SatelliteResourceLanguages>en-US</SatelliteResourceLanguages>
-        <Authors>Sam Gerene</Authors>
         <PackageTags>Ecore modeltopia</PackageTags>
-        <GenerateDocumentationFile>true</GenerateDocumentationFile>
-        <GenerateSBOM>true</GenerateSBOM>
         <PackageReleaseNotes>
             [Update] Microsoft.Extensions.Logging.Abstractions to version 10.0.7
             [Update] Microsoft.SourceLink.GitHub to version 10.0.203
         </PackageReleaseNotes>
-        <PackageReadmeFile>README.md</PackageReadmeFile>
     </PropertyGroup>
 
     <ItemGroup>
-        <None Include="..\ecorenetto-Icon.png" Pack="true" PackagePath="" />
-        <None Include="..\README.md" Pack="true" PackagePath="\" />
-        <None Include="..\LICENSE" Pack="true" PackagePath="\" />
-        <None Include="..\NOTICE" Pack="true" PackagePath="\" />
-    </ItemGroup>
-
-    <ItemGroup>
-        <PackageReference Include="Microsoft.Extensions.Logging.Abstractions" Version="10.0.8" />
-        <PackageReference Include="Microsoft.Sbom.Targets" Version="4.1.5" PrivateAssets="all" />
-        <PackageReference Include="Microsoft.SourceLink.GitHub" Version="10.0.300" PrivateAssets="All" />
+        <PackageReference Include="Microsoft.Extensions.Logging.Abstractions" />
     </ItemGroup>
 
     <ItemGroup>


### PR DESCRIPTION
### Prerequisites

- [x] I have written a descriptive pull-request title
- [x] I have verified that there are no overlapping [pull-requests](https://github.com/STARIONGROUP/EcoreNetto/pulls) open
- [x] I have verified that I am following the EcoreNetto [code style guidelines](https://raw.githubusercontent.com/STARIONGROUP/EcoreNetto/master/.github/CONTRIBUTING.md)
- [x] I have provided test coverage for my change (where applicable)

### Description

  Consolidates duplicated csproj configuration into root props files.

  #47 — Central Package Management:
  - Adds Directory.Packages.props (ManagePackageVersionsCentrally=true) with all 23 package versions (no conflicts existed).
  - Removes Version= from every PackageReference (PrivateAssets/IncludeAssets kept).

  #46 — Shared metadata in Directory.Build.props:
  - Unconditional: Company, Copyright, Authors, PackageProjectUrl, license, repo URL/type, language metadata.
  - Non-test (4 libs + Tools): license-acceptance, icon, readme, doc-file, SBOM generation + Microsoft.Sbom.Targets ref + icon/README/LICENSE/NOTICE pack items.
  - Libraries-only (Tools excluded): IncludeSymbols/snupkg, PublishRepositoryUrl, EmbedUntrackedSources +  icrosoft.SourceLink.GitHub ref.
  - Per-csproj metadata stripped accordingly; project-specific settings (PackageId, Version, Description, ReleaseNotes, TargetFramework, etc.) retained.

<!-- Thanks for contributing to EcoreNetto! -->