### PR TITLE
[Fix] populate Resource.Contents on load and dedup ResourceSet.CreateResource; fixes #82, #84

### DIFF
--- a/ECoreNetto.Tests/Resource/ResourceLifecycleTestFixture.cs
+++ b/ECoreNetto.Tests/Resource/ResourceLifecycleTestFixture.cs
@@ -28,10 +28,13 @@ namespace ECoreNetto.Tests.Resource
     {
         private ResourceSet resourceSet = null!;
 
+        private string capellaDirectory = null!;
+
         [SetUp]
         public void SetUp()
         {
             this.resourceSet = new ResourceSet();
+            this.capellaDirectory = Path.Combine(TestContext.CurrentContext.TestDirectory, "Data", "capella");
         }
 
         [Test]
@@ -129,6 +132,80 @@ namespace ECoreNetto.Tests.Resource
                 // resolution still works across the set (no duplicate URIs poisoning the lookup)
                 Assert.That(main.GetEObject("loop-child.ecore#//Base"), Is.Not.Null);
             });
+        }
+
+        [Test]
+        public void Verify_that_loading_the_capella_metamodel_populates_Contents_for_every_resource()
+        {
+            this.DemandLoadCapellaMetamodel();
+
+            // the 21 cross-referencing Capella files were pulled into the set (some directly, some as
+            // demand-loaded dependencies); every one must expose its single root package via Contents (#82)
+            Assert.That(this.resourceSet.Resources, Is.Not.Empty);
+            Assert.Multiple(() =>
+            {
+                foreach (var resource in this.resourceSet.Resources)
+                {
+                    Assert.That(resource.Contents, Has.Count.EqualTo(1), $"resource '{resource.URI}' did not expose its root package");
+                    Assert.That(resource.Contents[0], Is.InstanceOf<EPackage>());
+                }
+            });
+
+            // AllContents flattens every resource's content tree across the whole metamodel
+            var allContents = this.resourceSet.AllContents().ToList();
+            Assert.That(allContents.OfType<EClass>().Any(), Is.True);
+        }
+
+        [Test]
+        public void Verify_that_re_registering_and_loading_capella_files_does_not_duplicate_resources()
+        {
+            // first pass: demand-load the whole metamodel (files reference each other across the set)
+            this.DemandLoadCapellaMetamodel();
+            var resourceCountAfterFirstPass = this.resourceSet.Resources.Count;
+
+            // second pass: the naive "register each file then load it" loop must reuse the already-loaded
+            // resources rather than registering duplicates or re-parsing (and corrupting) the set (#84)
+            Assert.That(() =>
+            {
+                foreach (var file in Directory.EnumerateFiles(this.capellaDirectory, "*.ecore"))
+                {
+                    var uri = new Uri(Path.GetFullPath(file));
+                    var resource = this.resourceSet.CreateResource(uri);
+                    resource.Load(null);
+                }
+            }, Throws.Nothing);
+
+            Assert.Multiple(() =>
+            {
+                // no new resources were added, and none carry a duplicate URI
+                Assert.That(this.resourceSet.Resources.Count, Is.EqualTo(resourceCountAfterFirstPass));
+                var duplicateUris = this.resourceSet.Resources
+                    .GroupBy(r => r.URI.AbsoluteUri)
+                    .Where(g => g.Count() > 1)
+                    .Select(g => g.Key)
+                    .ToList();
+                Assert.That(duplicateUris, Is.Empty, $"duplicate resource URIs: {string.Join("; ", duplicateUris)}");
+
+                // resolution across the set still works after the re-registration pass
+                foreach (var resource in this.resourceSet.Resources)
+                {
+                    Assert.That(resource.Errors, Is.Empty, $"resource '{resource.URI}' recorded errors after re-registration");
+                }
+            });
+        }
+
+        /// <summary>
+        /// Demand-loads every <c>.ecore</c> file in the Capella test-data directory into
+        /// <see cref="resourceSet"/> using <see cref="ResourceSet.Resource(Uri, bool)"/>, so files already
+        /// pulled in through cross-file references are not loaded twice.
+        /// </summary>
+        private void DemandLoadCapellaMetamodel()
+        {
+            foreach (var file in Directory.EnumerateFiles(this.capellaDirectory, "*.ecore"))
+            {
+                var uri = new Uri(Path.GetFullPath(file));
+                this.resourceSet.Resource(uri, true);
+            }
         }
 
         /// <summary>

--- a/ECoreNetto.Tests/Resource/ResourceLifecycleTestFixture.cs
+++ b/ECoreNetto.Tests/Resource/ResourceLifecycleTestFixture.cs
@@ -1,0 +1,170 @@
+// ------------------------------------------------------------------------------------------------
+// <copyright file="ResourceLifecycleTestFixture.cs" company="Starion Group S.A.">
+//
+//   Copyright 2017-2026 Starion Group S.A.
+//   SPDX-License-Identifier: Apache-2.0
+//
+// </copyright>
+// ------------------------------------------------------------------------------------------------
+
+namespace ECoreNetto.Tests.Resource
+{
+    using System;
+    using System.IO;
+    using System.Linq;
+
+    using ECoreNetto.Resource;
+
+    using NUnit.Framework;
+
+    /// <summary>
+    /// Suite of tests that verify resource lifecycle semantics: <see cref="Resource.Load"/> populates
+    /// <see cref="Resource.Contents"/> so a (possibly demand-loaded) resource exposes its root package
+    /// (see issue #82), and <see cref="ResourceSet.CreateResource"/> does not register a duplicate for an
+    /// already-known URI (see issue #84).
+    /// </summary>
+    [TestFixture]
+    public class ResourceLifecycleTestFixture
+    {
+        private ResourceSet resourceSet = null!;
+
+        [SetUp]
+        public void SetUp()
+        {
+            this.resourceSet = new ResourceSet();
+        }
+
+        [Test]
+        public void Verify_that_Load_populates_Contents_with_the_root_package()
+        {
+            var resource = this.CreateResourceForContent(
+                "contents.ecore",
+                Package("contents", "<eClassifiers xsi:type=\"ecore:EClass\" name=\"A\"/>"));
+
+            var root = resource.Load(null);
+
+            Assert.Multiple(() =>
+            {
+                Assert.That(resource.Contents, Has.Count.EqualTo(1));
+                Assert.That(resource.Contents[0], Is.SameAs(root));
+            });
+        }
+
+        [Test]
+        public void Verify_that_a_demand_loaded_resource_exposes_its_root_package_via_Contents()
+        {
+            this.WriteModel("dep-child.ecore", Package("depchild", "<eClassifiers xsi:type=\"ecore:EClass\" name=\"Base\"/>"));
+            var main = this.CreateResourceForContent(
+                "dep-main.ecore",
+                Package("depmain", "<eClassifiers xsi:type=\"ecore:EClass\" name=\"A\" eSuperTypes=\"dep-child.ecore#//Base\"/>"));
+
+            main.Load(null);
+
+            // the child was demand-loaded while resolving the cross-file super type; its root package must
+            // now be reachable through Contents
+            var childUri = new Uri(Path.Combine(TestContext.CurrentContext.TestDirectory, "dep-child.ecore"));
+            var child = this.resourceSet.Resource(childUri, false);
+
+            Assert.That(child, Is.Not.Null);
+            Assert.Multiple(() =>
+            {
+                Assert.That(child!.Contents, Has.Count.EqualTo(1));
+                Assert.That(((EPackage)child.Contents[0]).Name, Is.EqualTo("depchild"));
+            });
+        }
+
+        [Test]
+        public void Verify_that_ResourceSet_AllContents_returns_the_contents_of_all_resources()
+        {
+            var resource = this.CreateResourceForContent(
+                "allcontents.ecore",
+                Package("allcontents", "<eClassifiers xsi:type=\"ecore:EClass\" name=\"A\"/>"));
+            resource.Load(null);
+
+            var allContents = this.resourceSet.AllContents().ToList();
+
+            Assert.That(allContents, Is.Not.Empty);
+            Assert.That(allContents.OfType<EClass>().Any(c => c.Name == "A"), Is.True);
+        }
+
+        [Test]
+        public void Verify_that_CreateResource_returns_the_existing_resource_for_a_known_uri()
+        {
+            var uri = new Uri(Path.Combine(TestContext.CurrentContext.TestDirectory, "dup.ecore"));
+
+            var first = this.resourceSet.CreateResource(uri);
+            var second = this.resourceSet.CreateResource(uri);
+
+            Assert.Multiple(() =>
+            {
+                Assert.That(second, Is.SameAs(first));
+                Assert.That(this.resourceSet.Resources.Count(r => r.URI.AbsoluteUri == uri.AbsoluteUri), Is.EqualTo(1));
+            });
+        }
+
+        [Test]
+        public void Verify_that_creating_and_loading_an_already_demand_loaded_resource_does_not_corrupt_the_set()
+        {
+            this.WriteModel("loop-child.ecore", Package("loopchild", "<eClassifiers xsi:type=\"ecore:EClass\" name=\"Base\"/>"));
+            var main = this.CreateResourceForContent(
+                "loop-main.ecore",
+                Package("loopmain", "<eClassifiers xsi:type=\"ecore:EClass\" name=\"A\" eSuperTypes=\"loop-child.ecore#//Base\"/>"));
+
+            // loads main and demand-loads loop-child as a dependency
+            main.Load(null);
+
+            // the naive "register each file then load it" pattern must not create a duplicate nor throw when
+            // it reaches a file that was already demand-loaded (issue #84)
+            var childUri = new Uri(Path.Combine(TestContext.CurrentContext.TestDirectory, "loop-child.ecore"));
+            Resource child = null!;
+            Assert.That(() =>
+            {
+                child = this.resourceSet.CreateResource(childUri);
+                child.Load(null);
+            }, Throws.Nothing);
+
+            Assert.Multiple(() =>
+            {
+                Assert.That(this.resourceSet.Resources.Count(r => r.URI.AbsoluteUri == childUri.AbsoluteUri), Is.EqualTo(1));
+                // resolution still works across the set (no duplicate URIs poisoning the lookup)
+                Assert.That(main.GetEObject("loop-child.ecore#//Base"), Is.Not.Null);
+            });
+        }
+
+        /// <summary>
+        /// Wraps the supplied classifier markup in a minimal Ecore package.
+        /// </summary>
+        private static string Package(string packageName, string body)
+        {
+            return
+                "<?xml version=\"1.0\" encoding=\"UTF-8\"?>\r\n" +
+                "<ecore:EPackage xmi:version=\"2.0\" xmlns:xmi=\"http://www.omg.org/XMI\" " +
+                "xmlns:xsi=\"http://www.w3.org/2001/XMLSchema-instance\" " +
+                "xmlns:ecore=\"http://www.eclipse.org/emf/2002/Ecore\" " +
+                $"name=\"{packageName}\" nsURI=\"{packageName}\" nsPrefix=\"{packageName}\">\r\n" +
+                $"  {body}\r\n" +
+                "</ecore:EPackage>";
+        }
+
+        /// <summary>
+        /// Writes the provided <paramref name="content"/> to a file in the test directory.
+        /// </summary>
+        private void WriteModel(string fileName, string content)
+        {
+            File.WriteAllText(Path.Combine(TestContext.CurrentContext.TestDirectory, fileName), content);
+        }
+
+        /// <summary>
+        /// Writes the provided <paramref name="content"/> to a file in the test directory and
+        /// creates a <see cref="Resource"/> for it.
+        /// </summary>
+        private Resource CreateResourceForContent(string fileName, string content)
+        {
+            this.WriteModel(fileName, content);
+
+            var uri = new Uri(Path.Combine(TestContext.CurrentContext.TestDirectory, fileName));
+
+            return this.resourceSet.CreateResource(uri);
+        }
+    }
+}

--- a/ECoreNetto.Tests/Resource/ResourceLifecycleTestFixture.cs
+++ b/ECoreNetto.Tests/Resource/ResourceLifecycleTestFixture.cs
@@ -53,7 +53,7 @@ namespace ECoreNetto.Tests.Resource
         [Test]
         public void Verify_that_a_demand_loaded_resource_exposes_its_root_package_via_Contents()
         {
-            this.WriteModel("dep-child.ecore", Package("depchild", "<eClassifiers xsi:type=\"ecore:EClass\" name=\"Base\"/>"));
+            WriteModel("dep-child.ecore", Package("depchild", "<eClassifiers xsi:type=\"ecore:EClass\" name=\"Base\"/>"));
             var main = this.CreateResourceForContent(
                 "dep-main.ecore",
                 Package("depmain", "<eClassifiers xsi:type=\"ecore:EClass\" name=\"A\" eSuperTypes=\"dep-child.ecore#//Base\"/>"));
@@ -105,7 +105,7 @@ namespace ECoreNetto.Tests.Resource
         [Test]
         public void Verify_that_creating_and_loading_an_already_demand_loaded_resource_does_not_corrupt_the_set()
         {
-            this.WriteModel("loop-child.ecore", Package("loopchild", "<eClassifiers xsi:type=\"ecore:EClass\" name=\"Base\"/>"));
+            WriteModel("loop-child.ecore", Package("loopchild", "<eClassifiers xsi:type=\"ecore:EClass\" name=\"Base\"/>"));
             var main = this.CreateResourceForContent(
                 "loop-main.ecore",
                 Package("loopmain", "<eClassifiers xsi:type=\"ecore:EClass\" name=\"A\" eSuperTypes=\"loop-child.ecore#//Base\"/>"));
@@ -149,7 +149,7 @@ namespace ECoreNetto.Tests.Resource
         /// <summary>
         /// Writes the provided <paramref name="content"/> to a file in the test directory.
         /// </summary>
-        private void WriteModel(string fileName, string content)
+        private static void WriteModel(string fileName, string content)
         {
             File.WriteAllText(Path.Combine(TestContext.CurrentContext.TestDirectory, fileName), content);
         }
@@ -160,7 +160,7 @@ namespace ECoreNetto.Tests.Resource
         /// </summary>
         private Resource CreateResourceForContent(string fileName, string content)
         {
-            this.WriteModel(fileName, content);
+            WriteModel(fileName, content);
 
             var uri = new Uri(Path.Combine(TestContext.CurrentContext.TestDirectory, fileName));
 

--- a/ECoreNetto/Resource/Resource.cs
+++ b/ECoreNetto/Resource/Resource.cs
@@ -449,14 +449,22 @@ namespace ECoreNetto.Resource
         /// </exception>
         public EPackage Load(Dictionary<object, object>? options)
         {
+            if (this.isLoaded)
+            {
+                // the resource is already loaded; return its root package without re-parsing (loading twice
+                // would duplicate cache keys). This makes create-then-load loops over a ResourceSet safe.
+                return (EPackage)this.Contents[0];
+            }
+
             var sw = Stopwatch.StartNew();
 
             var parser = new ECoreParser(this, this.loggerFactory);
             var package = parser.ParseXml();
-            
+
+            this.Contents.Add(package);
             this.isLoaded = true;
 
-            this.logger.LogInformation("Package: '{0}' with prefix {1} and uri {2} loaded in {3} [ms]", 
+            this.logger.LogInformation("Package: '{0}' with prefix {1} and uri {2} loaded in {3} [ms]",
                 package.Name, package.NsPrefix, package.NsUri, sw.ElapsedMilliseconds);
 
             return package;

--- a/ECoreNetto/Resource/ResourceSet.cs
+++ b/ECoreNetto/Resource/ResourceSet.cs
@@ -23,6 +23,7 @@ namespace ECoreNetto.Resource
     using System;
     using System.Collections.Generic;
     using System.IO;
+    using System.Linq;
 
     using Microsoft.Extensions.Logging;
     using Microsoft.Extensions.Logging.Abstractions;
@@ -83,13 +84,26 @@ namespace ECoreNetto.Resource
         /// the <see cref="Uri"/> of the resource to create.
         /// </param>
         /// <returns>
-        /// a new resource
+        /// a new resource, or the resource already registered for <paramref name="uri"/> when one exists.
         /// </returns>
+        /// <remarks>
+        /// If a resource with the same URI is already contained in the set (for example because it was
+        /// demand-loaded as a dependency of another resource), the existing resource is returned rather than
+        /// registering a duplicate. Duplicate URIs would break URI-based lookups for the whole set.
+        /// </remarks>
         public Resource CreateResource(Uri uri)
         {
             if (uri == null)
             {
                 throw new ArgumentNullException(nameof(uri));
+            }
+
+            var existing = this.Resources.FirstOrDefault(resource => resource.URI != null && resource.URI.AbsoluteUri == uri.AbsoluteUri);
+            if (existing != null)
+            {
+                this.logger.LogInformation("Returning the existing resource for uri: {0}", uri);
+
+                return existing;
             }
 
             this.logger.LogInformation("Creating resource for uri: {0}", uri);
@@ -98,12 +112,12 @@ namespace ECoreNetto.Resource
             {
                 URI = uri
             };
-            
+
             this.Resources.Add(resource);
             resource.ResourceSet = this;
             return resource;
         }
-        
+
         /// <summary>
         /// Returns a tree iterator that iterates over all the direct resources and over the content tree of each.
         /// </summary>
@@ -112,7 +126,7 @@ namespace ECoreNetto.Resource
         /// </returns>
         public IEnumerable<Notifier> AllContents()
         {
-            throw new NotImplementedException();
+            return this.Resources.SelectMany(resource => resource.AllContents());
         }
 
         /// <summary>


### PR DESCRIPTION
## Summary

Fixes two related resource-lifecycle defects.

**#82 — `Resource.Contents` is never populated.** `Resource.Load` parsed the root
`EPackage` but never added it to `Contents`, so a loaded (or demand-loaded) resource
exposed nothing through `Contents`, and `ResourceSet.AllContents` was unimplemented.
`Load` now adds the parsed root package to `Contents` and is idempotent: a second
`Load` returns the already-parsed root package without re-parsing, so a
"register each file then load it" loop over a `ResourceSet` no longer duplicates
cache keys. `ResourceSet.AllContents` is implemented over the managed resources.

**#84 — `ResourceSet.CreateResource` registers duplicates.** Creating a resource for a
URI that was already demand-loaded (e.g. as a cross-file dependency of another model)
added a second `Resource` with the same URI, poisoning URI-based lookups
(`SingleOrDefault(x => x.URI == uri)`). `CreateResource` now returns the existing
resource for a known URI and guards against a null argument.

## Changes

- `ECoreNetto/Resource/Resource.cs` — `Load` populates `Contents` and is idempotent.
- `ECoreNetto/Resource/ResourceSet.cs` — `CreateResource` dedups by URI (with null
  guard); `AllContents` implemented.
- `ECoreNetto.Tests/Resource/ResourceLifecycleTestFixture.cs` — new fixture (5 tests):
  Contents population, demand-loaded resource exposes its root package via Contents,
  `AllContents`, `CreateResource` dedup, and the create-then-load-an-already-loaded
  pattern does not corrupt the set.

## Verification

Full solution test suite is green:

```
Passed! - ECoreNetto.Tests.dll: 79
Passed! - ECoreNetto.Extensions.Tests.dll: 30
Passed! - ECoreNetto.HandleBars.Tests.dll: 43
Passed! - ECoreNetto.Reporting.Tests.dll: 48
Passed! - ECoreNetto.Tools.Tests.dll: 42
```

Closes #82
Closes #84
