### PR TITLE
Fix copy-paste XML-doc errors in report commands/generators (#43)

### DIFF
--- a/ECoreNetto.Reporting/Generators/MarkdownReportGenerator.cs
+++ b/ECoreNetto.Reporting/Generators/MarkdownReportGenerator.cs
@@ -39,7 +39,7 @@ namespace ECoreNetto.Reporting.Generators
         private readonly ILogger<MarkdownReportGenerator> logger;
 
         /// <summary>
-        /// Initializes a new instance of the <see cref="HtmlReportGenerator"/> class.
+        /// Initializes a new instance of the <see cref="MarkdownReportGenerator"/> class.
         /// </summary>
         /// <param name="loggerFactory">
         /// The (injected) <see cref="ILoggerFactory"/> used to set up logging
@@ -67,7 +67,7 @@ namespace ECoreNetto.Reporting.Generators
         /// /// the path to the Ecore model of which the report is to be generated.
         /// </param>
         /// <returns>
-        /// the content of an HTML report in a string
+        /// the content of a Markdown report in a string
         /// </returns>
         public string GenerateReport(FileInfo modelPath)
         {
@@ -86,11 +86,11 @@ namespace ECoreNetto.Reporting.Generators
 
             var payload = CreateHandlebarsPayload(rootPackage);
 
-            var generatedHtml = template(payload);
+            var generatedMarkdown = template(payload);
 
             this.logger.LogInformation("Generated Markdown report in {ElapsedTime} [ms]", sw.ElapsedMilliseconds);
 
-            return generatedHtml;
+            return generatedMarkdown;
         }
 
         /// <summary>
@@ -116,7 +116,7 @@ namespace ECoreNetto.Reporting.Generators
 
             var sw = Stopwatch.StartNew();
 
-            var generatedHtml = this.GenerateReport(modelPath) ;
+            var generatedMarkdown = this.GenerateReport(modelPath) ;
 
             if (outputPath.Exists)
             {
@@ -124,7 +124,7 @@ namespace ECoreNetto.Reporting.Generators
             }
 
             using var writer = outputPath.CreateText();
-            writer.Write(generatedHtml);
+            writer.Write(generatedMarkdown);
 
             this.logger.LogInformation("Generated Markdown report in {ElapsedTime} [ms]", sw.ElapsedMilliseconds);
         }

--- a/ECoreNetto.Tools/Commands/HtmlReportCommand.cs
+++ b/ECoreNetto.Tools/Commands/HtmlReportCommand.cs
@@ -32,7 +32,7 @@ namespace ECoreNetto.Tools.Commands
     public class HtmlReportCommand : ReportCommand
     {
         /// <summary>
-        /// Initializes a new instance of the <see cref="XlReportCommand"/>
+        /// Initializes a new instance of the <see cref="HtmlReportCommand"/>
         /// </summary>
         public HtmlReportCommand() : base("html-report", "Generates a html report of the ECore model")
         {
@@ -49,16 +49,16 @@ namespace ECoreNetto.Tools.Commands
         }
 
         /// <summary>
-        /// The Command Handler of the <see cref="XlReportCommand"/>
+        /// The Command Handler of the <see cref="HtmlReportCommand"/>
         /// </summary>
         public class Handler : ReportHandler
         {
             /// <summary>
-            /// Initializes a nwe instance of the <see cref="Handler"/> class.
+            /// Initializes a new instance of the <see cref="Handler"/> class.
             /// </summary>
             /// <param name="htmlReportGenerator">
             /// The (injected) <see cref="IHtmlReportGenerator"/> that is used to generate the
-            /// excel report
+            /// html report
             /// </param>
             /// <param name="versionChecker">
             /// The <see cref="IVersionChecker"/> used to check the github version

--- a/ECoreNetto.Tools/Commands/MarkdownReportCommand.cs
+++ b/ECoreNetto.Tools/Commands/MarkdownReportCommand.cs
@@ -32,7 +32,7 @@ namespace ECoreNetto.Tools.Commands
     public class MarkdownReportCommand : ReportCommand
     {
         /// <summary>
-        /// Initializes a new instance of the <see cref="XlReportCommand"/>
+        /// Initializes a new instance of the <see cref="MarkdownReportCommand"/>
         /// </summary>
         public MarkdownReportCommand() : base("md-report", "Generates a Markdown report of the ECore model")
         {
@@ -54,11 +54,11 @@ namespace ECoreNetto.Tools.Commands
         public class Handler : ReportHandler
         {
             /// <summary>
-            /// Initializes a nwe instance of the <see cref="Handler"/> class.
+            /// Initializes a new instance of the <see cref="Handler"/> class.
             /// </summary>
             /// <param name="markdownReportGenerator">
             /// The (injected) <see cref="IMarkdownReportGenerator"/> that is used to generate the
-            /// excel report
+            /// markdown report
             /// </param>
             /// <param name="versionChecker">
             /// The <see cref="IVersionChecker"/> used to check the github version

--- a/ECoreNetto.Tools/Commands/ModelInspectionCommand.cs
+++ b/ECoreNetto.Tools/Commands/ModelInspectionCommand.cs
@@ -50,12 +50,12 @@ namespace ECoreNetto.Tools.Commands
         }
 
         /// <summary>
-        /// The Command Handler of the <see cref="XlReportCommand"/>
+        /// The Command Handler of the <see cref="ModelInspectionCommand"/>
         /// </summary>
         public  class Handler : ReportHandler
         {
             /// <summary>
-            /// Initializes a nwe instance of the <see cref="Handler"/> class.
+            /// Initializes a new instance of the <see cref="Handler"/> class.
             /// </summary>
             /// <param name="modelInspector">
             /// The (injected) <see cref="IModelInspector"/> that is used to generate the

--- a/ECoreNetto.Tools/Commands/XlReportCommand.cs
+++ b/ECoreNetto.Tools/Commands/XlReportCommand.cs
@@ -55,7 +55,7 @@ namespace ECoreNetto.Tools.Commands
         public class Handler : ReportHandler
         {
             /// <summary>
-            /// Initializes a nwe instance of the <see cref="Handler"/> class.
+            /// Initializes a new instance of the <see cref="Handler"/> class.
             /// </summary>
             /// <param name="xlReportGenerator">
             /// The (injected) <see cref="IXlReportGenerator"/> that is used to generate the


### PR DESCRIPTION
### Prerequisites

- [x] I have written a descriptive pull-request title
- [x] I have verified that there are no overlapping [pull-requests](https://github.com/STARIONGROUP/EcoreNetto/pulls) open
- [x] I have verified that I am following the EcoreNetto [code style guidelines](https://raw.githubusercontent.com/STARIONGROUP/EcoreNetto/master/.github/CONTRIBUTING.md)
- [x] I have provided test coverage for my change (where applicable)

### Description

  Documentation/naming cleanup only — no behavior change.

  - HtmlReportCommand / MarkdownReportCommand / ModelInspectionCommand: correct the <see cref="XlReportCommand"/> references copied into the wrong classes, fix the "excel report" param text on the html/markdown handlers, and fix the "nwe instance" typo (also in XlReportCommand, the original source).
  - MarkdownReportGenerator: fix the ctor doc that referenced HtmlReportGenerator and the "<returns> ... HTML report" text, and rename the misleading generatedHtml variable to generatedMarkdown in both GenerateReport overloads.


<!-- Thanks for contributing to EcoreNetto! -->