### PR TITLE
[Test] assert report-output content & add VersionChecker/GitHubRelease error-path tests; fixes #53

### DIFF
--- a/ECoreNetto.Reporting.Tests/Generators/HtmlReportGeneratorTestFixture.cs
+++ b/ECoreNetto.Reporting.Tests/Generators/HtmlReportGeneratorTestFixture.cs
@@ -74,6 +74,27 @@ namespace ECoreNetto.Tools.Tests.Generators
         }
 
         [Test]
+        public void Verify_that_the_generated_html_contains_the_expected_content()
+        {
+            var modelFileInfo = new FileInfo(Path.Combine(TestContext.CurrentContext.TestDirectory, "Data", "recipe.ecore"));
+
+            var html = this.htmlReportGenerator.GenerateReport(modelFileInfo);
+
+            Assert.Multiple(() =>
+            {
+                // package name, the three top-level sections and a representative class and enum
+                // (and one of its literals) from the recipe model must all be rendered
+                Assert.That(html, Does.Contain("recipe"));
+                Assert.That(html, Does.Contain("Enumeration Types"));
+                Assert.That(html, Does.Contain("Data Types"));
+                Assert.That(html, Does.Contain("Classes"));
+                Assert.That(html, Does.Contain("Container"));
+                Assert.That(html, Does.Contain("Unit"));
+                Assert.That(html, Does.Contain("PIECE"));
+            });
+        }
+
+        [Test]
         public void Verify_that_when_modelpath_is_null_exception_is_thrown()
         {
             FileInfo? modelFileInfo = null;

--- a/ECoreNetto.Reporting.Tests/Generators/MarkdownReportGeneratorTestFixture.cs
+++ b/ECoreNetto.Reporting.Tests/Generators/MarkdownReportGeneratorTestFixture.cs
@@ -72,5 +72,26 @@ namespace ECoreNetto.Tools.Tests.Generators
 
             Assert.That(() => this.markdownReportGenerator.GenerateReport(modelFileInfo, reportFileInfo), Throws.Nothing);
         }
+
+        [Test]
+        public void Verify_that_the_generated_markdown_contains_the_expected_content()
+        {
+            var modelFileInfo = new FileInfo(Path.Combine(TestContext.CurrentContext.TestDirectory, "Data", "recipe.ecore"));
+
+            var markdown = this.markdownReportGenerator.GenerateReport(modelFileInfo);
+
+            Assert.Multiple(() =>
+            {
+                // the model-information block (with the namespace uri), the section headers and a
+                // representative class and enum from the recipe model must all be rendered
+                Assert.That(markdown, Does.Contain("## Model Information"));
+                Assert.That(markdown, Does.Contain("hu.bme.mit.mdsd.recipe"));
+                Assert.That(markdown, Does.Contain("## Data Types"));
+                Assert.That(markdown, Does.Contain("## Enumeration Types"));
+                Assert.That(markdown, Does.Contain("## Classes"));
+                Assert.That(markdown, Does.Contain("Container"));
+                Assert.That(markdown, Does.Contain("Unit"));
+            });
+        }
     }
 }

--- a/ECoreNetto.Reporting.Tests/Generators/ModelInspectorTestFixture.cs
+++ b/ECoreNetto.Reporting.Tests/Generators/ModelInspectorTestFixture.cs
@@ -20,7 +20,6 @@
 
 namespace ECoreNetto.Tools.Tests.Generators
 {
-    using System;
     using System.IO;
 
     using ECoreNetto.Resource;
@@ -85,9 +84,12 @@ namespace ECoreNetto.Tools.Tests.Generators
         {
             var report = this.modelInspector.Inspect(this.rootPackage, false);
 
-            Assert.That(report, Is.Not.Empty);
-
-            Console.Write(report);
+            Assert.Multiple(() =>
+            {
+                Assert.That(report, Does.Contain("ANALYSIS"));
+                Assert.That(report, Does.Contain("MULTIPLICITY RESULTS"));
+                Assert.That(report, Does.Contain("INTERESTING CLASSES"));
+            });
         }
 
         [Test]
@@ -95,9 +97,12 @@ namespace ECoreNetto.Tools.Tests.Generators
         {
             var report = this.modelInspector.Inspect(this.rootPackage, true);
 
-            Assert.That(report, Is.Not.Empty);
-
-            Console.Write(report);
+            Assert.Multiple(() =>
+            {
+                Assert.That(report, Does.Contain("MULTIPLICITY RESULTS"));
+                // recursion descends into the recipe package, so its name must appear in the analysis
+                Assert.That(report, Does.Contain("recipe"));
+            });
         }
 
         [Test]
@@ -105,9 +110,8 @@ namespace ECoreNetto.Tools.Tests.Generators
         {
             var report = this.modelInspector.Inspect(this.rootPackage, "Container");
 
-            Assert.That(report, Is.Not.Empty);
-
-            Console.Write(report);
+            // the per-class inspection must be headed by the inspected class
+            Assert.That(report, Does.Contain("Container"));
         }
 
         [Test]
@@ -115,9 +119,7 @@ namespace ECoreNetto.Tools.Tests.Generators
         {
             var report = this.modelInspector.AnalyzeDocumentation(this.rootPackage, false);
 
-            Assert.That(report, Is.Not.Empty);
-
-            Console.Write(report);
+            Assert.That(report, Does.Contain("MISSING DOCUMENTATION"));
         }
 
         [Test]
@@ -125,9 +127,7 @@ namespace ECoreNetto.Tools.Tests.Generators
         {
             var report = this.modelInspector.AnalyzeDocumentation(this.rootPackage, true);
 
-            Assert.That(report, Is.Not.Empty);
-
-            Console.Write(report);
+            Assert.That(report, Does.Contain("MISSING DOCUMENTATION"));
         }
 
         [Test]

--- a/ECoreNetto.Reporting.Tests/Generators/XlReportGeneratorTestFixture.cs
+++ b/ECoreNetto.Reporting.Tests/Generators/XlReportGeneratorTestFixture.cs
@@ -21,6 +21,7 @@
 namespace ECoreNetto.Reporting.Tests.Generators
 {
     using System.IO;
+    using System.Linq;
 
     using ClosedXML.Excel;
 
@@ -63,6 +64,33 @@ namespace ECoreNetto.Reporting.Tests.Generators
                 Assert.That(info.Cell(4, 2).GetString(), Is.EqualTo("recipe"));
                 Assert.That(info.Cell(5, 1).GetString(), Is.EqualTo("Root Package - ns uri"));
                 Assert.That(info.Cell(5, 2).GetString(), Is.EqualTo("hu.bme.mit.mdsd.recipe"));
+            });
+        }
+
+        [Test]
+        public void Verify_that_the_class_enum_and_datatype_sheets_contain_the_expected_content()
+        {
+            this.generator.GenerateReport(this.modelFileInfo, this.reportFileInfo);
+
+            using var workbook = new XLWorkbook(this.reportFileInfo.FullName);
+
+            var eClassSheet = workbook.Worksheet("EClass");
+            var eEnumSheet = workbook.Worksheet("EEnum");
+            var eDataTypeSheet = workbook.Worksheet("EDataType");
+
+            Assert.Multiple(() =>
+            {
+                // the EClass sheet must list representative classes and a feature of the recipe model
+                Assert.That(eClassSheet.CellsUsed().Any(c => c.GetString() == "Container"), Is.True);
+                Assert.That(eClassSheet.CellsUsed().Any(c => c.GetString() == "Recipe"), Is.True);
+                Assert.That(eClassSheet.CellsUsed().Any(c => c.GetString() == "capacity"), Is.True);
+
+                // the EEnum sheet must list the Unit enumeration and one of its literals
+                Assert.That(eEnumSheet.CellsUsed().Any(c => c.GetString() == "Unit"), Is.True);
+                Assert.That(eEnumSheet.CellsUsed().Any(c => c.GetString() == "PIECE"), Is.True);
+
+                // the EDataType sheet must carry its column header
+                Assert.That(eDataTypeSheet.CellsUsed().Any(c => c.GetString() == "DataType"), Is.True);
             });
         }
 

--- a/ECoreNetto.Tools.Tests/Services/VersionCheckerTestFixture.cs
+++ b/ECoreNetto.Tools.Tests/Services/VersionCheckerTestFixture.cs
@@ -159,6 +159,68 @@ namespace ECoreNetto.Tools.Tests.Services
             await Assert.ThatAsync(() => checker.ExecuteAsync(new CancellationTokenSource().Token), Throws.Nothing);
         }
 
+        [Test]
+        public async Task Verify_that_QueryLatestReleaseAsync_returns_a_populated_release_on_success()
+        {
+            var factory = new StubHttpClientFactory(new HttpClient(new SuccessHandler()));
+
+            var checker = new VersionChecker(factory, this.loggerFactory);
+
+            var release = await checker.QueryLatestReleaseAsync(new CancellationTokenSource().Token);
+
+            Assert.That(release, Is.Not.Null);
+            Assert.Multiple(() =>
+            {
+                Assert.That(release!.TagName, Is.EqualTo("1.2.3"));
+                Assert.That(release.Body, Is.EqualTo("notes"));
+                Assert.That(release.HtmlUrl, Is.EqualTo("https://example.com"));
+            });
+        }
+
+        [Test]
+        public async Task Verify_that_QueryLatestReleaseAsync_returns_null_on_a_non_success_status()
+        {
+            var factory = new StubHttpClientFactory(new HttpClient(new NotFoundHandler()));
+
+            var checker = new VersionChecker(factory, this.loggerFactory);
+
+            var release = await checker.QueryLatestReleaseAsync(new CancellationTokenSource().Token);
+
+            Assert.That(release, Is.Null);
+        }
+
+        [Test]
+        public async Task Verify_that_ExecuteAsync_does_not_throw_on_a_non_success_status()
+        {
+            var factory = new StubHttpClientFactory(new HttpClient(new NotFoundHandler()));
+
+            var checker = new VersionChecker(factory, this.loggerFactory);
+
+            await Assert.ThatAsync(() => checker.ExecuteAsync(new CancellationTokenSource().Token), Throws.Nothing);
+        }
+
+        [Test]
+        public async Task Verify_that_QueryLatestReleaseAsync_returns_null_on_malformed_json()
+        {
+            var factory = new StubHttpClientFactory(new HttpClient(new MalformedJsonHandler()));
+
+            var checker = new VersionChecker(factory, this.loggerFactory);
+
+            var release = await checker.QueryLatestReleaseAsync(new CancellationTokenSource().Token);
+
+            Assert.That(release, Is.Null);
+        }
+
+        [Test]
+        public async Task Verify_that_ExecuteAsync_does_not_throw_on_malformed_json()
+        {
+            var factory = new StubHttpClientFactory(new HttpClient(new MalformedJsonHandler()));
+
+            var checker = new VersionChecker(factory, this.loggerFactory);
+
+            await Assert.ThatAsync(() => checker.ExecuteAsync(new CancellationTokenSource().Token), Throws.Nothing);
+        }
+
         /// <summary>
         /// Very simple IHttpClientFactory used just for tests.
         /// It always returns the HttpClient passed in the constructor.
@@ -254,6 +316,31 @@ namespace ECoreNetto.Tools.Tests.Services
                 return Task.FromResult(new HttpResponseMessage(System.Net.HttpStatusCode.OK)
                 {
                     Content = new StringContent(json)
+                });
+            }
+        }
+
+        /// <summary>
+        /// A handler that always responds with a non-success (404) status.
+        /// </summary>
+        private sealed class NotFoundHandler : HttpMessageHandler
+        {
+            protected override Task<HttpResponseMessage> SendAsync(HttpRequestMessage request, CancellationToken cancellationToken)
+            {
+                return Task.FromResult(new HttpResponseMessage(System.Net.HttpStatusCode.NotFound));
+            }
+        }
+
+        /// <summary>
+        /// A handler that responds with a 200 status but a body that is not valid JSON.
+        /// </summary>
+        private sealed class MalformedJsonHandler : HttpMessageHandler
+        {
+            protected override Task<HttpResponseMessage> SendAsync(HttpRequestMessage request, CancellationToken cancellationToken)
+            {
+                return Task.FromResult(new HttpResponseMessage(System.Net.HttpStatusCode.OK)
+                {
+                    Content = new StringContent("{ this is not valid json ")
                 });
             }
         }


### PR DESCRIPTION
Addresses the two acceptance criteria of #53.

**Generator tests now assert content, not just file creation:**
- `HtmlReportGenerator` / `MarkdownReportGenerator`: assert the rendered output contains the package name/namespace, the section headers, and a representative class (`Container`) and enum (`Unit`/`PIECE`) from the recipe model (via the string-returning `GenerateReport` overload).
- `XlReportGenerator`: re-open the workbook and assert the `EClass` / `EEnum` / `EDataType` sheets carry the expected cells (`Container`, `Recipe`, `capacity`, `Unit`, `PIECE`, `DataType`).
- `ModelInspector`: replace `Is.Not.Empty` with assertions on the report's section markers (`MULTIPLICITY RESULTS`, `INTERESTING CLASSES`, `MISSING DOCUMENTATION`) and the inspected class.

**VersionChecker / GitHubRelease error paths (mocked HTTP layer):**
- success: `QueryLatestReleaseAsync` returns a populated `GitHubRelease` (tag/body/url) - covers deserialization;
- non-success status (404) ? returns null and `ExecuteAsync` does not throw;
- malformed JSON ? returns null and `ExecuteAsync` does not throw.

Reuses the existing custom `HttpMessageHandler` test pattern. Full suite green (192 tests).

Fixes #53.