### PR TITLE
[Docs] add core-library getting-started example to README; fixes #54

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,6 +8,42 @@ ECoreNetto is a suite of dotnet core libraries and tools that are used to deseri
 
 The core library used to deserialize an ecore file and create an in memory ECore model object graph.
 
+### Getting Started
+
+The following snippet shows how to load an `.ecore` file with the core **ECoreNetto** library, obtain the root `EPackage` and walk the model. A `ResourceSet` demand-loads the `.ecore` file (and any cross-referenced models) and `Resource.Load(...)` returns the root `EPackage`.
+
+```csharp
+using System;
+using ECoreNetto;
+using ECoreNetto.Resource;
+
+// point the ResourceSet at the .ecore file to deserialize
+var uri = new Uri(@"C:\path\to\model.ecore");
+
+var resourceSet = new ResourceSet();
+var resource = resourceSet.CreateResource(uri);
+
+// Resource.Load returns the root EPackage of the model
+EPackage rootPackage = resource.Load(null);
+
+Console.WriteLine($"package: {rootPackage.Name}");
+
+// iterate over the classifiers (EClass, EDataType, EEnum, ...) in the package
+foreach (var classifier in rootPackage.EClassifiers)
+{
+    Console.WriteLine($"  {classifier.GetType().Name}: {classifier.Name}");
+
+    // for classes, inspect their structural features (attributes and references)
+    if (classifier is EClass eClass)
+    {
+        foreach (var structuralFeature in eClass.EStructuralFeatures)
+        {
+            Console.WriteLine($"    - {structuralFeature.Name} : {structuralFeature.EType?.Name}");
+        }
+    }
+}
+```
+
 ## ECoreNetto.Extensions
 
 The **ECoreNetto.Extensions** library provides extensions methods to the EcoreNetto library to support code generation. This library is part of the EcoreNetto ecosystem.


### PR DESCRIPTION
Adds a `Getting Started` section to `README.md` with a compiling core-library snippet: it loads an `.ecore` file via `ResourceSet`/`Resource.Load(...)`, obtains the root `EPackage`, and iterates the classifiers and their structural features. The snippet was verified to compile against `ECoreNetto`. Documentation only.

Fixes #54.