### PR TITLE
[Test] add positive eOpposite resolution regression tests; fixes #81

### DIFF
--- a/ECoreNetto.Tests/Resource/CapellaMetamodelTestFixture.cs
+++ b/ECoreNetto.Tests/Resource/CapellaMetamodelTestFixture.cs
@@ -84,6 +84,37 @@ namespace ECoreNetto.Tests.Resource
             });
         }
 
+        [Test]
+        public void Verify_that_a_cross_file_eOpposite_resolves_across_capella_files()
+        {
+            this.LoadCapellaMetamodel();
+
+            // LogicalArchitecture.ecore (package 'la') declares on class LogicalArchitecture:
+            //   <eStructuralFeatures name="allocatedSystemAnalyses"
+            //       eOpposite="ContextArchitecture.ecore#//SystemAnalysis/allocatingLogicalArchitectures"/>
+            // The opposite feature lives in ContextArchitecture.ecore (a different file).
+            var logicalArchitectureUri = new Uri(Path.Combine(this.capellaDirectory, "LogicalArchitecture.ecore"));
+            var logicalArchitectureResource = this.resourceSet.Resource(logicalArchitectureUri, false);
+            Assert.That(logicalArchitectureResource, Is.Not.Null);
+
+            var allocatedSystemAnalyses = logicalArchitectureResource!.AllContents()
+                .OfType<EReference>()
+                .Single(r => r.Name == "allocatedSystemAnalyses" && r.EContainingClass.Name == "LogicalArchitecture");
+
+            Assert.That(allocatedSystemAnalyses.EOpposite, Is.Not.Null, "the cross-file eOpposite did not resolve");
+            Assert.Multiple(() =>
+            {
+                Assert.That(allocatedSystemAnalyses.EOpposite!.Name, Is.EqualTo("allocatingLogicalArchitectures"));
+                Assert.That(allocatedSystemAnalyses.EOpposite!.EContainingClass.Name, Is.EqualTo("SystemAnalysis"));
+                // resolved into ContextArchitecture.ecore, a different file than the referring feature
+                Assert.That(
+                    Path.GetFileName(allocatedSystemAnalyses.EOpposite!.EResource.URI.LocalPath),
+                    Is.EqualTo("ContextArchitecture.ecore"));
+                // the opposite relation is symmetric
+                Assert.That(allocatedSystemAnalyses.EOpposite!.EOpposite, Is.SameAs(allocatedSystemAnalyses));
+            });
+        }
+
         /// <summary>
         /// Loads every <c>.ecore</c> file in the Capella test-data directory into <see cref="resourceSet"/>.
         /// Uses the demand-loading <see cref="ResourceSet.Resource(Uri, bool)"/> so files already pulled in

--- a/ECoreNetto.Tests/Resource/EOppositeResolutionTestFixture.cs
+++ b/ECoreNetto.Tests/Resource/EOppositeResolutionTestFixture.cs
@@ -1,0 +1,186 @@
+// ------------------------------------------------------------------------------------------------
+// <copyright file="EOppositeResolutionTestFixture.cs" company="Starion Group S.A.">
+//
+//   Copyright 2017-2026 Starion Group S.A.
+//   SPDX-License-Identifier: Apache-2.0
+//
+// </copyright>
+// ------------------------------------------------------------------------------------------------
+
+namespace ECoreNetto.Tests.Resource
+{
+    using System;
+    using System.IO;
+    using System.Linq;
+
+    using ECoreNetto.Resource;
+
+    using NUnit.Framework;
+
+    /// <summary>
+    /// Suite of tests that verify <c>eOpposite</c> references resolve to the correct <see cref="EReference"/>
+    /// regardless of parse order and across files (see issue #81). The crash described in that issue was
+    /// resolved by the file-name resource segment (#79) and the resolution-cycle guard (#80); these tests
+    /// positively assert that same-file (both directions), cross-file, and forward opposites resolve.
+    /// </summary>
+    [TestFixture]
+    public class EOppositeResolutionTestFixture
+    {
+        private ResourceSet resourceSet = null!;
+
+        [SetUp]
+        public void SetUp()
+        {
+            this.resourceSet = new ResourceSet();
+        }
+
+        [Test]
+        public void Verify_that_same_file_opposites_resolve_in_both_directions()
+        {
+            // class A (and its reference toB, whose opposite points at B/toA) is declared BEFORE class B,
+            // so toB -> B/toA is a forward reference at the point A is parsed
+            var body =
+                "<eClassifiers xsi:type=\"ecore:EClass\" name=\"A\">" +
+                "<eStructuralFeatures xsi:type=\"ecore:EReference\" name=\"toB\" eType=\"#//B\" eOpposite=\"#//B/toA\"/>" +
+                "</eClassifiers>" +
+                "<eClassifiers xsi:type=\"ecore:EClass\" name=\"B\">" +
+                "<eStructuralFeatures xsi:type=\"ecore:EReference\" name=\"toA\" eType=\"#//A\" eOpposite=\"#//A/toB\"/>" +
+                "</eClassifiers>";
+
+            var resource = this.CreateResourceForContent("same-file-opposite.ecore", Package("samefileopposite", body));
+            var root = resource.Load(null);
+
+            var toB = Reference(root, "A", "toB");
+            var toA = Reference(root, "B", "toA");
+
+            Assert.Multiple(() =>
+            {
+                Assert.That(toB.EOpposite, Is.SameAs(toA));
+                Assert.That(toA.EOpposite, Is.SameAs(toB));
+                // the opposite relation is symmetric
+                Assert.That(toB.EOpposite!.EOpposite, Is.SameAs(toB));
+            });
+        }
+
+        [Test]
+        public void Verify_that_a_cross_file_opposite_resolves_to_the_reference_in_the_sibling_resource()
+        {
+            WriteModel(
+                "cross-child.ecore",
+                Package(
+                    "crosschild",
+                    "<eClassifiers xsi:type=\"ecore:EClass\" name=\"B\">" +
+                    "<eStructuralFeatures xsi:type=\"ecore:EReference\" name=\"toA\" eType=\"cross-main.ecore#//A\" eOpposite=\"cross-main.ecore#//A/toB\"/>" +
+                    "</eClassifiers>"));
+
+            var main = this.CreateResourceForContent(
+                "cross-main.ecore",
+                Package(
+                    "crossmain",
+                    "<eClassifiers xsi:type=\"ecore:EClass\" name=\"A\">" +
+                    "<eStructuralFeatures xsi:type=\"ecore:EReference\" name=\"toB\" eType=\"cross-child.ecore#//B\" eOpposite=\"cross-child.ecore#//B/toA\"/>" +
+                    "</eClassifiers>"));
+
+            var root = main.Load(null);
+
+            var toB = Reference(root, "A", "toB");
+
+            Assert.That(toB.EOpposite, Is.Not.Null, "the cross-file opposite did not resolve");
+            Assert.Multiple(() =>
+            {
+                Assert.That(toB.EOpposite!.Name, Is.EqualTo("toA"));
+                Assert.That(toB.EOpposite!.EContainingClass.Name, Is.EqualTo("B"));
+                // the opposite lives in the demand-loaded sibling resource
+                Assert.That(Path.GetFileName(toB.EOpposite!.EResource.URI.LocalPath), Is.EqualTo("cross-child.ecore"));
+                // and the relation is symmetric back into this resource
+                Assert.That(toB.EOpposite!.EOpposite, Is.SameAs(toB));
+            });
+        }
+
+        [Test]
+        public void Verify_that_a_forward_cross_file_opposite_does_not_throw()
+        {
+            WriteModel(
+                "forward-child.ecore",
+                Package(
+                    "forwardchild",
+                    "<eClassifiers xsi:type=\"ecore:EClass\" name=\"B\">" +
+                    "<eStructuralFeatures xsi:type=\"ecore:EReference\" name=\"toA\" eType=\"forward-main.ecore#//A\" eOpposite=\"forward-main.ecore#//A/toB\"/>" +
+                    "</eClassifiers>"));
+
+            var mainUri = new Uri(Path.Combine(TestContext.CurrentContext.TestDirectory, "forward-main.ecore"));
+            WriteModel(
+                "forward-main.ecore",
+                Package(
+                    "forwardmain",
+                    "<eClassifiers xsi:type=\"ecore:EClass\" name=\"A\">" +
+                    "<eStructuralFeatures xsi:type=\"ecore:EReference\" name=\"toB\" eType=\"forward-child.ecore#//B\" eOpposite=\"forward-child.ecore#//B/toA\"/>" +
+                    "</eClassifiers>"));
+
+            // demand-loading main pulls in forward-child while resolving the forward cross-file opposite;
+            // this must not raise the IOException / StackOverflowException reported in issue #81
+            Assert.That(() => this.resourceSet.Resource(mainUri, true), Throws.Nothing);
+
+            Assert.Multiple(() =>
+            {
+                foreach (var resource in this.resourceSet.Resources)
+                {
+                    Assert.That(
+                        resource.Errors,
+                        Is.Empty,
+                        $"resource '{resource.URI}' recorded errors: {string.Join("; ", resource.Errors.Select(e => e.Message))}");
+                }
+            });
+        }
+
+        /// <summary>
+        /// Resolves the <see cref="EReference"/> named <paramref name="referenceName"/> on the class named
+        /// <paramref name="className"/> within the supplied root <see cref="EPackage"/>.
+        /// </summary>
+        private static EReference Reference(EPackage root, string className, string referenceName)
+        {
+            return root.EClassifiers
+                .OfType<EClass>()
+                .Single(c => c.Name == className)
+                .EStructuralFeatures
+                .OfType<EReference>()
+                .Single(r => r.Name == referenceName);
+        }
+
+        /// <summary>
+        /// Wraps the supplied classifier markup in a minimal Ecore package.
+        /// </summary>
+        private static string Package(string packageName, string body)
+        {
+            return
+                "<?xml version=\"1.0\" encoding=\"UTF-8\"?>\r\n" +
+                "<ecore:EPackage xmi:version=\"2.0\" xmlns:xmi=\"http://www.omg.org/XMI\" " +
+                "xmlns:xsi=\"http://www.w3.org/2001/XMLSchema-instance\" " +
+                "xmlns:ecore=\"http://www.eclipse.org/emf/2002/Ecore\" " +
+                $"name=\"{packageName}\" nsURI=\"{packageName}\" nsPrefix=\"{packageName}\">\r\n" +
+                $"  {body}\r\n" +
+                "</ecore:EPackage>";
+        }
+
+        /// <summary>
+        /// Writes the provided <paramref name="content"/> to a file in the test directory.
+        /// </summary>
+        private static void WriteModel(string fileName, string content)
+        {
+            File.WriteAllText(Path.Combine(TestContext.CurrentContext.TestDirectory, fileName), content);
+        }
+
+        /// <summary>
+        /// Writes the provided <paramref name="content"/> to a file in the test directory and
+        /// creates a <see cref="Resource"/> for it.
+        /// </summary>
+        private Resource CreateResourceForContent(string fileName, string content)
+        {
+            WriteModel(fileName, content);
+
+            var uri = new Uri(Path.Combine(TestContext.CurrentContext.TestDirectory, fileName));
+
+            return this.resourceSet.CreateResource(uri);
+        }
+    }
+}


### PR DESCRIPTION
## Summary

Fixes #81 by locking in `eOpposite` resolution with positive regression tests.

**The reported crash is already resolved.** Issue #81 (filed against 7.0.9) describes `eOpposite`
resolution building invalid `EStructuralFeature::<file>` URI fragments that crash with an `IOException`
(the `:` is illegal in a Windows file name) or a `StackOverflowException`, plus same-file opposites only
resolving when the target feature was parsed before the referrer. Two later fixes closed this:

- **#79** made the resource segment the actual `.ecore` **file name**, so the fragment delegated to the
  sibling resource hits that resource's cache.
- `GetEObject` strips the `EStructuralFeature::` prefix before locating the sibling resource, so it no
  longer treats `EStructuralFeature::<file>.ecore` as a file name.
- **#80**'s visited-set guard stops the unbounded recursion.
- Same-file opposites resolve regardless of parse order because deserialization is two-phase: the whole
  resource is cached in pass 1 before opposites are resolved in pass 2.

**The gap this PR closes:** there was no test that *positively* asserted an `eOpposite` resolves to the
correct `EReference` — only negative/guard tests. A regression could silently break or mis-resolve
opposites.

## Changes

- `ECoreNetto.Tests/Resource/EOppositeResolutionTestFixture.cs` — new fixture (3 tests):
  - same-file opposites resolve in both directions, including the forward-reference case, with symmetry
    (`toB.EOpposite.EOpposite == toB`);
  - a cross-file opposite resolves to the reference in the demand-loaded sibling resource (correct name,
    containing class, file, and symmetry);
  - a forward cross-file opposite loads with `Throws.Nothing` and no recorded `Errors` (guards against
    re-introducing the #81 crash).
- `ECoreNetto.Tests/Resource/CapellaMetamodelTestFixture.cs` — one positive cross-file assertion against
  the real Capella metamodel: `LogicalArchitecture/allocatedSystemAnalyses` ⟷
  `ContextArchitecture/allocatingLogicalArchitectures`.

No production code changes.

## Verification

Full solution test suite is green:

```
Passed! - ECoreNetto.Tests.dll: 85
Passed! - ECoreNetto.Extensions.Tests.dll: 30
Passed! - ECoreNetto.HandleBars.Tests.dll: 43
Passed! - ECoreNetto.Reporting.Tests.dll: 48
Passed! - ECoreNetto.Tools.Tests.dll: 42
```

Closes #81
