### PR TITLE
Fix Excel info-sheet dropping the namespace-prefix row (#30)

### DIFF
--- a/ECoreNetto.Reporting.Tests/Generators/XlReportGeneratorTestFixture.cs
+++ b/ECoreNetto.Reporting.Tests/Generators/XlReportGeneratorTestFixture.cs
@@ -1,0 +1,79 @@
+// -------------------------------------------------------------------------------------------------
+// <copyright file="XlReportGeneratorTestFixture.cs" company="Starion Group S.A">
+//
+//   Copyright 2017-2025 Starion Group S.A.
+//
+//   Licensed under the Apache License, Version 2.0 (the "License");
+//   you may not use this file except in compliance with the License.
+//   You may obtain a copy of the License at
+//
+//        http://www.apache.org/licenses/LICENSE-2.0
+//
+//    Unless required by applicable law or agreed to in writing, software
+//    distributed under the License is distributed on an "AS IS" BASIS,
+//    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+//    See the License for the specific language governing permissions and
+//    limitations under the License.
+//
+// </copyright>
+// ------------------------------------------------------------------------------------------------
+
+namespace ECoreNetto.Reporting.Tests.Generators
+{
+    using System.IO;
+
+    using ClosedXML.Excel;
+
+    using ECoreNetto.Reporting.Generators;
+
+    using NUnit.Framework;
+
+    /// <summary>
+    /// Suite of tests for the <see cref="XlReportGenerator"/> class.
+    /// </summary>
+    [TestFixture]
+    public class XlReportGeneratorTestFixture
+    {
+        private XlReportGenerator generator = null!;
+
+        private FileInfo modelFileInfo = null!;
+
+        private FileInfo reportFileInfo = null!;
+
+        [SetUp]
+        public void SetUp()
+        {
+            this.generator = new XlReportGenerator();
+
+            this.modelFileInfo = new FileInfo(Path.Combine(TestContext.CurrentContext.TestDirectory, "Data", "recipe.ecore"));
+            this.reportFileInfo = new FileInfo(Path.Combine(TestContext.CurrentContext.TestDirectory, "xl-report.xlsx"));
+        }
+
+        [Test]
+        public void Verify_that_the_info_sheet_contains_distinct_ns_prefix_and_ns_uri_rows()
+        {
+            this.generator.GenerateReport(this.modelFileInfo, this.reportFileInfo);
+
+            using var workbook = new XLWorkbook(this.reportFileInfo.FullName);
+            var info = workbook.Worksheet("Model Info");
+
+            Assert.Multiple(() =>
+            {
+                Assert.That(info.Cell(4, 1).GetString(), Is.EqualTo("Root Package - ns prefix"));
+                Assert.That(info.Cell(4, 2).GetString(), Is.EqualTo("recipe"));
+                Assert.That(info.Cell(5, 1).GetString(), Is.EqualTo("Root Package - ns uri"));
+                Assert.That(info.Cell(5, 2).GetString(), Is.EqualTo("hu.bme.mit.mdsd.recipe"));
+            });
+        }
+
+        [Test]
+        public void Verify_that_IsValidReportExtension_returns_expected_results()
+        {
+            Assert.Multiple(() =>
+            {
+                Assert.That(this.generator.IsValidReportExtension(new FileInfo("report.xlsx")).Item1, Is.True);
+                Assert.That(this.generator.IsValidReportExtension(new FileInfo("report.txt")).Item1, Is.False);
+            });
+        }
+    }
+}

--- a/ECoreNetto.Reporting/Generators/XlReportGenerator.cs
+++ b/ECoreNetto.Reporting/Generators/XlReportGenerator.cs
@@ -142,8 +142,8 @@ namespace ECoreNetto.Reporting.Generators
             infoWorksheet.Cell(4, 1).Value = "Root Package - ns prefix";
             infoWorksheet.Cell(4, 2).Value = rootPackage.NsPrefix;
 
-            infoWorksheet.Cell(4, 1).Value = "Root Package - ns uri";
-            infoWorksheet.Cell(4, 2).Value = rootPackage.NsUri;
+            infoWorksheet.Cell(5, 1).Value = "Root Package - ns uri";
+            infoWorksheet.Cell(5, 2).Value = rootPackage.NsUri;
 
             this.FormatSheet(infoWorksheet);
         }


### PR DESCRIPTION
### Prerequisites

- [x] I have written a descriptive pull-request title
- [x] I have verified that there are no overlapping [pull-requests](https://github.com/STARIONGROUP/EcoreNetto/pulls) open
- [x] I have verified that I am following the EcoreNetto [code style guidelines](https://raw.githubusercontent.com/STARIONGROUP/EcoreNetto/master/.github/CONTRIBUTING.md)
- [x] I have provided test coverage for my change (where applicable)

### Description

In XlReportGenerator.AddInfoSheet the "ns uri" pair was written to row 4, overwriting the "ns prefix" pair, so the namespace prefix was silently lost from the "Model Info" sheet. Moves the ns-uri pair to row 5 so both appear.

  Adds XlReportGeneratorTestFixture (the generator had no dedicated tests): it generates the workbook from recipe.ecore, reopens it with ClosedXML, and asserts distinct ns-prefix (row 4) and ns-uri (row 5) rows, plus a basic IsValidReportExtension check.

<!-- Thanks for contributing to EcoreNetto! -->