### PR TITLE
[Feature] Consolidate duplicated ResourceLoader into shared Reporting implementation; fixes #44

### DIFF
--- a/ECoreNetto.Reporting/Generators/HandleBarsReportGenerator.cs
+++ b/ECoreNetto.Reporting/Generators/HandleBarsReportGenerator.cs
@@ -91,7 +91,7 @@ namespace ECoreNetto.Reporting.Generators
         {
             var templatePath = $"ECoreNetto.Reporting.Templates.{name}.hbs";
 
-            var template = ResourceLoader.LoadEmbeddedResource(templatePath);
+            var template = ResourceLoader.LoadEmbeddedResource(typeof(HandleBarsReportGenerator).Assembly, templatePath);
 
             var compiledTemplate = Handlebars.Compile(template);
 

--- a/ECoreNetto.Reporting/Resources/ResourceLoader.cs
+++ b/ECoreNetto.Reporting/Resources/ResourceLoader.cs
@@ -27,21 +27,22 @@ namespace ECoreNetto.Reporting.Resources
     /// <summary>
     /// Class responsible for loading embedded resources.
     /// </summary>
-    internal static class ResourceLoader
+    public static class ResourceLoader
     {
         /// <summary>
-        /// Load an embedded resource
+        /// Load an embedded resource from the provided <see cref="Assembly"/>
         /// </summary>
+        /// <param name="assembly">
+        /// The <see cref="Assembly"/> whose manifest contains the embedded resource
+        /// </param>
         /// <param name="path">
         /// The path of the embedded resource
         /// </param>
         /// <returns>
         /// a string containing the contents of the embedded resource
         /// </returns>
-        public static string LoadEmbeddedResource(string path)
+        public static string LoadEmbeddedResource(Assembly assembly, string path)
         {
-            var assembly = Assembly.GetExecutingAssembly();
-
             using var stream = assembly.GetManifestResourceStream(path);
 
             using var reader = new StreamReader(stream ?? throw new MissingManifestResourceException());

--- a/ECoreNetto.Tools/Resources/ResourceLoader.cs
+++ b/ECoreNetto.Tools/Resources/ResourceLoader.cs
@@ -20,17 +20,18 @@
 
 namespace ECoreNetto.Tools.Resources
 {
-    using System.IO;
     using System.Reflection;
-    using System.Resources;
+
+    using SharedResourceLoader = ECoreNetto.Reporting.Resources.ResourceLoader;
 
     /// <summary>
-    /// Class responsible for loading embedded resources.
+    /// Class responsible for loading embedded resources from this assembly and for the
+    /// Tools-specific version and logo queries.
     /// </summary>
     public static class ResourceLoader
     {
         /// <summary>
-        /// Load an embedded resource
+        /// Load an embedded resource from the executing (ECoreNetto.Tools) assembly
         /// </summary>
         /// <param name="path">
         /// The path of the embedded resource
@@ -40,13 +41,7 @@ namespace ECoreNetto.Tools.Resources
         /// </returns>
         public static string LoadEmbeddedResource(string path)
         {
-            var assembly = Assembly.GetExecutingAssembly();
-
-            using var stream = assembly.GetManifestResourceStream(path);
-
-            using var reader = new StreamReader(stream ?? throw new MissingManifestResourceException());
-
-            return reader.ReadToEnd();
+            return SharedResourceLoader.LoadEmbeddedResource(Assembly.GetExecutingAssembly(), path);
         }
 
         /// <summary>


### PR DESCRIPTION
@
Factors the duplicated embedded-resource loading logic out of `ECoreNetto.Tools` and `ECoreNetto.Reporting` into a single shared implementation.

## Changes
- **`ECoreNetto.Reporting/Resources/ResourceLoader.cs`** — now the single source of truth. Made `public` and changed the signature to `LoadEmbeddedResource(Assembly assembly, string path)`. The `Assembly` is passed in explicitly so callers in other assemblies resolve resources from their own manifest (the reason the logic could not simply be shared as-is: `Assembly.GetExecutingAssembly()` would always return the Reporting assembly).
- **`ECoreNetto.Reporting/Generators/HandleBarsReportGenerator.cs`** — the single caller now passes `typeof(HandleBarsReportGenerator).Assembly`, where the `.hbs` templates are embedded.
- **`ECoreNetto.Tools/Resources/ResourceLoader.cs`** — removed the duplicated loading logic; `LoadEmbeddedResource(string)` now delegates to the shared loader, binding the Tools assembly. The Tools-specific `QueryVersion`/`QueryLogo` helpers stay put.

## Acceptance criteria
- [x] Shared loading logic is not duplicated — one implementation in `ECoreNetto.Reporting`; project-specific helpers kept separate.

## Verification
Solution builds clean (0 warnings/0 errors); the 4 `ResourceLoaderTestFixture` tests and all 23 Reporting tests pass. Public Tools API (`LoadEmbeddedResource(string)`, `QueryVersion`, `QueryLogo`) is preserved, so no test changes were needed.

Closes #44
@