### PR TITLE
[Feature] Populate Resource.Errors with diagnostics during parse (#35)

### DIFF
--- a/ECoreNetto.Tests/Resource/DiagnosticsTestFixture.cs
+++ b/ECoreNetto.Tests/Resource/DiagnosticsTestFixture.cs
@@ -1,0 +1,145 @@
+// -------------------------------------------------------------------------------------------------
+// <copyright file="DiagnosticsTestFixture.cs" company="Starion Group S.A.">
+//
+//   Copyright 2017-2025 Starion Group S.A.
+//
+//   Licensed under the Apache License, Version 2.0 (the "License");
+//   you may not use this file except in compliance with the License.
+//   You may obtain a copy of the License at
+//
+//       http://www.apache.org/licenses/LICENSE-2.0
+//
+//   Unless required by applicable law or agreed to in writing, software
+//   distributed under the License is distributed on an "AS IS" BASIS,
+//   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+//   See the License for the specific language governing permissions and
+//   limitations under the License.
+//
+// </copyright>
+// ------------------------------------------------------------------------------------------------
+
+namespace ECoreNetto.Tests.Resource
+{
+    using System;
+    using System.IO;
+    using System.Linq;
+
+    using ECoreNetto.Resource;
+
+    using NUnit.Framework;
+
+    /// <summary>
+    /// Suite of tests that verify the <see cref="ECoreNetto.ECoreParser"/> records a <see cref="Diagnostic"/>
+    /// in <see cref="Resource.Errors"/> for malformed or unrecognized input before aborting the load (see issue #35).
+    /// </summary>
+    [TestFixture]
+    public class DiagnosticsTestFixture
+    {
+        private ResourceSet resourceSet = null!;
+
+        [SetUp]
+        public void SetUp()
+        {
+            this.resourceSet = new ResourceSet();
+        }
+
+        [Test]
+        public void Verify_that_a_malformed_boolean_attribute_is_recorded_as_an_error_and_aborts_the_load()
+        {
+            var model = Package("malformed-bool", "<eClassifiers xsi:type=\"ecore:EClass\" name=\"A\" abstract=\"notabool\"/>");
+            var resource = this.CreateResourceForContent("malformed-bool.ecore", model);
+
+            Assert.Throws<FormatException>(() => resource.Load(null));
+
+            var error = resource.Errors.SingleOrDefault();
+            Assert.That(error, Is.Not.Null);
+            Assert.Multiple(() =>
+            {
+                Assert.That(error!.Message, Does.Contain("abstract"));
+                Assert.That(error.Message, Does.Contain("notabool"));
+                Assert.That(error.Location, Is.EqualTo(resource.URI.AbsoluteUri));
+            });
+        }
+
+        [Test]
+        public void Verify_that_a_malformed_integer_attribute_is_recorded_as_an_error_and_aborts_the_load()
+        {
+            var model = Package(
+                "malformed-int",
+                "<eClassifiers xsi:type=\"ecore:EEnum\" name=\"E\">\r\n" +
+                "    <eLiterals name=\"X\" value=\"notanint\"/>\r\n" +
+                "  </eClassifiers>");
+            var resource = this.CreateResourceForContent("malformed-int.ecore", model);
+
+            Assert.Throws<FormatException>(() => resource.Load(null));
+
+            var error = resource.Errors.SingleOrDefault();
+            Assert.That(error, Is.Not.Null);
+            Assert.Multiple(() =>
+            {
+                Assert.That(error!.Message, Does.Contain("value"));
+                Assert.That(error.Message, Does.Contain("notanint"));
+            });
+        }
+
+        [Test]
+        public void Verify_that_an_unrecognized_classifier_type_is_recorded_as_an_error_and_aborts_the_load()
+        {
+            var model = Package("unknown-classifier", "<eClassifiers xsi:type=\"ecore:Bogus\" name=\"A\"/>");
+            var resource = this.CreateResourceForContent("unknown-classifier.ecore", model);
+
+            Assert.Throws<InvalidOperationException>(() => resource.Load(null));
+
+            var error = resource.Errors.SingleOrDefault();
+            Assert.That(error, Is.Not.Null);
+            Assert.That(error!.Message, Does.Contain("Bogus"));
+        }
+
+        [Test]
+        public void Verify_that_an_unrecognized_structural_feature_type_is_recorded_as_an_error_and_aborts_the_load()
+        {
+            var model = Package(
+                "unknown-feature",
+                "<eClassifiers xsi:type=\"ecore:EClass\" name=\"A\">\r\n" +
+                "    <eStructuralFeatures xsi:type=\"ecore:Bogus\" name=\"f\"/>\r\n" +
+                "  </eClassifiers>");
+            var resource = this.CreateResourceForContent("unknown-feature.ecore", model);
+
+            Assert.Throws<InvalidOperationException>(() => resource.Load(null));
+
+            var error = resource.Errors.SingleOrDefault();
+            Assert.That(error, Is.Not.Null);
+            Assert.That(error!.Message, Does.Contain("Bogus"));
+        }
+
+        /// <summary>
+        /// Wraps the supplied classifier markup in a minimal Ecore package whose name matches
+        /// <paramref name="packageName"/>.
+        /// </summary>
+        private static string Package(string packageName, string body)
+        {
+            return
+                "<?xml version=\"1.0\" encoding=\"UTF-8\"?>\r\n" +
+                "<ecore:EPackage xmi:version=\"2.0\" xmlns:xmi=\"http://www.omg.org/XMI\" " +
+                "xmlns:xsi=\"http://www.w3.org/2001/XMLSchema-instance\" " +
+                "xmlns:ecore=\"http://www.eclipse.org/emf/2002/Ecore\" " +
+                $"name=\"{packageName}\" nsURI=\"{packageName}\" nsPrefix=\"{packageName}\">\r\n" +
+                $"  {body}\r\n" +
+                "</ecore:EPackage>";
+        }
+
+        /// <summary>
+        /// Writes the provided <paramref name="content"/> to a file in the test directory and
+        /// creates a <see cref="Resource"/> for it.
+        /// </summary>
+        private Resource CreateResourceForContent(string fileName, string content)
+        {
+            var path = Path.Combine(TestContext.CurrentContext.TestDirectory, fileName);
+            File.WriteAllText(path, content);
+
+            var uri = new Uri(Path.GetFullPath(path));
+
+            return this.resourceSet.CreateResource(uri);
+        }
+    }
+}

--- a/ECoreNetto/ModelElement/EObject.cs
+++ b/ECoreNetto/ModelElement/EObject.cs
@@ -356,7 +356,65 @@ namespace ECoreNetto
                 this.Attributes.Add(readerAttribute.Name, attributeValue);
             }
         }
-        
+
+        /// <summary>
+        /// Parses the value of a boolean attribute, recording an error <see cref="Resource.Diagnostic"/> and
+        /// throwing when the value is malformed.
+        /// </summary>
+        /// <param name="attributeName">
+        /// The name of the attribute being parsed; used in the diagnostic message.
+        /// </param>
+        /// <param name="rawValue">
+        /// The raw attribute value to parse.
+        /// </param>
+        /// <returns>
+        /// The parsed <see cref="bool"/> value.
+        /// </returns>
+        /// <exception cref="FormatException">
+        /// Thrown when <paramref name="rawValue"/> is not a valid boolean. The issue is recorded in
+        /// <see cref="Resource.Resource.Errors"/> before the load is aborted.
+        /// </exception>
+        protected bool ParseBoolean(string attributeName, string rawValue)
+        {
+            if (bool.TryParse(rawValue, out var value))
+            {
+                return value;
+            }
+
+            var message = $"The '{attributeName}' attribute of '{this.Identifier}' has a malformed boolean value '{rawValue}'.";
+            this.EResource.AddError(message);
+            throw new FormatException(message);
+        }
+
+        /// <summary>
+        /// Parses the value of an integer attribute, recording an error <see cref="Resource.Diagnostic"/> and
+        /// throwing when the value is malformed.
+        /// </summary>
+        /// <param name="attributeName">
+        /// The name of the attribute being parsed; used in the diagnostic message.
+        /// </param>
+        /// <param name="rawValue">
+        /// The raw attribute value to parse.
+        /// </param>
+        /// <returns>
+        /// The parsed <see cref="int"/> value.
+        /// </returns>
+        /// <exception cref="FormatException">
+        /// Thrown when <paramref name="rawValue"/> is not a valid integer. The issue is recorded in
+        /// <see cref="Resource.Resource.Errors"/> before the load is aborted.
+        /// </exception>
+        protected int ParseInt32(string attributeName, string rawValue)
+        {
+            if (int.TryParse(rawValue, out var value))
+            {
+                return value;
+            }
+
+            var message = $"The '{attributeName}' attribute of '{this.Identifier}' has a malformed integer value '{rawValue}'.";
+            this.EResource.AddError(message);
+            throw new FormatException(message);
+        }
+
         /// <summary>
         /// Instantiate new <see cref="EObject"/> from the current node of the <see cref="XmlReader"/>
         /// </summary>

--- a/ECoreNetto/ModelElement/NamedElement/Classifier/EClass.cs
+++ b/ECoreNetto/ModelElement/NamedElement/Classifier/EClass.cs
@@ -170,12 +170,12 @@ namespace ECoreNetto
 
             if (this.Attributes.TryGetValue(EcoreAbstractKeyword, out var output))
             {
-                this.Abstract = bool.Parse(output);
+                this.Abstract = this.ParseBoolean(EcoreAbstractKeyword, output);
             }
 
             if (this.Attributes.TryGetValue(EcoreInterfaceKeyword, out output))
             {
-                this.Interface = bool.Parse(output);
+                this.Interface = this.ParseBoolean(EcoreInterfaceKeyword, output);
             }
 
             if (this.Attributes.TryGetValue(EcoreSuperTypeKeyword, out output))
@@ -219,7 +219,9 @@ namespace ECoreNetto
                         ecoreAttribute.ReadXml(reader);
                         break;
                     default:
-                        throw new InvalidOperationException($"Type of structural feature not recognized: {ecoreType}");
+                        var featureError = $"Type of structural feature not recognized: {ecoreType}";
+                        this.EResource.AddError(featureError);
+                        throw new InvalidOperationException(featureError);
                 }
             }
 

--- a/ECoreNetto/ModelElement/NamedElement/Classifier/EDataType.cs
+++ b/ECoreNetto/ModelElement/NamedElement/Classifier/EDataType.cs
@@ -70,7 +70,7 @@ namespace ECoreNetto
 
             if (this.Attributes.TryGetValue("serializable", out var output))
             {
-                this.Serializable = bool.Parse(output);
+                this.Serializable = this.ParseBoolean("serializable", output);
             }
         }
     }

--- a/ECoreNetto/ModelElement/NamedElement/EEnumLiteral.cs
+++ b/ECoreNetto/ModelElement/NamedElement/EEnumLiteral.cs
@@ -68,7 +68,7 @@ namespace ECoreNetto
 
             if (this.Attributes.TryGetValue("value", out var output))
             {
-                this.Value = int.Parse(output);
+                this.Value = this.ParseInt32("value", output);
             }
         }
 

--- a/ECoreNetto/ModelElement/NamedElement/EPackage.cs
+++ b/ECoreNetto/ModelElement/NamedElement/EPackage.cs
@@ -183,7 +183,9 @@ namespace ECoreNetto
                     ecoreEnum.ReadXml(reader);
                     break;
                 default:
-                    throw new InvalidOperationException($"Type of classifier not recognized: {ecoreType}");
+                    var classifierError = $"Type of classifier not recognized: {ecoreType}";
+                    this.EResource.AddError(classifierError);
+                    throw new InvalidOperationException(classifierError);
             }
         }
 

--- a/ECoreNetto/ModelElement/NamedElement/ETypedElement.cs
+++ b/ECoreNetto/ModelElement/NamedElement/ETypedElement.cs
@@ -103,32 +103,32 @@ namespace ECoreNetto
 
             if (this.Attributes.TryGetValue("ordered", out var output))
             {
-                this.Ordered = bool.Parse(output);
+                this.Ordered = this.ParseBoolean("ordered", output);
             }
 
             if (this.Attributes.TryGetValue("unique", out output))
             {
-                this.Unique = bool.Parse(output);
+                this.Unique = this.ParseBoolean("unique", output);
             }
 
             if (this.Attributes.TryGetValue("many", out output))
             {
-                this.Many = bool.Parse(output);
+                this.Many = this.ParseBoolean("many", output);
             }
 
             if (this.Attributes.TryGetValue("required", out output))
             {
-                this.Required = bool.Parse(output);
+                this.Required = this.ParseBoolean("required", output);
             }
 
             if (this.Attributes.TryGetValue("lowerBound", out output))
             {
-                this.LowerBound = int.Parse(output);
+                this.LowerBound = this.ParseInt32("lowerBound", output);
             }
 
             if (this.Attributes.TryGetValue("upperBound", out output))
             {
-                this.UpperBound = int.Parse(output);
+                this.UpperBound = this.ParseInt32("upperBound", output);
             }
 
             if (this.Attributes.TryGetValue("eType", out output))

--- a/ECoreNetto/ModelElement/NamedElement/TypedElement/EStructuralFeature.cs
+++ b/ECoreNetto/ModelElement/NamedElement/TypedElement/EStructuralFeature.cs
@@ -135,17 +135,17 @@ namespace ECoreNetto
 
             if (this.Attributes.TryGetValue("changeable", out var output))
             {
-                this.Changeable = bool.Parse(output);
+                this.Changeable = this.ParseBoolean("changeable", output);
             }
             
             if (this.Attributes.TryGetValue("volatile", out output))
             {
-                this.Volatile = bool.Parse(output);
+                this.Volatile = this.ParseBoolean("volatile", output);
             }
 
             if (this.Attributes.TryGetValue("transient", out output))
             {
-                this.Transient = bool.Parse(output);
+                this.Transient = this.ParseBoolean("transient", output);
             }
 
             if (this.Attributes.TryGetValue("defaultValueLiteral", out output))
@@ -155,12 +155,12 @@ namespace ECoreNetto
 
             if (this.Attributes.TryGetValue("unsettable", out output))
             {
-                this.Unsettable = bool.Parse(output);
+                this.Unsettable = this.ParseBoolean("unsettable", output);
             }
 
             if (this.Attributes.TryGetValue("derived", out output))
             {
-                this.Derived = bool.Parse(output);
+                this.Derived = this.ParseBoolean("derived", output);
             }
         }
 

--- a/ECoreNetto/ModelElement/NamedElement/TypedElement/StructuralFeature/EAttribute.cs
+++ b/ECoreNetto/ModelElement/NamedElement/TypedElement/StructuralFeature/EAttribute.cs
@@ -70,7 +70,7 @@ namespace ECoreNetto
 
             if (this.Attributes.TryGetValue("iD", out var output))
             {
-                this.ID = bool.Parse(output);
+                this.ID = this.ParseBoolean("iD", output);
             }
         }
     }

--- a/ECoreNetto/ModelElement/NamedElement/TypedElement/StructuralFeature/EReference.cs
+++ b/ECoreNetto/ModelElement/NamedElement/TypedElement/StructuralFeature/EReference.cs
@@ -103,17 +103,17 @@ namespace ECoreNetto
 
             if (this.Attributes.TryGetValue("container", out var output))
             {
-                this.IsContainer = bool.Parse(output);
+                this.IsContainer = this.ParseBoolean("container", output);
             }
 
             if (this.Attributes.TryGetValue("containment", out output))
             {
-                this.IsContainment = bool.Parse(output);
+                this.IsContainment = this.ParseBoolean("containment", output);
             }
 
             if (this.Attributes.TryGetValue("resolveProxies", out output))
             {
-                this.IsResolveProxies = bool.Parse(output);
+                this.IsResolveProxies = this.ParseBoolean("resolveProxies", output);
             }
 
             if (this.Attributes.TryGetValue("eOpposite", out output))

--- a/ECoreNetto/Resource/Resource.cs
+++ b/ECoreNetto/Resource/Resource.cs
@@ -404,10 +404,25 @@ namespace ECoreNetto.Resource
         }
 
         /// <summary>
+        /// Records an error <see cref="Diagnostic"/> that was encountered while loading the resource.
+        /// </summary>
+        /// <param name="message">
+        /// The translated message describing the issue.
+        /// </param>
+        /// <remarks>
+        /// The diagnostic is exposed through <see cref="Errors"/>. The source location is the URI of this
+        /// resource; line and column are not available once parsing has reached the property-resolution phase.
+        /// </remarks>
+        internal void AddError(string message)
+        {
+            this.errors.Add(new Diagnostic(0, 0, this.URI?.AbsoluteUri ?? string.Empty, message));
+        }
+
+        /// <summary>
         /// Gets an <see cref="IEnumerable{String}"/> of the errors in the resource;
         /// </summary>
         /// <remarks>
-        /// These will typically be produced as the resource is loaded. 
+        /// These will typically be produced as the resource is loaded.
         /// </remarks>
         public IEnumerable<Diagnostic> Errors => this.errors;
         


### PR DESCRIPTION
@
## Summary

Closes #35.

`Resource` exposed `Errors`/`Warnings` (`IEnumerable<Diagnostic>`), but nothing ever wrote to them — parse problems were invisible to callers or silently aborted the load with a bare exception. This change populates `Resource.Errors` with a structured `Diagnostic` (carrying a source location) whenever the parser hits fatal input, before aborting.

Per the design decision on the issue, **malformed/unrecognized input remains fatal and aborts the load** — this does not recover with defaults. The benefit is that a caller catching the exception can now inspect `Resource.Errors` for a structured, located diagnostic.

## Changes

- **`Resource.cs`** — add internal `AddError(message)` that appends a `Diagnostic` (location = resource URI) to the existing backing list.
- **`EObject.cs`** — add protected `ParseBoolean`/`ParseInt32` helpers that, on malformed input, record an error Diagnostic and throw `FormatException`.
- Route the ~19 `bool.Parse`/`int.Parse` call sites through these helpers (`EClass`, `EDataType`, `EEnumLiteral`, `ETypedElement`, `EStructuralFeature`, `EAttribute`, `EReference`).
- Record an error at the unknown-`xsi:type` throw sites in `EPackage` (classifier) and `EClass` (structural feature) before throwing `InvalidOperationException`.

## Tests

New `DiagnosticsTestFixture` asserts that, for each failure case, `Load` throws **and** `Resource.Errors` contains the matching diagnostic: malformed boolean, malformed integer, unknown classifier type, unknown structural-feature type, plus a `Diagnostic.Location` check.

## Verification

- `dotnet build EcoreNetto.sln` — 0 warnings.
- `dotnet test EcoreNetto.sln` — green (182 tests).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
@