### PR TITLE
[Feature] implement Resource.GetURIFragment(EObject); fixes #76

### DIFF
--- a/ECoreNetto.Tests/Resource/GetUriFragmentTestFixture.cs
+++ b/ECoreNetto.Tests/Resource/GetUriFragmentTestFixture.cs
@@ -1,0 +1,119 @@
+// -------------------------------------------------------------------------------------------------
+// <copyright file="GetUriFragmentTestFixture.cs" company="Starion Group S.A.">
+//
+//   Copyright 2017-2025 Starion Group S.A.
+//
+//   Licensed under the Apache License, Version 2.0 (the "License");
+//   you may not use this file except in compliance with the License.
+//   You may obtain a copy of the License at
+//
+//       http://www.apache.org/licenses/LICENSE-2.0
+//
+//   Unless required by applicable law or agreed to in writing, software
+//   distributed under the License is distributed on an "AS IS" BASIS,
+//   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+//   See the License for the specific language governing permissions and
+//   limitations under the License.
+//
+// </copyright>
+// ------------------------------------------------------------------------------------------------
+
+namespace ECoreNetto.Tests.Resource
+{
+    using System;
+    using System.IO;
+    using System.Linq;
+
+    using ECoreNetto.Resource;
+
+    using NUnit.Framework;
+
+    /// <summary>
+    /// Suite of tests that verify <see cref="Resource.GetURIFragment"/> is the inverse of
+    /// <see cref="Resource.GetEObject(string)"/> and is appropriately guarded (see issue #76).
+    /// </summary>
+    [TestFixture]
+    public class GetUriFragmentTestFixture
+    {
+        private ResourceSet resourceSet = null!;
+
+        private Resource resource = null!;
+
+        private EPackage rootPackage = null!;
+
+        [SetUp]
+        public void SetUp()
+        {
+            var path = Path.Combine(TestContext.CurrentContext.TestDirectory, "Data", "recipe.ecore");
+            var uri = new Uri(Path.GetFullPath(path));
+
+            this.resourceSet = new ResourceSet();
+            this.resource = this.resourceSet.CreateResource(uri);
+            this.rootPackage = this.resource.Load(null);
+        }
+
+        [Test]
+        public void Verify_that_the_root_package_round_trips()
+        {
+            var fragment = this.resource.GetURIFragment(this.rootPackage);
+
+            Assert.That(this.resource.GetEObject(fragment), Is.SameAs(this.rootPackage));
+        }
+
+        [Test]
+        public void Verify_that_a_class_round_trips()
+        {
+            var eClass = this.rootPackage.EClassifiers.OfType<EClass>().First();
+
+            var fragment = this.resource.GetURIFragment(eClass);
+
+            Assert.Multiple(() =>
+            {
+                Assert.That(fragment, Is.EqualTo(eClass.Identifier));
+                Assert.That(this.resource.GetEObject(fragment), Is.SameAs(eClass));
+            });
+        }
+
+        [Test]
+        public void Verify_that_a_structural_feature_round_trips()
+        {
+            var feature = this.rootPackage.EClassifiers
+                .OfType<EClass>()
+                .SelectMany(eClass => eClass.EStructuralFeatures)
+                .First();
+
+            var fragment = this.resource.GetURIFragment(feature);
+
+            Assert.That(this.resource.GetEObject(fragment), Is.SameAs(feature));
+        }
+
+        [Test]
+        public void Verify_that_an_enum_literal_round_trips()
+        {
+            // the recipe model defines the 'Unit' enumeration with a 'PIECE' literal
+            var literal = this.resource.GetEObject("recipe.ecore#//Unit/PIECE");
+            Assert.That(literal, Is.Not.Null);
+
+            var fragment = this.resource.GetURIFragment(literal!);
+
+            Assert.That(this.resource.GetEObject(fragment), Is.SameAs(literal));
+        }
+
+        [Test]
+        public void Verify_that_a_null_object_throws()
+        {
+            Assert.That(() => this.resource.GetURIFragment(null!), Throws.ArgumentNullException);
+        }
+
+        [Test]
+        public void Verify_that_an_object_not_contained_in_the_resource_throws()
+        {
+            var eClass = this.rootPackage.EClassifiers.OfType<EClass>().First();
+
+            // a different resource does not contain the object, so a fragment cannot be produced
+            var otherResource = new Resource();
+
+            Assert.That(() => otherResource.GetURIFragment(eClass), Throws.TypeOf<InvalidOperationException>());
+        }
+    }
+}

--- a/ECoreNetto/Resource/Resource.cs
+++ b/ECoreNetto/Resource/Resource.cs
@@ -201,7 +201,7 @@ namespace ECoreNetto.Resource
         }
 
         /// <summary>
-        /// Returns the URI fragment that, when passed to getEObject will return the given object. 
+        /// Returns the URI fragment that, when passed to <see cref="GetEObject(string)"/>, will return the given object.
         /// </summary>
         /// <param name="eObject">
         /// The object to identify
@@ -209,9 +209,36 @@ namespace ECoreNetto.Resource
         /// <returns>
         /// the URI fragment for the object.
         /// </returns>
+        /// <remarks>
+        /// The returned fragment is the name-based Ecore reference under which the object is registered in this
+        /// resource (its <see cref="EObject.Identifier"/>), for example <c>recipe.ecore#//Recipe</c> for a class or
+        /// <c>EStructuralFeature::recipe.ecore#//Recipe/ingredients</c> for a structural feature. This is exactly the
+        /// reference string consumed by <see cref="GetEObject(string)"/>, so the round-trip
+        /// <c>GetEObject(GetURIFragment(eObject))</c> returns the same instance.
+        /// </remarks>
+        /// <exception cref="ArgumentNullException">
+        /// Thrown when <paramref name="eObject"/> is null.
+        /// </exception>
+        /// <exception cref="InvalidOperationException">
+        /// Thrown when <paramref name="eObject"/> is not contained in this resource and therefore cannot be turned
+        /// into a resolvable URI fragment.
+        /// </exception>
         public string GetURIFragment(EObject eObject)
         {
-            throw new NotImplementedException();
+            if (eObject == null)
+            {
+                throw new ArgumentNullException(nameof(eObject));
+            }
+
+            var fragment = eObject.Identifier;
+
+            if (string.IsNullOrEmpty(fragment) || !this.Cache.TryGetValue(fragment, out var cached) || !ReferenceEquals(cached, eObject))
+            {
+                throw new InvalidOperationException(
+                    $"The provided '{eObject.GetType().Name}' is not contained in this resource and cannot be turned into a URI fragment.");
+            }
+
+            return fragment;
         }
 
         /// <summary>


### PR DESCRIPTION
Implements `Resource.GetURIFragment(EObject)`, previously a `NotImplementedException` stub, as the inverse of `GetEObject(string)`.

**Approach**
- During load every `ENamedElement` is registered in `Resource.Cache` keyed by its `EObject.Identifier`, and `GetEObject` resolves a reference by that same key. `GetURIFragment` therefore returns the object's `Identifier` (the name-based Ecore reference, e.g. `recipe.ecore#//Recipe` for a class, `EStructuralFeature::recipe.ecore#//Recipe/ingredients` for a feature), which guarantees the round-trip `GetEObject(GetURIFragment(x)) == x` with no change to `GetEObject`.
- Guards: `null` -> `ArgumentNullException`; an object not contained in this resource -> a descriptive `InvalidOperationException` (consistent with the guarded patterns from #32/#37).

**Design note / deviation from the ticket**
The ticket listed a possible acceptance bullet that the fragment contain no leading `#`. The existing architecture keys the cache by the composed identifier (which includes the `<resource>.ecore#` prefix), so returning that composed form is what round-trips with the current `GetEObject`. Returning a pure intra-resource fragment (`//Recipe`) would require re-architecting `GetEObject`/`BuildIdentifier` and was deliberately left out of scope; the round-trip is satisfied as the primary contract. Happy to follow up with the pure-fragment form if desired.

**Tests** (new `GetUriFragmentTestFixture`): round-trip for the root package, a class, a structural feature and an enum literal, plus `null` and not-contained guard cases. Full suite green (198 tests).

Fixes #76.