### PR TITLE
Remove static TopPackageName and harden URI-based reference handling (fixes #31, #38)

### DIFF
--- a/ECoreNetto.Tests/Resource/ConcurrentLoadTestFixture.cs
+++ b/ECoreNetto.Tests/Resource/ConcurrentLoadTestFixture.cs
@@ -1,0 +1,66 @@
+// ------------------------------------------------------------------------------------------------
+// <copyright file="ConcurrentLoadTestFixture.cs" company="Starion Group S.A.">
+//
+//   Copyright 2017-2026 Starion Group S.A.
+//   SPDX-License-Identifier: Apache-2.0
+//
+// </copyright>
+// ------------------------------------------------------------------------------------------------
+
+namespace ECoreNetto.Tests.Resource
+{
+    using System;
+    using System.Collections.Concurrent;
+    using System.IO;
+    using System.Linq;
+    using System.Threading.Tasks;
+
+    using ECoreNetto.Resource;
+
+    using NUnit.Framework;
+
+    /// <summary>
+    /// Suite of tests that verify loading is free of shared mutable parsing state: two different models
+    /// loaded concurrently must each resolve their own references, with no cross-contamination (see issue
+    /// #31 — the former static <c>EObject.TopPackageName</c>).
+    /// </summary>
+    [TestFixture]
+    public class ConcurrentLoadTestFixture
+    {
+        [Test]
+        public void Verify_that_two_different_models_load_concurrently_and_resolve_their_own_references()
+        {
+            var results = new ConcurrentBag<(string expected, string actual, int errors)>();
+
+            // alternate loading two different single-file models on many threads; each uses its own
+            // ResourceSet and must resolve its own references without interference from the other
+            Parallel.For(0, 100, i =>
+            {
+                var (fileName, expectedRoot) = (i % 2 == 0)
+                    ? ("recipe.ecore", "recipe")
+                    : ("ecore.ecore", "ecore");
+
+                var path = Path.Combine(TestContext.CurrentContext.TestDirectory, "Data", fileName);
+
+                var resourceSet = new ResourceSet();
+                var resource = resourceSet.CreateResource(new Uri(Path.GetFullPath(path)));
+                var root = resource.Load(null);
+
+                results.Add((expectedRoot, root.Name, resource.Errors.Count()));
+            });
+
+            Assert.That(results, Has.Count.EqualTo(100));
+            Assert.Multiple(() =>
+            {
+                Assert.That(
+                    results.All(r => r.actual == r.expected),
+                    Is.True,
+                    "a concurrently loaded model resolved to the wrong root package");
+                Assert.That(
+                    results.All(r => r.errors == 0),
+                    Is.True,
+                    "a concurrently loaded model recorded reference-resolution errors");
+            });
+        }
+    }
+}

--- a/ECoreNetto.Tests/Resource/EscapedPathTestFixture.cs
+++ b/ECoreNetto.Tests/Resource/EscapedPathTestFixture.cs
@@ -1,0 +1,100 @@
+// ------------------------------------------------------------------------------------------------
+// <copyright file="EscapedPathTestFixture.cs" company="Starion Group S.A.">
+//
+//   Copyright 2017-2026 Starion Group S.A.
+//   SPDX-License-Identifier: Apache-2.0
+//
+// </copyright>
+// ------------------------------------------------------------------------------------------------
+
+namespace ECoreNetto.Tests.Resource
+{
+    using System;
+    using System.IO;
+    using System.Linq;
+
+    using ECoreNetto.Resource;
+
+    using NUnit.Framework;
+
+    /// <summary>
+    /// Suite of tests that verify models load and cross-resource references resolve when the model path
+    /// contains characters that are percent-escaped in a URI beyond a plain space (%20), such as a space
+    /// and a non-ASCII character (see issue #38 — reference handling must use proper URI decoding).
+    /// </summary>
+    [TestFixture]
+    public class EscapedPathTestFixture
+    {
+        // a directory name with a space (%20) and a non-ASCII character (escapes to %C3%A4) exercises
+        // escaped path segments beyond %20
+        private string escapedDirectory = null!;
+
+        [SetUp]
+        public void SetUp()
+        {
+            this.escapedDirectory = Path.Combine(TestContext.CurrentContext.TestDirectory, "escaped path ä");
+            Directory.CreateDirectory(this.escapedDirectory);
+        }
+
+        [Test]
+        public void Verify_that_a_model_in_an_escaped_path_can_be_loaded()
+        {
+            var path = Path.Combine(this.escapedDirectory, "single.ecore");
+            File.WriteAllText(path, Package("single", "<eClassifiers xsi:type=\"ecore:EClass\" name=\"A\"/>"));
+
+            var resourceSet = new ResourceSet();
+            var resource = resourceSet.CreateResource(new Uri(Path.GetFullPath(path)));
+
+            EPackage root = null!;
+            Assert.That(() => root = resource.Load(null), Throws.Nothing);
+            Assert.Multiple(() =>
+            {
+                Assert.That(root.Name, Is.EqualTo("single"));
+                Assert.That(resource.Errors, Is.Empty);
+            });
+        }
+
+        [Test]
+        public void Verify_that_a_cross_resource_reference_resolves_across_an_escaped_path()
+        {
+            var childPath = Path.Combine(this.escapedDirectory, "child.ecore");
+            File.WriteAllText(childPath, Package("child", "<eClassifiers xsi:type=\"ecore:EClass\" name=\"Base\"/>"));
+
+            var mainPath = Path.Combine(this.escapedDirectory, "main.ecore");
+            File.WriteAllText(
+                mainPath,
+                Package("main", "<eClassifiers xsi:type=\"ecore:EClass\" name=\"A\" eSuperTypes=\"child.ecore#//Base\"/>"));
+
+            var resourceSet = new ResourceSet();
+            var resource = resourceSet.CreateResource(new Uri(Path.GetFullPath(mainPath)));
+
+            EPackage root = null!;
+            Assert.That(() => root = resource.Load(null), Throws.Nothing);
+
+            var a = root.EClassifiers.OfType<EClass>().Single(c => c.Name == "A");
+            var superType = a.ESuperTypes.SingleOrDefault();
+
+            Assert.Multiple(() =>
+            {
+                Assert.That(superType, Is.Not.Null);
+                Assert.That(superType!.Name, Is.EqualTo("Base"));
+                Assert.That(resource.Errors, Is.Empty);
+            });
+        }
+
+        /// <summary>
+        /// Wraps the supplied classifier markup in a minimal Ecore package.
+        /// </summary>
+        private static string Package(string packageName, string body)
+        {
+            return
+                "<?xml version=\"1.0\" encoding=\"UTF-8\"?>\r\n" +
+                "<ecore:EPackage xmi:version=\"2.0\" xmlns:xmi=\"http://www.omg.org/XMI\" " +
+                "xmlns:xsi=\"http://www.w3.org/2001/XMLSchema-instance\" " +
+                "xmlns:ecore=\"http://www.eclipse.org/emf/2002/Ecore\" " +
+                $"name=\"{packageName}\" nsURI=\"{packageName}\" nsPrefix=\"{packageName}\">\r\n" +
+                $"  {body}\r\n" +
+                "</ecore:EPackage>";
+        }
+    }
+}

--- a/ECoreNetto/ECoreParser.cs
+++ b/ECoreNetto/ECoreParser.cs
@@ -93,8 +93,8 @@ namespace ECoreNetto
                 XmlResolver = null
             };
 
-            var fileInfo = new FileInfo(this.resource.URI.AbsolutePath.Replace("%20", " "));
-            var fullPath = Path.GetFullPath(fileInfo.FullName);
+            // URI.LocalPath yields the unescaped local file path (handles %20 and any other escaped characters)
+            var fullPath = Path.GetFullPath(this.resource.URI.LocalPath);
 
             if (!File.Exists(fullPath))
             {

--- a/ECoreNetto/ModelElement/EObject.cs
+++ b/ECoreNetto/ModelElement/EObject.cs
@@ -60,9 +60,29 @@ namespace ECoreNetto
         public Resource.Resource EResource { get; private set; }
 
         /// <summary>
-        /// Gets or sets the current top package name used during .
+        /// Queries the '.ecore' resource segment used when building identifiers and when rewriting implicit
+        /// references, so that both agree with the file name that cross-file references use.
         /// </summary>
-        internal static string? TopPackageName { get; set; }
+        /// <returns>
+        /// The resource file name (e.g. <c>recipe.ecore</c>) taken from the <see cref="EResource"/> URI, or the
+        /// root package name suffixed with <c>.ecore</c> when the resource has no backing file.
+        /// </returns>
+        protected string QueryResourceSegment()
+        {
+            if (this.EResource.URI != null)
+            {
+                return Path.GetFileName(this.EResource.URI.LocalPath);
+            }
+
+            // no backing file (in-memory construction): fall back to the root package name
+            var root = this;
+            while (root.EContainer != null)
+            {
+                root = root.EContainer;
+            }
+
+            return $"{(root as ENamedElement)?.Name}.ecore";
+        }
 
         /// <summary>
         /// Gets the identifier for this <see cref="EModelElement"/>
@@ -473,17 +493,12 @@ namespace ECoreNetto
             // split the attribute value to support one or many value parts
             var attributeValueParts = attributeValue.Split(' ');
 
-            // rewrite an implicit reference to the current resource's file so it matches the file-name-based
-            // cache keys; fall back to the top package name when there is no backing file
+            // rewrite an implicit reference so it matches the file-name-based cache keys of the current resource
             for (var i = 0; i < attributeValueParts.Length; i++)
             {
                 if (attributeValueParts[i].StartsWith("#//"))
                 {
-                    var fileName = this.EResource.URI != null
-                        ? Path.GetFileName(this.EResource.URI.LocalPath)
-                        : $"{TopPackageName}.ecore";
-
-                    attributeValueParts[i] = $"{fileName}{attributeValueParts[i]}";
+                    attributeValueParts[i] = $"{this.QueryResourceSegment()}{attributeValueParts[i]}";
                 }
             }
 

--- a/ECoreNetto/ModelElement/NamedElement/EPackage.cs
+++ b/ECoreNetto/ModelElement/NamedElement/EPackage.cs
@@ -22,7 +22,6 @@ namespace ECoreNetto
 {
     using System;
     using System.Collections.Generic;
-    using System.IO;
     using System.Linq;
     using System.Xml;
 
@@ -200,11 +199,6 @@ namespace ECoreNetto
         {
             var packageHierarchy = new List<string> { this.Name };
             var superPackage = this.ESuperPackage;
-            if (superPackage == null)
-            {
-                // set the current package
-                EModelElement.TopPackageName = this.Name;
-            }
 
             while (superPackage != null)
             {
@@ -212,12 +206,8 @@ namespace ECoreNetto
                 superPackage = superPackage.ESuperPackage;
             }
 
-            // use the actual .ecore file name, falling back to the package name when there is no backing file
-            var fileName = this.EResource.URI != null
-                ? Path.GetFileName(this.EResource.URI.LocalPath)
-                : $"{packageHierarchy[packageHierarchy.Count - 1]}.ecore";
-
-            packageHierarchy[packageHierarchy.Count - 1] = $"{fileName}#/";
+            // the resource segment is the actual .ecore file name so cross-file references resolve
+            packageHierarchy[packageHierarchy.Count - 1] = $"{this.QueryResourceSegment()}#/";
 
             packageHierarchy.Reverse();
 

--- a/ECoreNetto/Resource/Resource.cs
+++ b/ECoreNetto/Resource/Resource.cs
@@ -310,22 +310,18 @@ namespace ECoreNetto.Resource
                 filePart = filePart.Substring(typePrefixIndex + 2);
             }
 
-            if (!filePart.Contains(".ecore"))
+            if (!Path.HasExtension(filePart))
             {
-                // the fragment does not point at another .ecore resource and was not found in
-                // this resource's cache or the known ECore types: it cannot be resolved.
+                // the fragment does not point at another resource file and was not found in this resource's
+                // cache or the known ECore types: it cannot be resolved.
                 this.logger.LogTrace("EObject using uri fragment '{0}' could not be resolved", uriFragment);
 
                 return null;
             }
 
-            var index = this.URI.AbsolutePath.LastIndexOf('/');
-            if (index <= 0)
-            {
-                throw new ArgumentException($"Invalid path for the current resource: {this.URI.AbsolutePath}");
-            }
-
-            var resourceUri = new Uri($"{this.URI.AbsolutePath.Substring(0, index)}/{filePart}");
+            // resolve the file part against the current resource URI (proper URI resolution handles escaped
+            // path segments and any file extension without hardcoded string manipulation)
+            var resourceUri = new Uri(this.URI, filePart);
 
             this.logger.LogTrace("EObject not found in current resource, loading other resources: {0}", resourceUri);
 


### PR DESCRIPTION
Combined fix for two closely-coupled defects in the reference-resolution / URI-handling subsystem (same files and hot path — see the discussion on why they belong in one PR).

## #31 — Remove static mutable `EObject.TopPackageName`

`EObject.TopPackageName` was a **static** property set during parsing (from the root package name in `EPackage.BuildIdentifier`) and read while rewriting implicit `#//` references in `EObject.ProcessAttributeValue`. Two resources loading concurrently could clobber it across threads — a non-deterministic corruption of reference rewriting.

- Introduced an instance helper `EObject.QueryResourceSegment()` that returns the `.ecore` resource segment from the resource's own `URI` file name, falling back to the root package name (via the `EContainer` chain) only when there is no backing file (in-memory construction).
- `EPackage.BuildIdentifier` and `EObject.ProcessAttributeValue` now call it; the static property and its assignment are removed. No shared mutable parsing state remains.

## #38 — Replace fragile string-based reference rewriting

Cross-reference handling relied on ad-hoc string ops:

- `ECoreParser.ParseXml` opened the model via `URI.AbsolutePath.Replace("%20", " ")` — only `%20` was decoded. Now it uses `URI.LocalPath`, which unescapes `%20` **and any other** percent-escaped character.
- `Resource.GetEObject` detected a cross-file reference with a hardcoded `.Contains(".ecore")` and built the sibling URI with `AbsolutePath.LastIndexOf('/')` + substring. Now it uses `Path.HasExtension(filePart)` (no hardcoded extension in the hot path) and `new Uri(this.URI, filePart)` (proper URI resolution that handles escaped path segments).

## Tests

- `ConcurrentLoadTestFixture` — 100 parallel loads alternating two different models (`recipe.ecore` / `ecore.ecore`), each in its own `ResourceSet`; asserts every load resolves to its own root package with zero resolution errors (no cross-contamination).
- `EscapedPathTestFixture` — loads a model, and a cross-resource reference, from a directory whose name contains a space and a non-ASCII character (`escaped path ä`, i.e. escaping beyond `%20`); asserts both load and the cross-file supertype resolves.

Full solution suite green: ECoreNetto.Tests 71 (+3), Extensions 30, HandleBars 43, Reporting 48, Tools 42 — no regressions.

## Acceptance criteria

**#31**
- [x] No static mutable state tracks the top package during parsing.
- [x] A test loads two different models concurrently and asserts each resolves its own references.

**#38**
- [x] Paths containing escaped characters beyond `%20` load correctly.
- [x] Reference rewriting no longer depends on a hardcoded extension string in the hot path.
- [x] Tests cover an escaped-path and a cross-resource reference scenario.

Fixes #31
Fixes #38

## Note

Touches `Resource.GetEObject` in the same region as the open PR for #80 (recursion guard). Whichever merges second will need a trivial rebase; the changes are compatible (this PR changes the file-part detection and sibling-URI construction; #80 adds a visited-set around the delegation).
