### PR TITLE
Honor loadOnDemand in ResourceSet.Resource(...) (fixes #39)

### DIFF
--- a/ECoreNetto.Tests/Resource/ResourceSetTestFixture.cs
+++ b/ECoreNetto.Tests/Resource/ResourceSetTestFixture.cs
@@ -129,5 +129,33 @@ namespace ECoreNetto.Tests.Resource
         {
             Assert.That(() => this.resourceSet.Resource(null!, false), Throws.ArgumentNullException);
         }
+
+        [Test]
+        public void Verify_that_with_loadOnDemand_true_a_missing_resource_is_created_and_loaded()
+        {
+            var path = Path.Combine(TestContext.CurrentContext.TestDirectory, "Data", "ecore.ecore");
+            var uri = new Uri(Path.GetFullPath(path));
+
+            var result = this.resourceSet.Resource(uri, true);
+
+            Assert.That(result, Is.Not.Null);
+            Assert.Multiple(() =>
+            {
+                Assert.That(result!.IsLoaded(), Is.True);
+                Assert.That(this.resourceSet.Resources, Does.Contain(result));
+            });
+        }
+
+        [Test]
+        public void Verify_that_with_loadOnDemand_true_and_a_nonexistent_file_returns_null()
+        {
+            var path = Path.Combine(TestContext.CurrentContext.TestDirectory, "does-not-exist.ecore");
+            var uri = new Uri(Path.GetFullPath(path));
+
+            var result = this.resourceSet.Resource(uri, true);
+
+            Assert.That(result, Is.Null);
+            Assert.That(this.resourceSet.Resources, Is.Empty);
+        }
     }
 }

--- a/ECoreNetto/Resource/ResourceSet.cs
+++ b/ECoreNetto/Resource/ResourceSet.cs
@@ -22,6 +22,7 @@ namespace ECoreNetto.Resource
 {
     using System;
     using System.Collections.Generic;
+    using System.IO;
 
     using Microsoft.Extensions.Logging;
     using Microsoft.Extensions.Logging.Abstractions;
@@ -138,7 +139,8 @@ namespace ECoreNetto.Resource
         /// the URI to resolve.
         /// </param>
         /// <param name="loadOnDemand">
-        /// whether to create and load the resource, if it doesn't already exist.
+        /// whether to create and load the resource, if it doesn't already exist. The resource is only
+        /// demand-loaded when the <paramref name="uri"/> points at a file that exists on disk.
         /// </param>
         /// <returns>
         /// the resource resolved by the URI, or null if there isn't one, and it's not being demand loaded.
@@ -156,6 +158,22 @@ namespace ECoreNetto.Resource
                 {
                     return resource;
                 }
+            }
+
+            if (loadOnDemand)
+            {
+                if (!File.Exists(uri.LocalPath))
+                {
+                    this.logger.LogTrace(
+                        "The resource for uri '{0}' could not be demand-loaded because the file does not exist", uri);
+
+                    return null;
+                }
+
+                var resource = this.CreateResource(uri);
+                resource.Load(null);
+
+                return resource;
             }
 
             return null;


### PR DESCRIPTION
## Summary

`ResourceSet.Resource(Uri uri, bool loadOnDemand)` ignored its `loadOnDemand` parameter: it only searched the already-registered resources and returned `null` when none matched, so `loadOnDemand: true` had no effect despite being part of the contract.

## Change

When `loadOnDemand` is true and no matching resource exists, create and load it — mirroring the demand-load already implemented in `Resource.GetEObject`:

- Guard with `File.Exists(uri.LocalPath)`; a missing file returns `null` (no throw), consistent with `GetEObject` and the #36 load hardening.
- Otherwise `CreateResource(uri)` + `Load(null)` and return the loaded resource.

Scope is limited to the "no matching resource exists" case (as the issue specifies); an already-registered resource found in the set is still returned as-is.

## Tests

Extended `ResourceSetTestFixture`:
- `loadOnDemand: true` with a real file: resource is created, loaded (`IsLoaded()`), and added to `Resources`.
- `loadOnDemand: true` with a nonexistent file: returns `null`, nothing added.
- `loadOnDemand: false` unchanged is covered by the existing tests.

Full suite green (66 tests).

## Acceptance criteria

- [x] With `loadOnDemand: true`, a not-yet-loaded resource is created and loaded.
- [x] With `loadOnDemand: false`, behavior is unchanged.
- [x] Tests cover both paths.

Fixes #39
