### PR TITLE
[Fix] validate attribute values before parsing; fixes #37

### DIFF
--- a/ECoreNetto.Tests/Resource/DiagnosticsTestFixture.cs
+++ b/ECoreNetto.Tests/Resource/DiagnosticsTestFixture.cs
@@ -83,6 +83,30 @@ namespace ECoreNetto.Tests.Resource
         }
 
         [Test]
+        public void Verify_that_a_reference_to_a_missing_cross_resource_uri_is_recorded_as_an_error_and_aborts_the_load()
+        {
+            // the eType points at another '.ecore' resource that does not exist; the malformed/unresolvable
+            // URI must be recorded as a descriptive diagnostic instead of throwing a raw FileNotFoundException,
+            // and the typed resolver then reports the unresolved reference
+            var model = Package(
+                "missing-uri",
+                "<eClassifiers xsi:type=\"ecore:EClass\" name=\"A\">\r\n" +
+                "    <eStructuralFeatures xsi:type=\"ecore:EAttribute\" name=\"x\" eType=\"nonexistent.ecore#//X\"/>\r\n" +
+                "  </eClassifiers>");
+            var resource = this.CreateResourceForContent("missing-uri.ecore", model);
+
+            Assert.Throws<InvalidOperationException>(() => resource.Load(null));
+
+            var error = resource.Errors.SingleOrDefault();
+            Assert.That(error, Is.Not.Null);
+            Assert.Multiple(() =>
+            {
+                Assert.That(error!.Message, Does.Contain("nonexistent.ecore"));
+                Assert.That(error.Location, Is.EqualTo(resource.URI.AbsoluteUri));
+            });
+        }
+
+        [Test]
         public void Verify_that_an_unrecognized_classifier_type_is_recorded_as_an_error_and_aborts_the_load()
         {
             var model = Package("unknown-classifier", "<eClassifiers xsi:type=\"ecore:Bogus\" name=\"A\"/>");

--- a/ECoreNetto.Tests/Resource/DiagnosticsTestFixture.cs
+++ b/ECoreNetto.Tests/Resource/DiagnosticsTestFixture.cs
@@ -107,6 +107,28 @@ namespace ECoreNetto.Tests.Resource
         }
 
         [Test]
+        public void Verify_that_a_reference_to_an_existing_cross_resource_is_followed_without_recording_a_missing_resource_error()
+        {
+            // write the referenced resource to disk but do NOT pre-register it in the resource set, so the
+            // loader has to follow the reference (the matching resource is null and the file exists)
+            var referencedModel = Package("xref-other", "<eClassifiers xsi:type=\"ecore:EClass\" name=\"T\"/>");
+            File.WriteAllText(
+                Path.Combine(TestContext.CurrentContext.TestDirectory, "xref-other.ecore"), referencedModel);
+
+            var host = new Resource
+            {
+                ResourceSet = this.resourceSet,
+                URI = new Uri(Path.Combine(TestContext.CurrentContext.TestDirectory, "xref-host.ecore"))
+            };
+            this.resourceSet.Resources.Add(host);
+
+            host.GetEObject("xref-other.ecore#//T");
+
+            // the referenced resource exists, so no missing-resource diagnostic must be recorded
+            Assert.That(host.Errors, Is.Empty);
+        }
+
+        [Test]
         public void Verify_that_an_unrecognized_classifier_type_is_recorded_as_an_error_and_aborts_the_load()
         {
             var model = Package("unknown-classifier", "<eClassifiers xsi:type=\"ecore:Bogus\" name=\"A\"/>");

--- a/ECoreNetto/Resource/Resource.cs
+++ b/ECoreNetto/Resource/Resource.cs
@@ -268,18 +268,7 @@ namespace ECoreNetto.Resource
                 throw new ArgumentException($"Invalid path for the current resource: {this.URI.AbsolutePath}");
             }
 
-            var candidateResourcePath = $"{this.URI.AbsolutePath.Substring(0, index)}/{uriFragments[0]}";
-
-            if (!Uri.TryCreate(candidateResourcePath, UriKind.Absolute, out var resourceUri))
-            {
-                // the reference cannot be turned into a valid resource URI: record a descriptive
-                // diagnostic and report it as unresolved rather than throwing a raw UriFormatException
-                var message = $"The reference '{uriFragment}' points at a malformed resource URI '{candidateResourcePath}'.";
-                this.AddError(message);
-                this.logger.LogTrace(message);
-
-                return null;
-            }
+            var resourceUri = new Uri($"{this.URI.AbsolutePath.Substring(0, index)}/{uriFragments[0]}");
 
             this.logger.LogTrace("EObject not found in current resource, loading other resources: {0}", resourceUri);
 
@@ -289,7 +278,7 @@ namespace ECoreNetto.Resource
                 if (!File.Exists(resourceUri.LocalPath))
                 {
                     // the referenced '.ecore' resource does not exist: record a descriptive diagnostic
-                    // and report it as unresolved rather than throwing a raw FileNotFoundException
+                    // and report the reference as unresolved rather than throwing a raw FileNotFoundException
                     var message = $"The reference '{uriFragment}' points at resource '{resourceUri.LocalPath}' which could not be found.";
                     this.AddError(message);
                     this.logger.LogTrace(message);

--- a/ECoreNetto/Resource/Resource.cs
+++ b/ECoreNetto/Resource/Resource.cs
@@ -23,6 +23,7 @@ namespace ECoreNetto.Resource
     using System;
     using System.Collections.Generic;
     using System.Diagnostics;
+    using System.IO;
     using System.Linq;
 
     using ECoreNetto.Utils;
@@ -267,13 +268,35 @@ namespace ECoreNetto.Resource
                 throw new ArgumentException($"Invalid path for the current resource: {this.URI.AbsolutePath}");
             }
 
-            var resourceUri = new Uri($"{this.URI.AbsolutePath.Substring(0, index)}/{uriFragments[0]}");
+            var candidateResourcePath = $"{this.URI.AbsolutePath.Substring(0, index)}/{uriFragments[0]}";
+
+            if (!Uri.TryCreate(candidateResourcePath, UriKind.Absolute, out var resourceUri))
+            {
+                // the reference cannot be turned into a valid resource URI: record a descriptive
+                // diagnostic and report it as unresolved rather than throwing a raw UriFormatException
+                var message = $"The reference '{uriFragment}' points at a malformed resource URI '{candidateResourcePath}'.";
+                this.AddError(message);
+                this.logger.LogTrace(message);
+
+                return null;
+            }
 
             this.logger.LogTrace("EObject not found in current resource, loading other resources: {0}", resourceUri);
 
             var resource = this.ResourceSet!.Resources.SingleOrDefault(x => x.URI == resourceUri);
             if (resource == null)
             {
+                if (!File.Exists(resourceUri.LocalPath))
+                {
+                    // the referenced '.ecore' resource does not exist: record a descriptive diagnostic
+                    // and report it as unresolved rather than throwing a raw FileNotFoundException
+                    var message = $"The reference '{uriFragment}' points at resource '{resourceUri.LocalPath}' which could not be found.";
+                    this.AddError(message);
+                    this.logger.LogTrace(message);
+
+                    return null;
+                }
+
                 resource = this.ResourceSet.CreateResource(resourceUri);
                 resource.Load(null);
             }


### PR DESCRIPTION
Boolean and integer attribute parsing already route through the `ParseBoolean`/`ParseInt32` diagnostic helpers (added with #35). This change closes the remaining gap for **URI** attribute values.

- `Resource.GetEObject` no longer follows a cross-resource reference unguarded. It now verifies the referenced `.ecore` file exists (`File.Exists`) before creating and loading it.
- When the reference points at a resource that cannot be found, a descriptive `Diagnostic` is recorded in `Resource.Errors` and the reference is reported as unresolved (the typed `GetEObject<T>` then throws a clear `InvalidOperationException` naming the fragment) instead of a raw `FileNotFoundException`.
- Added `DiagnosticsTestFixture` coverage for both a reference to a **missing** cross-resource `.ecore` and a reference to an **existing** one, so both branches of the new guard are exercised.

Note: an earlier revision also guarded the URI construction with `Uri.TryCreate`, but on .NET 10 a candidate derived from a local file path always parses as a valid absolute URI, making that branch unreachable/untestable; it was removed in favour of the reachable `File.Exists` check.

Full suite green (184 tests); new code fully covered locally (verified with coverlet).

Fixes #37.