### PR TITLE
 Make ReportHandler properly async and testable (#41)

### DIFF
--- a/ECoreNetto.Tools.Tests/Commands/HtmlReportCommandTestFixture.cs
+++ b/ECoreNetto.Tools.Tests/Commands/HtmlReportCommandTestFixture.cs
@@ -65,6 +65,9 @@ namespace ECoreNetto.Tools.Tests.Commands
                 .Returns(new Tuple<bool, string>(true, "valid extension"));
 
             this.handler = new HtmlReportCommand.Handler(this.htmlReportGenerator.Object, this.versionChecker.Object);
+
+            // disable the artificial status delay so the generation path runs without latency
+            this.handler.StatusDelay = TimeSpan.Zero;
         }
 
         [Test]

--- a/ECoreNetto.Tools.Tests/Commands/MarkdownReportCommandTestFixture.cs
+++ b/ECoreNetto.Tools.Tests/Commands/MarkdownReportCommandTestFixture.cs
@@ -65,6 +65,9 @@ namespace ECoreNetto.Tools.Tests.Commands
                 .Returns(new Tuple<bool, string>(true, "valid extension"));
 
             this.handler = new MarkdownReportCommand.Handler(this.markdownReportGenerator.Object, this.versionChecker.Object);
+
+            // disable the artificial status delay so the generation path runs without latency
+            this.handler.StatusDelay = TimeSpan.Zero;
         }
 
         [Test]

--- a/ECoreNetto.Tools.Tests/Commands/ModelInspectionCommandTestFixture.cs
+++ b/ECoreNetto.Tools.Tests/Commands/ModelInspectionCommandTestFixture.cs
@@ -65,6 +65,9 @@ namespace ECoreNetto.Tools.Tests.Commands
                 .Returns(new Tuple<bool, string>(true, "valid extension"));
 
             this.handler = new ModelInspectionCommand.Handler(this.modelInspector.Object, this.versionChecker.Object);
+
+            // disable the artificial status delay so the generation path runs without latency
+            this.handler.StatusDelay = TimeSpan.Zero;
         }
 
         [Test]

--- a/ECoreNetto.Tools.Tests/Commands/XlReportCommandTestFixture.cs
+++ b/ECoreNetto.Tools.Tests/Commands/XlReportCommandTestFixture.cs
@@ -65,6 +65,9 @@ namespace ECoreNetto.Tools.Tests.Commands
                 .Returns(new Tuple<bool, string>(true, "valid extension"));
 
             this.handler = new XlReportCommand.Handler(this.reportGenerator.Object, this.versionChecker.Object);
+
+            // disable the artificial status delay so the generation path runs without latency
+            this.handler.StatusDelay = TimeSpan.Zero;
         }
 
         [Test]

--- a/ECoreNetto.Tools.Tests/Commands/XlReportCommandTestFixture.cs
+++ b/ECoreNetto.Tools.Tests/Commands/XlReportCommandTestFixture.cs
@@ -138,5 +138,108 @@ namespace ECoreNetto.Tools.Tests.Commands
 
             Assert.That(result, Is.EqualTo(-1), "InvokeAsync should return -1 upon failure.");
         }
+
+        [Test]
+        public async Task Verify_that_InvokeAsync_without_no_logo_returns_0()
+        {
+            // omitting --no-logo exercises the logo-rendering branch
+            var args = new[]
+            {
+                "excel-report",
+                "--input-model", Path.Combine(TestContext.CurrentContext.TestDirectory, "Data", "recipe.ecore"),
+                "--output-report", Path.Combine(TestContext.CurrentContext.TestDirectory, "tabular-report.xlsx")
+            };
+
+            var parseResult = this.rootCommand.Parse(args);
+
+            var result = await this.handler.InvokeAsync(parseResult, this.cts.Token);
+
+            Assert.That(result, Is.EqualTo(0), "InvokeAsync should return 0 upon success.");
+        }
+
+        [Test]
+        public async Task Verify_that_InvokeAsync_with_auto_open_report_returns_0()
+        {
+            // exercises the ExecuteAutoOpenAsync path; the generated file does not exist, so the
+            // open attempt fails and is swallowed, but the report generation itself succeeds
+            var args = new[]
+            {
+                "excel-report",
+                "--no-logo",
+                "--auto-open-report",
+                "--input-model", Path.Combine(TestContext.CurrentContext.TestDirectory, "Data", "recipe.ecore"),
+                "--output-report", Path.Combine(TestContext.CurrentContext.TestDirectory, "tabular-report.xlsx")
+            };
+
+            var parseResult = this.rootCommand.Parse(args);
+
+            var result = await this.handler.InvokeAsync(parseResult, this.cts.Token);
+
+            this.reportGenerator.Verify(x => x.GenerateReport(It.IsAny<FileInfo>(), It.IsAny<FileInfo>()), Times.Once);
+
+            Assert.That(result, Is.EqualTo(0), "InvokeAsync should return 0 upon success.");
+        }
+
+        [Test]
+        public async Task Verify_that_when_GenerateReport_throws_IOException_it_is_handled()
+        {
+            this.reportGenerator.Setup(x => x.GenerateReport(It.IsAny<FileInfo>(), It.IsAny<FileInfo>()))
+                .Throws(new IOException("the report file is locked"));
+
+            var args = new[]
+            {
+                "excel-report",
+                "--no-logo",
+                "--input-model", Path.Combine(TestContext.CurrentContext.TestDirectory, "Data", "recipe.ecore"),
+                "--output-report", Path.Combine(TestContext.CurrentContext.TestDirectory, "tabular-report.xlsx")
+            };
+
+            var parseResult = this.rootCommand.Parse(args);
+
+            // the IOException is caught and reported to the console; the call completes without throwing
+            var result = await this.handler.InvokeAsync(parseResult, this.cts.Token);
+
+            Assert.That(result, Is.EqualTo(0));
+        }
+
+        [Test]
+        public async Task Verify_that_when_GenerateReport_throws_an_exception_returns_minus_1()
+        {
+            this.reportGenerator.Setup(x => x.GenerateReport(It.IsAny<FileInfo>(), It.IsAny<FileInfo>()))
+                .Throws(new InvalidOperationException("something went wrong"));
+
+            var args = new[]
+            {
+                "excel-report",
+                "--no-logo",
+                "--input-model", Path.Combine(TestContext.CurrentContext.TestDirectory, "Data", "recipe.ecore"),
+                "--output-report", Path.Combine(TestContext.CurrentContext.TestDirectory, "tabular-report.xlsx")
+            };
+
+            var parseResult = this.rootCommand.Parse(args);
+
+            var result = await this.handler.InvokeAsync(parseResult, this.cts.Token);
+
+            Assert.That(result, Is.EqualTo(-1), "InvokeAsync should return -1 when report generation fails.");
+        }
+
+        [Test]
+        public void Verify_that_when_cancellation_is_requested_an_exception_is_thrown()
+        {
+            this.cts.Cancel();
+
+            var args = new[]
+            {
+                "excel-report",
+                "--no-logo",
+                "--input-model", Path.Combine(TestContext.CurrentContext.TestDirectory, "Data", "recipe.ecore"),
+                "--output-report", Path.Combine(TestContext.CurrentContext.TestDirectory, "tabular-report.xlsx")
+            };
+
+            var parseResult = this.rootCommand.Parse(args);
+
+            Assert.That(async () => await this.handler.InvokeAsync(parseResult, this.cts.Token),
+                Throws.InstanceOf<OperationCanceledException>());
+        }
     }
 }

--- a/ECoreNetto.Tools/Commands/ReportHandler.cs
+++ b/ECoreNetto.Tools/Commands/ReportHandler.cs
@@ -38,7 +38,12 @@ namespace ECoreNetto.Tools.Commands
     /// </summary>
     public abstract class ReportHandler
     {
-        private const int SleepTime = 1500;
+        /// <summary>
+        /// Gets or sets the delay between Spectre status updates. This keeps the themed status
+        /// messages briefly visible on the console during a real run. Tests set this to
+        /// <see cref="TimeSpan.Zero"/> so the generation path runs without artificial latency.
+        /// </summary>
+        public TimeSpan StatusDelay { get; internal set; } = TimeSpan.FromMilliseconds(1500);
 
         /// <summary>
         /// Initializes a new instance of the <see cref="ReportHandler"/>
@@ -129,27 +134,24 @@ namespace ECoreNetto.Tools.Commands
                 await AnsiConsole.Status()
                     .AutoRefresh(true)
                     .SpinnerStyle(Style.Parse("green bold"))
-                    .Start($"Preparing Warp Engines for {this.ReportGenerator.QueryReportType()} reporting...", ctx =>
+                    .StartAsync($"Preparing Warp Engines for {this.ReportGenerator.QueryReportType()} reporting...", async ctx =>
                     {
-                        Thread.Sleep(SleepTime);
+                        await Task.Delay(this.StatusDelay, cancellationToken);
 
                         ctx.Status($"Generating Ecore Model report at Warp 11, Captain..., SLOW DOWN!");
 
-                        Thread.Sleep(SleepTime);
+                        await Task.Delay(this.StatusDelay, cancellationToken);
 
                         this.ReportGenerator.GenerateReport(this.inputModel, this.outputReport);
 
                         AnsiConsole.MarkupLine(
                             $"[grey]LOG:[/] Ecore {this.ReportGenerator.QueryReportType()} report generated at [bold]{this.outputReport.FullName}[/]");
-                        Thread.Sleep(SleepTime);
+                        await Task.Delay(this.StatusDelay, cancellationToken);
 
-                        this.ExecuteAutoOpen(ctx);
+                        await this.ExecuteAutoOpenAsync(ctx, cancellationToken);
 
                         ctx.Status("[green]Dropping to impulse speed[/]");
-                        Thread.Sleep(SleepTime);
-
-                        return Task.FromResult(0);
-
+                        await Task.Delay(this.StatusDelay, cancellationToken);
                     });
             }
             catch (IOException ex)
@@ -223,12 +225,15 @@ namespace ECoreNetto.Tools.Commands
         /// <param name="ctx">
         /// Spectre Console <see cref="StatusContext"/>
         /// </param>
-        protected void ExecuteAutoOpen(StatusContext ctx)
+        /// <param name="cancellationToken">
+        /// The <see cref="CancellationToken"/> used to cancel the operation
+        /// </param>
+        protected async Task ExecuteAutoOpenAsync(StatusContext ctx, CancellationToken cancellationToken)
         {
             if (this.autoOpenReport)
             {
                 ctx.Status($"Opening generated report");
-                Thread.Sleep(SleepTime);
+                await Task.Delay(this.StatusDelay, cancellationToken);
 
                 try
                 {
@@ -239,7 +244,7 @@ namespace ECoreNetto.Tools.Commands
                 catch
                 {
                     ctx.Status($"Opening of generated report failed, please open manually");
-                    Thread.Sleep(SleepTime);
+                    await Task.Delay(this.StatusDelay, cancellationToken);
                 }
             }
         }


### PR DESCRIPTION
### Prerequisites

- [x] I have written a descriptive pull-request title
- [x] I have verified that there are no overlapping [pull-requests](https://github.com/STARIONGROUP/EcoreNetto/pulls) open
- [x] I have verified that I am following the EcoreNetto [code style guidelines](https://raw.githubusercontent.com/STARIONGROUP/EcoreNetto/master/.github/CONTRIBUTING.md)
- [x] I have provided test coverage for my change (where applicable)

### Description

Reworks ReportHandler so the report-generation flow is genuinely asynchronous and testable, without losing the Spectre.Console status experience.

  - Replaces the const SleepTime with a configurable, cancellable StatusDelay (default 1500ms for the CLI; internal setter so tests can zero it).
  - Switches AnsiConsole.Status().Start(sync lambda + Task.FromResult) to the async StartAsync API; replaces all Thread.Sleep calls with await Task.Delay(StatusDelay, cancellationToken). ExecuteAutoOpen becomes ExecuteAutoOpenAsync.
  - Command test fixtures set StatusDelay = TimeSpan.Zero, so the generation path runs with no artificial latency (Tools.Tests ~46s → ~22s).


<!-- Thanks for contributing to EcoreNetto! -->