### PR TITLE
Guarantee Resource.GetEObject terminates on unresolvable fragments (fixes #80)

### DIFF
--- a/ECoreNetto.Tests/Resource/GetEObjectRecursionTestFixture.cs
+++ b/ECoreNetto.Tests/Resource/GetEObjectRecursionTestFixture.cs
@@ -1,0 +1,121 @@
+// ------------------------------------------------------------------------------------------------
+// <copyright file="GetEObjectRecursionTestFixture.cs" company="Starion Group S.A.">
+//
+//   Copyright 2017-2026 Starion Group S.A.
+//   SPDX-License-Identifier: Apache-2.0
+//
+// </copyright>
+// ------------------------------------------------------------------------------------------------
+
+namespace ECoreNetto.Tests.Resource
+{
+    using System;
+    using System.IO;
+    using System.Linq;
+
+    using ECoreNetto.Resource;
+
+    using NUnit.Framework;
+
+    /// <summary>
+    /// Suite of tests that verify <see cref="Resource.GetEObject(string)"/> always terminates: an
+    /// unresolvable fragment whose file part resolves back to a resource already on the resolution path
+    /// must be reported as unresolved (with a recorded <see cref="Diagnostic"/>) rather than recursing
+    /// unboundedly into a <see cref="StackOverflowException"/> (see issue #80).
+    /// </summary>
+    [TestFixture]
+    public class GetEObjectRecursionTestFixture
+    {
+        private ResourceSet resourceSet = null!;
+
+        [SetUp]
+        public void SetUp()
+        {
+            this.resourceSet = new ResourceSet();
+        }
+
+        [Test]
+        public void Verify_that_a_fragment_pointing_at_the_own_resource_for_an_unknown_element_returns_null_without_recursing()
+        {
+            var resource = this.CreateResourceForContent(
+                "self-cycle.ecore",
+                Package("self-cycle", "<eClassifiers xsi:type=\"ecore:EClass\" name=\"A\"/>"));
+            resource.Load(null);
+
+            EObject? result = null;
+
+            // the fragment names this resource's own file but an element that does not exist; resolution
+            // resolves the file back to this resource and must stop instead of recursing forever
+            Assert.That(() => result = resource.GetEObject("self-cycle.ecore#//DoesNotExist"), Throws.Nothing);
+
+            Assert.Multiple(() =>
+            {
+                Assert.That(result, Is.Null);
+                Assert.That(resource.Errors, Is.Not.Empty);
+                Assert.That(resource.Errors.Last().Message, Does.Contain("DoesNotExist"));
+            });
+        }
+
+        [Test]
+        public void Verify_that_an_eOpposite_style_fragment_for_an_unknown_feature_returns_null_without_recursing()
+        {
+            var resource = this.CreateResourceForContent(
+                "opposite-cycle.ecore",
+                Package("opposite-cycle", "<eClassifiers xsi:type=\"ecore:EClass\" name=\"A\"/>"));
+            resource.Load(null);
+
+            EObject? result = null;
+
+            // an eOpposite reference carries an 'EStructuralFeature::' prefix before the file name; an unknown
+            // feature must resolve to null without recursing
+            Assert.That(
+                () => result = resource.GetEObject("EStructuralFeature::opposite-cycle.ecore#//A/missingOpposite"),
+                Throws.Nothing);
+
+            Assert.That(result, Is.Null);
+        }
+
+        [Test]
+        public void Verify_that_loading_a_model_with_a_self_referencing_missing_super_type_reports_it_without_recursing()
+        {
+            var model = Package(
+                "broken-super",
+                "<eClassifiers xsi:type=\"ecore:EClass\" name=\"A\" eSuperTypes=\"broken-super.ecore#//Missing\"/>");
+            var resource = this.CreateResourceForContent("broken-super.ecore", model);
+
+            // EClass.SetProperties resolves eSuperTypes via the guarded GetEObject<EClass>; the unresolved
+            // reference must surface as a clear InvalidOperationException, not a stack overflow
+            var exception = Assert.Throws<InvalidOperationException>(() => resource.Load(null));
+            Assert.That(exception!.Message, Does.Contain("Missing"));
+        }
+
+        /// <summary>
+        /// Wraps the supplied classifier markup in a minimal Ecore package.
+        /// </summary>
+        private static string Package(string packageName, string body)
+        {
+            return
+                "<?xml version=\"1.0\" encoding=\"UTF-8\"?>\r\n" +
+                "<ecore:EPackage xmi:version=\"2.0\" xmlns:xmi=\"http://www.omg.org/XMI\" " +
+                "xmlns:xsi=\"http://www.w3.org/2001/XMLSchema-instance\" " +
+                "xmlns:ecore=\"http://www.eclipse.org/emf/2002/Ecore\" " +
+                $"name=\"{packageName}\" nsURI=\"{packageName}\" nsPrefix=\"{packageName}\">\r\n" +
+                $"  {body}\r\n" +
+                "</ecore:EPackage>";
+        }
+
+        /// <summary>
+        /// Writes the provided <paramref name="content"/> to a file in the test directory and
+        /// creates a <see cref="Resource"/> for it.
+        /// </summary>
+        private Resource CreateResourceForContent(string fileName, string content)
+        {
+            var path = Path.Combine(TestContext.CurrentContext.TestDirectory, fileName);
+            File.WriteAllText(path, content);
+
+            var uri = new Uri(Path.GetFullPath(path));
+
+            return this.resourceSet.CreateResource(uri);
+        }
+    }
+}

--- a/ECoreNetto/Resource/Resource.cs
+++ b/ECoreNetto/Resource/Resource.cs
@@ -275,6 +275,26 @@ namespace ECoreNetto.Resource
         /// </returns>
         public EObject? GetEObject(string uriFragment)
         {
+            return this.GetEObject(uriFragment, new HashSet<Resource>());
+        }
+
+        /// <summary>
+        /// Returns the resolved object for the given URI fragment, tracking the resources already consulted
+        /// during the current resolution so that resolution always terminates.
+        /// </summary>
+        /// <param name="uriFragment">
+        /// the fragment to resolve.
+        /// </param>
+        /// <param name="visitedResources">
+        /// the resources already visited while resolving <paramref name="uriFragment"/>. A delegation to a
+        /// resource that is already present would repeat with the same (resource, fragment) pair and never
+        /// make progress, so it is reported as unresolved rather than recursed into.
+        /// </param>
+        /// <returns>
+        /// The resolved object for the given fragment, or null if it can't be resolved.
+        /// </returns>
+        private EObject? GetEObject(string uriFragment, HashSet<Resource> visitedResources)
+        {
             this.logger.LogTrace("Getting EObject for resources {0}", uriFragment);
 
             if (string.IsNullOrWhiteSpace(uriFragment))
@@ -329,6 +349,9 @@ namespace ECoreNetto.Resource
 
             this.logger.LogTrace("EObject not found in current resource, loading other resources: {0}", resourceUri);
 
+            // record that resolution has now passed through this resource
+            visitedResources.Add(this);
+
             var resource = this.ResourceSet!.Resources.SingleOrDefault(x => x.URI == resourceUri);
             if (resource == null)
             {
@@ -347,16 +370,19 @@ namespace ECoreNetto.Resource
                 resource.Load(null);
             }
 
-            if (resource == this)
+            if (visitedResources.Contains(resource))
             {
-                // the fragment points back at the current resource but was not found in its cache:
-                // it cannot be resolved. Returning here avoids unbounded self-recursion.
-                this.logger.LogTrace("EObject using uri fragment '{0}' could not be resolved", uriFragment);
+                // delegating to a resource already on the resolution path would repeat with the same
+                // (resource, fragment) pair and never terminate; report the reference as unresolved
+                // instead of recursing unboundedly.
+                var message = $"The reference '{uriFragment}' could not be resolved; resolution cycled back to resource '{resource.URI}'.";
+                this.AddError(message);
+                this.logger.LogTrace(message);
 
                 return null;
             }
 
-            return resource.GetEObject(uriFragment);
+            return resource.GetEObject(uriFragment, visitedResources);
         }
 
         /// <summary>


### PR DESCRIPTION
## Summary

`Resource.GetEObject(string)` delegated cross-resource resolution with the **unchanged** fragment (`return resource.GetEObject(uriFragment)`). Because the sibling-resource URI is a pure function of the fragment, a fragment that could not be resolved could re-derive the same resource and delegate again with the same input, recursing until an uncatchable `StackOverflowException` (issue #80). The `development` branch guarded only the direct `resource == this` self-delegation; it did not cover delegation cycles between distinct resources, and 7.0.9 had no guard at all.

## Fix

Track the resources already visited while resolving a single fragment and treat a delegation to a resource **already on the resolution path** as unresolvable — it would repeat with the same `(resource, fragment)` pair and never make progress. In that case record a `Diagnostic` (via `AddError`) and return `null` instead of recursing.

- `GetEObject(string)` is now a thin wrapper over a private `GetEObject(string, HashSet<Resource>)` that carries the visited set.
- The generalized guard subsumes the previous `resource == this` special case and also catches any distinct-resource cycle.
- This is defense-in-depth on top of #79 (which made cross-file references actually resolve): legitimate references still hit the target resource's cache on the first delegation; only genuinely unresolvable fragments reach the guard.

## Tests

New `GetEObjectRecursionTestFixture`:
- a fragment naming the resource's own file with an unknown element resolves to `null` (no recursion) and records a diagnostic;
- an `EStructuralFeature::…` (eOpposite-style) fragment for an unknown feature resolves to `null` without recursing;
- loading a model whose `eSuperTypes` points at a missing self-file type surfaces a clear `InvalidOperationException` (not a stack overflow).

Full solution suite green: ECoreNetto.Tests 71, Extensions 30, HandleBars 43, Reporting 48, Tools 42 — no regressions (including `GuardedGetEObjectTestFixture`, `DiagnosticsTestFixture`, and `CapellaMetamodelTestFixture`).

## Acceptance

- [x] `GetEObject` no longer recurses unboundedly on unresolvable fragments (self-delegation and distinct-resource cycles).
- [x] The unresolved reference is recorded as a `Diagnostic` and returns `null`.
- [x] Tests cover the pathological fragments.

Fixes #80
