### PR TITLE
[Fix] resolve built-in Ecore types by exact key; fixes #83

### DIFF
--- a/ECoreNetto.Tests/Resource/EcoreBuiltInTypeResolutionTestFixture.cs
+++ b/ECoreNetto.Tests/Resource/EcoreBuiltInTypeResolutionTestFixture.cs
@@ -1,0 +1,97 @@
+// ------------------------------------------------------------------------------------------------
+// <copyright file="EcoreBuiltInTypeResolutionTestFixture.cs" company="Starion Group S.A.">
+//
+//   Copyright 2017-2026 Starion Group S.A.
+//   SPDX-License-Identifier: Apache-2.0
+//
+// </copyright>
+// ------------------------------------------------------------------------------------------------
+
+namespace ECoreNetto.Tests.Resource
+{
+    using ECoreNetto.Resource;
+
+    using NUnit.Framework;
+
+    /// <summary>
+    /// Suite of tests that verify <see cref="Resource.GetEObject(string)"/> resolves the built-in Ecore
+    /// types by exact key (see issue #83). References to those types appear either as the bare
+    /// <c>//EName</c> fragment or in the fully-qualified
+    /// <c>http://www.eclipse.org/emf/2002/Ecore#//EName</c> form; both must resolve to exactly the right
+    /// type without the substring-matching defects (misnamed <c>EBool</c> key, and
+    /// <c>Sequence contains more than one matching element</c> for prefix-overlapping names).
+    /// </summary>
+    [TestFixture]
+    public class EcoreBuiltInTypeResolutionTestFixture
+    {
+        private const string EcoreNamespacePrefix = "http://www.eclipse.org/emf/2002/Ecore#";
+
+        private Resource resource = null!;
+
+        [SetUp]
+        public void SetUp()
+        {
+            this.resource = new Resource();
+        }
+
+        [Test]
+        public void Verify_that_a_fully_qualified_EBoolean_reference_resolves_to_the_EBoolean_data_type()
+        {
+            // the Capella metamodel references 'Ecore#//EBoolean'; it must resolve to the EBoolean data type
+            // and not to a misnamed 'EBool' via substring matching
+            var resolved = this.resource.GetEObject($"{EcoreNamespacePrefix}//EBoolean");
+
+            Assert.That(resolved, Is.InstanceOf<EDataType>());
+            Assert.That(((EDataType)resolved!).Name, Is.EqualTo("EBoolean"));
+        }
+
+        [Test]
+        public void Verify_that_a_bare_fragment_reference_resolves_the_built_in_type()
+        {
+            var resolved = this.resource.GetEObject("//EString");
+
+            Assert.That(resolved, Is.InstanceOf<EDataType>());
+            Assert.That(((EDataType)resolved!).Name, Is.EqualTo("EString"));
+        }
+
+        [Test]
+        public void Verify_that_a_prefix_overlapping_reference_resolves_exactly_and_does_not_throw()
+        {
+            // '//EClassifier' contains '//EClass'; substring matching used to throw
+            // "Sequence contains more than one matching element"
+            EObject? resolved = null;
+
+            Assert.That(
+                () => resolved = this.resource.GetEObject($"{EcoreNamespacePrefix}//EClassifier"),
+                Throws.Nothing);
+
+            Assert.That(((EClass)resolved!).Name, Is.EqualTo("EClassifier"));
+        }
+
+        [Test]
+        public void Verify_that_EStringToStringMapEntry_resolves_exactly_and_not_to_EString()
+        {
+            // '//EStringToStringMapEntry' contains '//EString'; used to be ambiguous
+            EObject? resolved = null;
+
+            Assert.That(
+                () => resolved = this.resource.GetEObject($"{EcoreNamespacePrefix}//EStringToStringMapEntry"),
+                Throws.Nothing);
+
+            Assert.That(((EClass)resolved!).Name, Is.EqualTo("EStringToStringMapEntry"));
+        }
+
+        [Test]
+        public void Verify_that_EEnumLiteral_resolves_exactly_and_not_to_EEnum()
+        {
+            // '//EEnumLiteral' contains '//EEnum'; used to be ambiguous
+            EObject? resolved = null;
+
+            Assert.That(
+                () => resolved = this.resource.GetEObject($"{EcoreNamespacePrefix}//EEnumLiteral"),
+                Throws.Nothing);
+
+            Assert.That(((EClass)resolved!).Name, Is.EqualTo("EEnumLiteral"));
+        }
+    }
+}

--- a/ECoreNetto.Tests/Utils/EcoreObjectFactoryTestFixture.cs
+++ b/ECoreNetto.Tests/Utils/EcoreObjectFactoryTestFixture.cs
@@ -126,7 +126,7 @@ namespace ECoreNetto.Tests.Utils
             {
                 Assert.That(this.factory.EBigDecimal?.Name, Is.EqualTo("EBigDecimal"));
                 Assert.That(this.factory.EBigInteger?.Name, Is.EqualTo("EBigInteger"));
-                Assert.That(this.factory.EBool?.Name, Is.EqualTo("EBool"));
+                Assert.That(this.factory.EBoolean?.Name, Is.EqualTo("EBoolean"));
                 Assert.That(this.factory.EBooleanObject?.Name, Is.EqualTo("EBooleanObject"));
                 Assert.That(this.factory.EByte?.Name, Is.EqualTo("EByte"));
                 Assert.That(this.factory.EByteArray?.Name, Is.EqualTo("EByteArray"));

--- a/ECoreNetto/Resource/Resource.cs
+++ b/ECoreNetto/Resource/Resource.cs
@@ -77,6 +77,13 @@ namespace ECoreNetto.Resource
         private readonly Dictionary<string, EObject> eCoreTypes;
 
         /// <summary>
+        /// The namespace URI prefix under which the built-in Ecore types are referenced, i.e. the part that
+        /// precedes the <c>//EName</c> fragment in a fully-qualified reference such as
+        /// <c>http://www.eclipse.org/emf/2002/Ecore#//EString</c>.
+        /// </summary>
+        private const string EcoreNamespacePrefix = "http://www.eclipse.org/emf/2002/Ecore#";
+
+        /// <summary>
         /// Initializes a new instance of the <see cref="Resource"/> class.
         /// </summary>
         /// <param name="loggerFactory">
@@ -113,39 +120,39 @@ namespace ECoreNetto.Resource
                 { "//EGenericType", ecoreObjectFactory.EGenericType },
                 { "//ETypeParameter", ecoreObjectFactory.ETypeParameter },
                 
-                { "http://www.eclipse.org/emf/2002/Ecore#//EBigDecimal", ecoreObjectFactory.EBigDecimal},
-                { "http://www.eclipse.org/emf/2002/Ecore#//EBigInteger", ecoreObjectFactory.EBigInteger},
-                { "http://www.eclipse.org/emf/2002/Ecore#//EBool", ecoreObjectFactory.EBool},
-                { "http://www.eclipse.org/emf/2002/Ecore#//EBooleanObject", ecoreObjectFactory.EBooleanObject},
-                { "http://www.eclipse.org/emf/2002/Ecore#//EByte", ecoreObjectFactory.EByte},
-                { "http://www.eclipse.org/emf/2002/Ecore#//EByteArray", ecoreObjectFactory.EByteArray},
-                { "http://www.eclipse.org/emf/2002/Ecore#//EByteObject", ecoreObjectFactory.EByteObject},
-                { "http://www.eclipse.org/emf/2002/Ecore#//EChar", ecoreObjectFactory.EChar},
-                { "http://www.eclipse.org/emf/2002/Ecore#//ECharacterObject", ecoreObjectFactory.ECharacterObject},
-                { "http://www.eclipse.org/emf/2002/Ecore#//EDate", ecoreObjectFactory.EDate},
-                { "http://www.eclipse.org/emf/2002/Ecore#//EDiagnosticChain", ecoreObjectFactory.EDiagnosticChain},
-                { "http://www.eclipse.org/emf/2002/Ecore#//EDouble", ecoreObjectFactory.EDouble},
-                { "http://www.eclipse.org/emf/2002/Ecore#//EDoubleObject", ecoreObjectFactory.EDoubleObject},
-                { "http://www.eclipse.org/emf/2002/Ecore#//EEList", ecoreObjectFactory.EEList},
-                { "http://www.eclipse.org/emf/2002/Ecore#//EEnumerator", ecoreObjectFactory.EEnumerator},
-                { "http://www.eclipse.org/emf/2002/Ecore#//EFeatureMap", ecoreObjectFactory.EFeatureMap},
-                { "http://www.eclipse.org/emf/2002/Ecore#//EFeatureMapEntry", ecoreObjectFactory.EFeatureMapEntry},
-                { "http://www.eclipse.org/emf/2002/Ecore#//EFloat", ecoreObjectFactory.EFloat},
-                { "http://www.eclipse.org/emf/2002/Ecore#//EFloatObject", ecoreObjectFactory.EFloatObject},
-                { "http://www.eclipse.org/emf/2002/Ecore#//EInt", ecoreObjectFactory.EInt},
-                { "http://www.eclipse.org/emf/2002/Ecore#//EIntegerObject", ecoreObjectFactory.EIntegerObject},
-                { "http://www.eclipse.org/emf/2002/Ecore#//EJavaClass", ecoreObjectFactory.EJavaClass},
-                { "http://www.eclipse.org/emf/2002/Ecore#//EJavaObject", ecoreObjectFactory.EJavaObject},
-                { "http://www.eclipse.org/emf/2002/Ecore#//ELong", ecoreObjectFactory.ELong},
-                { "http://www.eclipse.org/emf/2002/Ecore#//ELongObject", ecoreObjectFactory.ELongObject},
-                { "http://www.eclipse.org/emf/2002/Ecore#//EMap", ecoreObjectFactory.EMap},
-                { "http://www.eclipse.org/emf/2002/Ecore#//EResource", ecoreObjectFactory.EResource},
-                { "http://www.eclipse.org/emf/2002/Ecore#//EResourceSet", ecoreObjectFactory.EResourceSet},
-                { "http://www.eclipse.org/emf/2002/Ecore#//EShort", ecoreObjectFactory.EShort},
-                { "http://www.eclipse.org/emf/2002/Ecore#//EShortObject", ecoreObjectFactory.EShortObject},
-                { "http://www.eclipse.org/emf/2002/Ecore#//EString", ecoreObjectFactory.EString},
-                { "http://www.eclipse.org/emf/2002/Ecore#//ETreeIterator", ecoreObjectFactory.ETreeIterator},
-                { "http://www.eclipse.org/emf/2002/Ecore#//EInvocationTargetException", ecoreObjectFactory.EInvocationTargetException}
+                { "//EBigDecimal", ecoreObjectFactory.EBigDecimal},
+                { "//EBigInteger", ecoreObjectFactory.EBigInteger},
+                { "//EBoolean", ecoreObjectFactory.EBoolean},
+                { "//EBooleanObject", ecoreObjectFactory.EBooleanObject},
+                { "//EByte", ecoreObjectFactory.EByte},
+                { "//EByteArray", ecoreObjectFactory.EByteArray},
+                { "//EByteObject", ecoreObjectFactory.EByteObject},
+                { "//EChar", ecoreObjectFactory.EChar},
+                { "//ECharacterObject", ecoreObjectFactory.ECharacterObject},
+                { "//EDate", ecoreObjectFactory.EDate},
+                { "//EDiagnosticChain", ecoreObjectFactory.EDiagnosticChain},
+                { "//EDouble", ecoreObjectFactory.EDouble},
+                { "//EDoubleObject", ecoreObjectFactory.EDoubleObject},
+                { "//EEList", ecoreObjectFactory.EEList},
+                { "//EEnumerator", ecoreObjectFactory.EEnumerator},
+                { "//EFeatureMap", ecoreObjectFactory.EFeatureMap},
+                { "//EFeatureMapEntry", ecoreObjectFactory.EFeatureMapEntry},
+                { "//EFloat", ecoreObjectFactory.EFloat},
+                { "//EFloatObject", ecoreObjectFactory.EFloatObject},
+                { "//EInt", ecoreObjectFactory.EInt},
+                { "//EIntegerObject", ecoreObjectFactory.EIntegerObject},
+                { "//EJavaClass", ecoreObjectFactory.EJavaClass},
+                { "//EJavaObject", ecoreObjectFactory.EJavaObject},
+                { "//ELong", ecoreObjectFactory.ELong},
+                { "//ELongObject", ecoreObjectFactory.ELongObject},
+                { "//EMap", ecoreObjectFactory.EMap},
+                { "//EResource", ecoreObjectFactory.EResource},
+                { "//EResourceSet", ecoreObjectFactory.EResourceSet},
+                { "//EShort", ecoreObjectFactory.EShort},
+                { "//EShortObject", ecoreObjectFactory.EShortObject},
+                { "//EString", ecoreObjectFactory.EString},
+                { "//ETreeIterator", ecoreObjectFactory.ETreeIterator},
+                { "//EInvocationTargetException", ecoreObjectFactory.EInvocationTargetException}
             };
 
             this.Cache = new Dictionary<string, EObject>();
@@ -309,12 +316,20 @@ namespace ECoreNetto.Resource
                 return @object;
             }
 
-            var ecoreType = this.eCoreTypes.SingleOrDefault(x => uriFragment.Contains(x.Key));
-            if (ecoreType.Value != null)
-            {
-                this.logger.LogTrace("EObject using Key: '{0}' found in found in ECore Types", ecoreType.Key);
+            // resolve a built-in Ecore type by exact key. References to these types appear either as the bare
+            // '//EName' fragment or in the fully-qualified 'http://www.eclipse.org/emf/2002/Ecore#//EName' form;
+            // normalize the latter to the bare fragment so a single exact lookup covers both. Substring matching
+            // would mis-resolve '//EBoolean' onto a '//EBool' key and throw on ambiguous prefixes such as
+            // '//EClass'/'//EClassifier' or '//EString'/'//EStringToStringMapEntry'.
+            var ecoreTypeKey = uriFragment.StartsWith(EcoreNamespacePrefix, StringComparison.Ordinal)
+                ? uriFragment.Substring(EcoreNamespacePrefix.Length)
+                : uriFragment;
 
-                return ecoreType.Value;
+            if (this.eCoreTypes.TryGetValue(ecoreTypeKey, out var ecoreType))
+            {
+                this.logger.LogTrace("EObject using Key: '{0}' found in ECore Types", ecoreTypeKey);
+
+                return ecoreType;
             }
 
             // load another resource

--- a/ECoreNetto/Resource/Resource.cs
+++ b/ECoreNetto/Resource/Resource.cs
@@ -316,11 +316,11 @@ namespace ECoreNetto.Resource
                 return @object;
             }
 
-            // resolve a built-in Ecore type by exact key. References to these types appear either as the bare
-            // '//EName' fragment or in the fully-qualified 'http://www.eclipse.org/emf/2002/Ecore#//EName' form;
-            // normalize the latter to the bare fragment so a single exact lookup covers both. Substring matching
-            // would mis-resolve '//EBoolean' onto a '//EBool' key and throw on ambiguous prefixes such as
-            // '//EClass'/'//EClassifier' or '//EString'/'//EStringToStringMapEntry'.
+            // resolve a built-in Ecore type by exact key. A reference to such a type is either a bare
+            // fragment (the type name preceded by a double slash) or the same fragment prefixed with the
+            // Ecore namespace URI. Stripping that namespace prefix lets one exact lookup cover both forms.
+            // The previous substring match mis-resolved the boolean type and threw on type names that share
+            // a prefix, for example EClass versus EClassifier, or EString versus EStringToStringMapEntry.
             var ecoreTypeKey = uriFragment.StartsWith(EcoreNamespacePrefix, StringComparison.Ordinal)
                 ? uriFragment.Substring(EcoreNamespacePrefix.Length)
                 : uriFragment;

--- a/ECoreNetto/Utils/EcoreObjectFactory.cs
+++ b/ECoreNetto/Utils/EcoreObjectFactory.cs
@@ -104,7 +104,7 @@ namespace ECoreNetto.Utils
 
             this.EBigDecimal = new EDataType(resource, loggerFactory) { Name = "EBigDecimal" };
             this.EBigInteger = new EDataType(resource, loggerFactory) { Name = "EBigInteger" };
-            this.EBool = new EDataType(resource, loggerFactory) { Name = "EBool"};
+            this.EBoolean = new EDataType(resource, loggerFactory) { Name = "EBoolean" };
             this.EBooleanObject = new EDataType(resource, loggerFactory) { Name = "EBooleanObject" };
             this.EByte = new EDataType(resource, loggerFactory) { Name = "EByte" };
             this.EByteArray = new EDataType(resource, loggerFactory) { Name = "EByteArray" };
@@ -250,9 +250,9 @@ namespace ECoreNetto.Utils
         public EDataType EBigInteger { get; private set; }
 
         /// <summary>
-        /// Gets the <see cref="EBool"/> instance
+        /// Gets the <see cref="EBoolean"/> instance
         /// </summary>
-        public EDataType EBool { get; private set; }
+        public EDataType EBoolean { get; private set; }
 
         /// <summary>
         /// Gets the <see cref="EBooleanObject"/> instance


### PR DESCRIPTION
## Summary

Fixes #83. `Resource.GetEObject` resolved built-in Ecore types with a **substring** test
(`uriFragment.Contains(key)`) over a dictionary whose datatype keys carried the full
`http://www.eclipse.org/emf/2002/Ecore#//EName` namespace. Two defects followed:

1. **Wrong-key hit / misnamed key.** The boolean datatype key was `…#//EBool`. A reference to
   `…#//EBoolean` (as the Capella metamodel uses) only resolved because `…#//EBool` is a *substring* of
   it — and it resolved to a data type whose `Name` was the misspelled `"EBool"`.
2. **Ambiguous matches throw.** For any pair where one key is a prefix of another (`//EClass`/`//EClassifier`,
   `//EString`/`//EStringToStringMapEntry`, `//EEnum`/`//EEnumLiteral`, `//EBool`/`//EBooleanObject`, …),
   a fragment containing the longer name matched both keys and `SingleOrDefault` threw
   `InvalidOperationException: Sequence contains more than one matching element`.

## Fix

- The lookup now **normalizes** the fragment (strips the `http://www.eclipse.org/emf/2002/Ecore#` prefix,
  leaving the bare `//EName`) and does an **exact** `TryGetValue`.
- The built-in datatype keys are stored in the same bare `//EName` form (previously fully-qualified), so a
  single exact lookup covers both the bare and fully-qualified reference styles.
- The misnamed `EBool` type is renamed to **`EBoolean`** — both the `EcoreObjectFactory` property and the
  `EDataType.Name`.

## Changes

- `ECoreNetto/Resource/Resource.cs` — normalize + exact-match lookup; `EcoreNamespacePrefix` constant;
  datatype keys stored as bare `//EName`.
- `ECoreNetto/Utils/EcoreObjectFactory.cs` — `EBool` → `EBoolean` (property + `Name`).
- `ECoreNetto.Tests/Resource/EcoreBuiltInTypeResolutionTestFixture.cs` — new fixture (5 tests): `EBoolean`
  resolves via fully-qualified and bare fragment; prefix-overlapping `EClassifier`,
  `EStringToStringMapEntry`, `EEnumLiteral` resolve exactly without throwing.
- `ECoreNetto.Tests/Utils/EcoreObjectFactoryTestFixture.cs` — updated the boolean name assertion.

## Verification

Full solution test suite is green:

```
Passed! - ECoreNetto.Tests.dll: 90
Passed! - ECoreNetto.Extensions.Tests.dll: 30
Passed! - ECoreNetto.HandleBars.Tests.dll: 43
Passed! - ECoreNetto.Reporting.Tests.dll: 48
Passed! - ECoreNetto.Tools.Tests.dll: 42
```

The Capella metamodel (`CapellaMetamodelTestFixture`) still loads without errors — now resolving
`Ecore#//EBoolean` by exact key rather than by accidental substring.

Closes #83
