### PR TITLE
[Feature] read Ecore generics (EGenericType/ETypeParameter) and operation exceptions; fixes #97

### DIFF
--- a/ECoreNetto.Tests/Resource/GenericTypeTestFixture.cs
+++ b/ECoreNetto.Tests/Resource/GenericTypeTestFixture.cs
@@ -1,0 +1,202 @@
+// ------------------------------------------------------------------------------------------------
+// <copyright file="GenericTypeTestFixture.cs" company="Starion Group S.A.">
+//
+//   Copyright 2017-2026 Starion Group S.A.
+//   SPDX-License-Identifier: Apache-2.0
+//
+// </copyright>
+// ------------------------------------------------------------------------------------------------
+
+namespace ECoreNetto.Tests.Resource
+{
+    using System;
+    using System.IO;
+    using System.Linq;
+
+    using ECoreNetto.Resource;
+
+    using NUnit.Framework;
+
+    /// <summary>
+    /// Suite of tests that verify Ecore generics (<see cref="EGenericType"/> / <see cref="ETypeParameter"/>)
+    /// and operation exceptions are read rather than silently dropped (see issue #97): type parameters and
+    /// their bounds, generic feature types, generic super types, generic exceptions, wildcard bounds, and
+    /// the derived erased <c>EType</c>/<c>ESuperTypes</c>/<c>EExceptions</c> views.
+    /// </summary>
+    [TestFixture]
+    public class GenericTypeTestFixture
+    {
+        private ResourceSet resourceSet = null!;
+        private EPackage root = null!;
+
+        [SetUp]
+        public void SetUp()
+        {
+            this.resourceSet = new ResourceSet();
+
+            var path = Path.Combine(TestContext.CurrentContext.TestDirectory, "generics.ecore");
+            File.WriteAllText(path, Model);
+
+            var resource = this.resourceSet.CreateResource(new Uri(path));
+            this.root = resource.Load(null);
+
+            Assert.That(
+                resource.Errors,
+                Is.Empty,
+                string.Join("; ", resource.Errors.Select(e => e.Message)));
+        }
+
+        [Test]
+        public void Verify_that_type_parameters_and_their_bounds_are_read()
+        {
+            var collection = this.Class("Collection");
+
+            Assert.That(collection.ETypeParameters, Has.Count.EqualTo(1));
+
+            var typeParameter = collection.ETypeParameters.Single();
+
+            Assert.Multiple(() =>
+            {
+                Assert.That(typeParameter.Name, Is.EqualTo("E"));
+                Assert.That(typeParameter.EBounds, Has.Count.EqualTo(1));
+                Assert.That(typeParameter.EBounds.Single().EClassifier, Is.SameAs(this.Class("Item")));
+            });
+        }
+
+        [Test]
+        public void Verify_that_a_generic_feature_type_and_its_type_parameter_argument_resolve()
+        {
+            var elements = this.Reference("Collection", "elements");
+            var typeParameter = this.Class("Collection").ETypeParameters.Single();
+
+            Assert.That(elements.EGenericType, Is.Not.Null);
+            Assert.Multiple(() =>
+            {
+                Assert.That(elements.EGenericType!.EClassifier, Is.SameAs(this.Class("Collection")));
+                // the erased EType is derived from the generic type's raw classifier
+                Assert.That(elements.EType, Is.SameAs(this.Class("Collection")));
+                Assert.That(elements.EGenericType!.ETypeArguments, Has.Count.EqualTo(1));
+                Assert.That(elements.EGenericType!.ETypeArguments.Single().ETypeParameter, Is.SameAs(typeParameter));
+            });
+        }
+
+        [Test]
+        public void Verify_that_wildcard_upper_and_lower_bounds_are_read()
+        {
+            var item = this.Class("Item");
+
+            var upper = this.Reference("Collection", "upperWild").EGenericType!.ETypeArguments.Single();
+            var lower = this.Reference("Collection", "lowerWild").EGenericType!.ETypeArguments.Single();
+
+            Assert.Multiple(() =>
+            {
+                Assert.That(upper.EUpperBound, Is.Not.Null);
+                Assert.That(upper.EUpperBound!.EClassifier, Is.SameAs(item));
+                Assert.That(lower.ELowerBound, Is.Not.Null);
+                Assert.That(lower.ELowerBound!.EClassifier, Is.SameAs(item));
+            });
+        }
+
+        [Test]
+        public void Verify_that_generic_super_types_resolve_and_feed_the_erased_super_type_view()
+        {
+            var itemCollection = this.Class("ItemCollection");
+            var collection = this.Class("Collection");
+
+            Assert.That(itemCollection.EGenericSuperTypes, Has.Count.EqualTo(1));
+
+            var genericSuperType = itemCollection.EGenericSuperTypes.Single();
+
+            Assert.Multiple(() =>
+            {
+                Assert.That(genericSuperType.EClassifier, Is.SameAs(collection));
+                Assert.That(genericSuperType.ETypeArguments.Single().EClassifier, Is.SameAs(this.Class("Item")));
+                // the raw class of the generic super type is added to the erased ESuperTypes view
+                Assert.That(itemCollection.ESuperTypes, Does.Contain(collection));
+            });
+        }
+
+        [Test]
+        public void Verify_that_operation_exceptions_are_read_from_both_the_attribute_and_generic_forms()
+        {
+            var notFound = this.Class("NotFound");
+
+            var findItems = this.Class("Collection").EOperations.Single(o => o.Name == "findItems");
+            var loadItems = this.Class("Collection").EOperations.Single(o => o.Name == "loadItems");
+
+            Assert.Multiple(() =>
+            {
+                // eExceptions attribute form
+                Assert.That(findItems.EExceptions, Does.Contain(notFound));
+                // eGenericExceptions element form, also surfaced through the erased EExceptions view
+                Assert.That(loadItems.EGenericExceptions.Single().EClassifier, Is.SameAs(notFound));
+                Assert.That(loadItems.EExceptions, Does.Contain(notFound));
+            });
+        }
+
+        [Test]
+        public void Verify_that_an_operation_type_parameter_is_read()
+        {
+            var transform = this.Class("Collection").EOperations.Single(o => o.Name == "transform");
+
+            Assert.That(transform.ETypeParameters, Has.Count.EqualTo(1));
+            Assert.That(transform.ETypeParameters.Single().Name, Is.EqualTo("R"));
+        }
+
+        private EClass Class(string name)
+        {
+            return this.root.EClassifiers.OfType<EClass>().Single(c => c.Name == name);
+        }
+
+        private EReference Reference(string className, string referenceName)
+        {
+            return this.Class(className).EStructuralFeatures.OfType<EReference>().Single(r => r.Name == referenceName);
+        }
+
+        private const string Model =
+            "<?xml version=\"1.0\" encoding=\"UTF-8\"?>\r\n" +
+            "<ecore:EPackage xmi:version=\"2.0\" xmlns:xmi=\"http://www.omg.org/XMI\" " +
+            "xmlns:xsi=\"http://www.w3.org/2001/XMLSchema-instance\" " +
+            "xmlns:ecore=\"http://www.eclipse.org/emf/2002/Ecore\" " +
+            "name=\"generics\" nsURI=\"generics\" nsPrefix=\"generics\">\r\n" +
+            "  <eClassifiers xsi:type=\"ecore:EClass\" name=\"Collection\">\r\n" +
+            "    <eTypeParameters name=\"E\">\r\n" +
+            "      <eBounds eClassifier=\"#//Item\"/>\r\n" +
+            "    </eTypeParameters>\r\n" +
+            "    <eStructuralFeatures xsi:type=\"ecore:EReference\" name=\"elements\" upperBound=\"-1\">\r\n" +
+            "      <eGenericType eClassifier=\"#//Collection\">\r\n" +
+            "        <eTypeArguments eTypeParameter=\"#//Collection/E\"/>\r\n" +
+            "      </eGenericType>\r\n" +
+            "    </eStructuralFeatures>\r\n" +
+            "    <eStructuralFeatures xsi:type=\"ecore:EReference\" name=\"upperWild\" upperBound=\"-1\">\r\n" +
+            "      <eGenericType eClassifier=\"#//Collection\">\r\n" +
+            "        <eTypeArguments>\r\n" +
+            "          <eUpperBound eClassifier=\"#//Item\"/>\r\n" +
+            "        </eTypeArguments>\r\n" +
+            "      </eGenericType>\r\n" +
+            "    </eStructuralFeatures>\r\n" +
+            "    <eStructuralFeatures xsi:type=\"ecore:EReference\" name=\"lowerWild\" upperBound=\"-1\">\r\n" +
+            "      <eGenericType eClassifier=\"#//Collection\">\r\n" +
+            "        <eTypeArguments>\r\n" +
+            "          <eLowerBound eClassifier=\"#//Item\"/>\r\n" +
+            "        </eTypeArguments>\r\n" +
+            "      </eGenericType>\r\n" +
+            "    </eStructuralFeatures>\r\n" +
+            "    <eOperations name=\"findItems\" eExceptions=\"#//NotFound\"/>\r\n" +
+            "    <eOperations name=\"loadItems\">\r\n" +
+            "      <eGenericExceptions eClassifier=\"#//NotFound\"/>\r\n" +
+            "    </eOperations>\r\n" +
+            "    <eOperations name=\"transform\">\r\n" +
+            "      <eTypeParameters name=\"R\"/>\r\n" +
+            "    </eOperations>\r\n" +
+            "  </eClassifiers>\r\n" +
+            "  <eClassifiers xsi:type=\"ecore:EClass\" name=\"Item\"/>\r\n" +
+            "  <eClassifiers xsi:type=\"ecore:EClass\" name=\"NotFound\"/>\r\n" +
+            "  <eClassifiers xsi:type=\"ecore:EClass\" name=\"ItemCollection\">\r\n" +
+            "    <eGenericSuperTypes eClassifier=\"#//Collection\">\r\n" +
+            "      <eTypeArguments eClassifier=\"#//Item\"/>\r\n" +
+            "    </eGenericSuperTypes>\r\n" +
+            "  </eClassifiers>\r\n" +
+            "</ecore:EPackage>";
+    }
+}

--- a/ECoreNetto/ModelElement/EGenericType.cs
+++ b/ECoreNetto/ModelElement/EGenericType.cs
@@ -1,0 +1,151 @@
+// ------------------------------------------------------------------------------------------------
+// <copyright file="EGenericType.cs" company="Starion Group S.A.">
+//
+//   Copyright 2017-2026 Starion Group S.A.
+//   SPDX-License-Identifier: Apache-2.0
+//
+// </copyright>
+// ------------------------------------------------------------------------------------------------
+
+namespace ECoreNetto
+{
+    using System;
+    using System.Xml;
+
+    using Microsoft.Extensions.Logging;
+    using Microsoft.Extensions.Logging.Abstractions;
+
+    /// <summary>
+    /// Represents a generic type reference (the Ecore <c>EGenericType</c> metaclass): a use of a
+    /// classifier or a type parameter, optionally parameterized with type arguments and/or constrained
+    /// by wildcard bounds.
+    /// </summary>
+    /// <remarks>
+    /// An <see cref="EGenericType"/> is not an <see cref="ENamedElement"/> and therefore is not registered
+    /// in the resource cache. Its cross-references are resolved during the second deserialization pass by
+    /// the containing element, which propagates <see cref="SetProperties"/> into it.
+    /// </remarks>
+    public class EGenericType : EObject
+    {
+        /// <summary>
+        /// The (injected) <see cref="ILoggerFactory"/> used to set up logging
+        /// </summary>
+        private readonly ILoggerFactory? loggerFactory;
+
+        /// <summary>
+        /// The <see cref="ILogger"/> used to log
+        /// </summary>
+        private readonly ILogger<EGenericType> logger;
+
+        /// <summary>
+        /// Initializes a new instance of the <see cref="EGenericType"/> class
+        /// </summary>
+        /// <param name="resource">
+        /// The <see cref="ECoreNetto.Resource.Resource"/> containing all instantiated <see cref="EObject"/>
+        /// </param>
+        /// <param name="loggerFactory">
+        /// The (injected) <see cref="ILoggerFactory"/> used to set up logging
+        /// </param>
+        public EGenericType(Resource.Resource resource, ILoggerFactory? loggerFactory = null) : base(resource, loggerFactory)
+        {
+            this.loggerFactory = loggerFactory;
+
+            this.logger = this.loggerFactory == null ? NullLogger<EGenericType>.Instance : this.loggerFactory.CreateLogger<EGenericType>();
+
+            this.ETypeArguments = new ContainerList<EGenericType>(this);
+        }
+
+        /// <summary>
+        /// Gets the referenced <see cref="EClassifier"/> (the raw type), or null when this is a
+        /// type-variable or unbounded-wildcard use.
+        /// </summary>
+        public EClassifier? EClassifier { get; private set; }
+
+        /// <summary>
+        /// Gets the referenced <see cref="ETypeParameter"/> when this generic type is a use of a type
+        /// variable, or null otherwise.
+        /// </summary>
+        public ETypeParameter? ETypeParameter { get; private set; }
+
+        /// <summary>
+        /// Gets the type arguments with which the <see cref="EClassifier"/> is parameterized.
+        /// </summary>
+        public ContainerList<EGenericType> ETypeArguments { get; }
+
+        /// <summary>
+        /// Gets the upper bound of this generic type (the <c>? extends X</c> part of a wildcard), or null.
+        /// </summary>
+        public EGenericType? EUpperBound { get; private set; }
+
+        /// <summary>
+        /// Gets the lower bound of this generic type (the <c>? super X</c> part of a wildcard), or null.
+        /// </summary>
+        public EGenericType? ELowerBound { get; private set; }
+
+        /// <summary>
+        /// Instantiate new <see cref="EGenericType"/> children from the current node of the <see cref="XmlNode"/>
+        /// </summary>
+        /// <param name="reader">
+        /// The <see cref="XmlNode"/>
+        /// </param>
+        protected override void DeserializeChildNode(XmlNode reader)
+        {
+            if (reader == null)
+            {
+                throw new ArgumentNullException(nameof(reader));
+            }
+
+            base.DeserializeChildNode(reader);
+
+            if (reader.NodeType != XmlNodeType.Element)
+            {
+                return;
+            }
+
+            switch (reader.Name)
+            {
+                case "eTypeArguments":
+                    var argument = new EGenericType(this.EResource, this.loggerFactory);
+                    this.ETypeArguments.Add(argument);
+                    argument.ReadXml(reader);
+                    break;
+                case "eUpperBound":
+                    this.EUpperBound = new EGenericType(this.EResource, this.loggerFactory) { EContainer = this };
+                    this.EUpperBound.ReadXml(reader);
+                    break;
+                case "eLowerBound":
+                    this.ELowerBound = new EGenericType(this.EResource, this.loggerFactory) { EContainer = this };
+                    this.ELowerBound.ReadXml(reader);
+                    break;
+            }
+        }
+
+        /// <summary>
+        /// Resolve the cross-references of this generic type and propagate to its nested generic types.
+        /// </summary>
+        internal override void SetProperties()
+        {
+            this.logger.LogTrace("setting properties of EGenericType");
+
+            if (this.Attributes.TryGetValue("eClassifier", out var output))
+            {
+                var parts = output.Split(' ');
+                this.EClassifier = this.EResource.GetEObject<EClassifier>(parts[parts.Length - 1]);
+            }
+
+            if (this.Attributes.TryGetValue("eTypeParameter", out output))
+            {
+                var parts = output.Split(' ');
+                this.ETypeParameter = this.EResource.GetEObject<ETypeParameter>(parts[parts.Length - 1]);
+            }
+
+            this.EUpperBound?.SetProperties();
+            this.ELowerBound?.SetProperties();
+
+            foreach (var argument in this.ETypeArguments)
+            {
+                argument.SetProperties();
+            }
+        }
+    }
+}

--- a/ECoreNetto/ModelElement/EObject.cs
+++ b/ECoreNetto/ModelElement/EObject.cs
@@ -468,7 +468,7 @@ namespace ECoreNetto
         /// The names of the reference attributes whose values may contain implicit references
         /// that need to be rewritten to point at the current top package.
         /// </summary>
-        private static readonly string[] ReferenceAttributes = { "eType", "eSuperTypes", "eOpposite" };
+        private static readonly string[] ReferenceAttributes = { "eType", "eSuperTypes", "eOpposite", "eClassifier", "eTypeParameter", "eExceptions" };
 
         /// <summary>
         /// Process the attribute value and rewrite if required.

--- a/ECoreNetto/ModelElement/NamedElement/Classifier/EClass.cs
+++ b/ECoreNetto/ModelElement/NamedElement/Classifier/EClass.cs
@@ -78,6 +78,7 @@ namespace ECoreNetto
             this.logger = this.loggerFactory == null ? NullLogger<EClass>.Instance : this.loggerFactory.CreateLogger<EClass>();
 
             this.ESuperTypes = new List<EClass>();
+            this.EGenericSuperTypes = new ContainerList<EGenericType>(this);
             this.EOperations = new ContainerList<EOperation>(this);
             this.EStructuralFeatures = new ContainerList<EStructuralFeature>(this);
         }
@@ -96,6 +97,16 @@ namespace ECoreNetto
         /// Gets the collection of super <see cref="EClass"/>
         /// </summary>
         public List<EClass> ESuperTypes { get; private set; }
+
+        /// <summary>
+        /// Gets the collection of generic super types of this <see cref="EClass"/> (super types expressed
+        /// generically, e.g. a parameterized super type).
+        /// </summary>
+        /// <remarks>
+        /// The raw <see cref="EClass"/> of each generic super type is also added to <see cref="ESuperTypes"/>,
+        /// so the erased super-type view remains complete.
+        /// </remarks>
+        public ContainerList<EGenericType> EGenericSuperTypes { get; private set; }
 
         /// <summary>
         /// Gets the collection of <see cref="EOperation"/>
@@ -186,6 +197,17 @@ namespace ECoreNetto
                     this.ESuperTypes.Add(this.EResource.GetEObject<EClass>(typeName));
                 }
             }
+
+            foreach (var genericSuperType in this.EGenericSuperTypes)
+            {
+                genericSuperType.SetProperties();
+
+                // keep the erased super-type view complete: add the raw class of each generic super type
+                if (genericSuperType.EClassifier is EClass superClass && !this.ESuperTypes.Contains(superClass))
+                {
+                    this.ESuperTypes.Add(superClass);
+                }
+            }
         }
 
         /// <summary>
@@ -230,6 +252,13 @@ namespace ECoreNetto
                 var ecoreOperation = new EOperation(this.EResource, this.loggerFactory);
                 this.EOperations.Add(ecoreOperation);
                 ecoreOperation.ReadXml(reader);
+            }
+
+            if (reader.Name == "eGenericSuperTypes" && reader.NodeType == XmlNodeType.Element)
+            {
+                var genericSuperType = new EGenericType(this.EResource, this.loggerFactory);
+                this.EGenericSuperTypes.Add(genericSuperType);
+                genericSuperType.ReadXml(reader);
             }
         }
     }

--- a/ECoreNetto/ModelElement/NamedElement/EClassifier.cs
+++ b/ECoreNetto/ModelElement/NamedElement/EClassifier.cs
@@ -20,7 +20,9 @@
 
 namespace ECoreNetto
 {
+    using System;
     using System.Collections.Generic;
+    using System.Xml;
 
     using Microsoft.Extensions.Logging;
     using Microsoft.Extensions.Logging.Abstractions;
@@ -30,6 +32,11 @@ namespace ECoreNetto
     /// </summary>
     public abstract class EClassifier : ENamedElement
     {
+        /// <summary>
+        /// The (injected) <see cref="ILoggerFactory"/> used to set up logging
+        /// </summary>
+        private readonly ILoggerFactory? loggerFactory;
+
         /// <summary>
         /// The <see cref="ILogger"/> used to log
         /// </summary>
@@ -46,13 +53,22 @@ namespace ECoreNetto
         /// </param>
         protected EClassifier(Resource.Resource resource, ILoggerFactory? loggerFactory = null) : base(resource, loggerFactory)
         {
+            this.loggerFactory = loggerFactory;
+
             this.logger = loggerFactory == null ? NullLogger<EClassifier>.Instance : loggerFactory.CreateLogger<EClassifier>();
+
+            this.ETypeParameters = new ContainerList<ETypeParameter>(this);
         }
 
         /// <summary>
         /// Gets the instance class name.
         /// </summary>
         public string? InstanceClassName { get; private set; }
+
+        /// <summary>
+        /// Gets the type parameters (type variables) declared by this <see cref="EClassifier"/>.
+        /// </summary>
+        public ContainerList<ETypeParameter> ETypeParameters { get; }
 
         /// <summary>
         /// Gets the containing <see cref="EPackage"/>
@@ -91,6 +107,30 @@ namespace ECoreNetto
             if (this.Attributes.TryGetValue("instanceClassName", out var output))
             {
                 this.InstanceClassName = output;
+            }
+        }
+
+        /// <summary>
+        /// Instantiate the type parameters declared by this <see cref="EClassifier"/> from the current node
+        /// of the <see cref="XmlNode"/>
+        /// </summary>
+        /// <param name="reader">
+        /// The <see cref="XmlNode"/>
+        /// </param>
+        protected override void DeserializeChildNode(XmlNode reader)
+        {
+            if (reader == null)
+            {
+                throw new ArgumentNullException(nameof(reader));
+            }
+
+            base.DeserializeChildNode(reader);
+
+            if (reader.Name == "eTypeParameters" && reader.NodeType == XmlNodeType.Element)
+            {
+                var typeParameter = new ETypeParameter(this.EResource, this.loggerFactory);
+                this.ETypeParameters.Add(typeParameter);
+                typeParameter.ReadXml(reader);
             }
         }
 

--- a/ECoreNetto/ModelElement/NamedElement/ETypeParameter.cs
+++ b/ECoreNetto/ModelElement/NamedElement/ETypeParameter.cs
@@ -1,0 +1,107 @@
+// ------------------------------------------------------------------------------------------------
+// <copyright file="ETypeParameter.cs" company="Starion Group S.A.">
+//
+//   Copyright 2017-2026 Starion Group S.A.
+//   SPDX-License-Identifier: Apache-2.0
+//
+// </copyright>
+// ------------------------------------------------------------------------------------------------
+
+namespace ECoreNetto
+{
+    using System;
+    using System.Xml;
+
+    using Microsoft.Extensions.Logging;
+    using Microsoft.Extensions.Logging.Abstractions;
+
+    /// <summary>
+    /// Represents a declared type parameter (type variable) of an <see cref="EClassifier"/> or
+    /// <see cref="EOperation"/> (the Ecore <c>ETypeParameter</c> metaclass), for example <c>E</c> in
+    /// <c>EEList&lt;E&gt;</c>.
+    /// </summary>
+    public class ETypeParameter : ENamedElement
+    {
+        /// <summary>
+        /// The (injected) <see cref="ILoggerFactory"/> used to set up logging
+        /// </summary>
+        private readonly ILoggerFactory? loggerFactory;
+
+        /// <summary>
+        /// The <see cref="ILogger"/> used to log
+        /// </summary>
+        private readonly ILogger<ETypeParameter> logger;
+
+        /// <summary>
+        /// Initializes a new instance of the <see cref="ETypeParameter"/> class
+        /// </summary>
+        /// <param name="resource">
+        /// The <see cref="ECoreNetto.Resource.Resource"/> containing all instantiated <see cref="EObject"/>
+        /// </param>
+        /// <param name="loggerFactory">
+        /// The (injected) <see cref="ILoggerFactory"/> used to set up logging
+        /// </param>
+        public ETypeParameter(Resource.Resource resource, ILoggerFactory? loggerFactory = null) : base(resource, loggerFactory)
+        {
+            this.loggerFactory = loggerFactory;
+
+            this.logger = this.loggerFactory == null ? NullLogger<ETypeParameter>.Instance : this.loggerFactory.CreateLogger<ETypeParameter>();
+
+            this.EBounds = new ContainerList<EGenericType>(this);
+        }
+
+        /// <summary>
+        /// Gets the bounds that constrain this type parameter (the <c>extends</c> constraints).
+        /// </summary>
+        public ContainerList<EGenericType> EBounds { get; }
+
+        /// <summary>
+        /// Instantiate new <see cref="EGenericType"/> bounds from the current node of the <see cref="XmlNode"/>
+        /// </summary>
+        /// <param name="reader">
+        /// The <see cref="XmlNode"/>
+        /// </param>
+        protected override void DeserializeChildNode(XmlNode reader)
+        {
+            if (reader == null)
+            {
+                throw new ArgumentNullException(nameof(reader));
+            }
+
+            base.DeserializeChildNode(reader);
+
+            if (reader.Name == "eBounds" && reader.NodeType == XmlNodeType.Element)
+            {
+                var bound = new EGenericType(this.EResource, this.loggerFactory);
+                this.EBounds.Add(bound);
+                bound.ReadXml(reader);
+            }
+        }
+
+        /// <summary>
+        /// Resolve the cross-references of this type parameter by propagating to its bounds.
+        /// </summary>
+        internal override void SetProperties()
+        {
+            this.logger.LogTrace("setting properties of ETypeParameter {0}:{1}", this.Identifier, this.Name);
+
+            base.SetProperties();
+
+            foreach (var bound in this.EBounds)
+            {
+                bound.SetProperties();
+            }
+        }
+
+        /// <summary>
+        /// Build the EModelElement.Identifier property
+        /// </summary>
+        /// <returns>
+        /// The identifier
+        /// </returns>
+        protected override string BuildIdentifier()
+        {
+            return $"{this.EContainer!.Identifier}/{this.Name}";
+        }
+    }
+}

--- a/ECoreNetto/ModelElement/NamedElement/ETypedElement.cs
+++ b/ECoreNetto/ModelElement/NamedElement/ETypedElement.cs
@@ -20,7 +20,9 @@
 
 namespace ECoreNetto
 {
+    using System;
     using System.Linq;
+    using System.Xml;
 
     using Microsoft.Extensions.Logging;
     using Microsoft.Extensions.Logging.Abstractions;
@@ -30,6 +32,11 @@ namespace ECoreNetto
     /// </summary>
     public abstract class ETypedElement : ENamedElement
     {
+        /// <summary>
+        /// The (injected) <see cref="ILoggerFactory"/> used to set up logging
+        /// </summary>
+        private readonly ILoggerFactory? loggerFactory;
+
         /// <summary>
         /// The <see cref="ILogger"/> used to log
         /// </summary>
@@ -46,6 +53,8 @@ namespace ECoreNetto
         /// </param>
         protected ETypedElement(Resource.Resource resource, ILoggerFactory? loggerFactory = null) : base(resource, loggerFactory)
         {
+            this.loggerFactory = loggerFactory;
+
             this.logger = loggerFactory == null ? NullLogger<ETypedElement>.Instance : loggerFactory.CreateLogger<ETypedElement>();
 
             // set the default value
@@ -93,6 +102,34 @@ namespace ECoreNetto
         public EClassifier? EType { get; private set; }
 
         /// <summary>
+        /// Gets the generic type of this <see cref="ETypedElement"/>, when the type is expressed generically
+        /// (e.g. a parameterized or type-variable type), or null otherwise.
+        /// </summary>
+        public EGenericType? EGenericType { get; private set; }
+
+        /// <summary>
+        /// Instantiate the generic type child of the current node of the <see cref="XmlNode"/>
+        /// </summary>
+        /// <param name="reader">
+        /// The <see cref="XmlNode"/>
+        /// </param>
+        protected override void DeserializeChildNode(XmlNode reader)
+        {
+            if (reader == null)
+            {
+                throw new ArgumentNullException(nameof(reader));
+            }
+
+            base.DeserializeChildNode(reader);
+
+            if (reader.Name == "eGenericType" && reader.NodeType == XmlNodeType.Element)
+            {
+                this.EGenericType = new EGenericType(this.EResource, this.loggerFactory) { EContainer = this };
+                this.EGenericType.ReadXml(reader);
+            }
+        }
+
+        /// <summary>
         /// Read the attributes of the current node
         /// </summary>
         internal override void SetProperties()
@@ -137,6 +174,15 @@ namespace ECoreNetto
                 var typeName = parts[parts.Length - 1];
 
                 this.EType = this.EResource.GetEObject<EClassifier>(typeName);
+            }
+
+            this.EGenericType?.SetProperties();
+
+            // when the type is expressed only generically, derive the erased EType from the generic type's
+            // raw classifier so consumers reading EType still see the type of a generically-typed element
+            if (this.EType == null && this.EGenericType?.EClassifier != null)
+            {
+                this.EType = this.EGenericType.EClassifier;
             }
         }
     }

--- a/ECoreNetto/ModelElement/NamedElement/TypedElement/EOperation.cs
+++ b/ECoreNetto/ModelElement/NamedElement/TypedElement/EOperation.cs
@@ -59,6 +59,8 @@ namespace ECoreNetto
 
             this.EParameters = new ContainerList<EParameter>(this);
             this.EExceptions = new List<EClassifier>();
+            this.ETypeParameters = new ContainerList<ETypeParameter>(this);
+            this.EGenericExceptions = new ContainerList<EGenericType>(this);
         }
 
         /// <summary>
@@ -70,6 +72,21 @@ namespace ECoreNetto
         /// Gets the exceptions that may be thrown by this <see cref="EOperation"/>
         /// </summary>
         public List<EClassifier> EExceptions { get; private set; }
+
+        /// <summary>
+        /// Gets the type parameters (type variables) declared by this <see cref="EOperation"/>.
+        /// </summary>
+        public ContainerList<ETypeParameter> ETypeParameters { get; private set; }
+
+        /// <summary>
+        /// Gets the generic exceptions that may be thrown by this <see cref="EOperation"/> (exceptions
+        /// expressed generically).
+        /// </summary>
+        /// <remarks>
+        /// The raw <see cref="EClassifier"/> of each generic exception is also added to
+        /// <see cref="EExceptions"/>, so the erased exception view remains complete.
+        /// </remarks>
+        public ContainerList<EGenericType> EGenericExceptions { get; private set; }
 
         /// <summary>
         /// Gets the containing <see cref="EClass"/>
@@ -88,6 +105,36 @@ namespace ECoreNetto
         public bool IsOverrideOf(EOperation someOperation)
         {
             throw new NotImplementedException();
+        }
+
+        /// <summary>
+        /// Read the attributes of the current node
+        /// </summary>
+        internal override void SetProperties()
+        {
+            this.logger.LogTrace("setting properties of EOperation {0}:{1}", this.Identifier, this.Name);
+
+            base.SetProperties();
+
+            if (this.Attributes.TryGetValue("eExceptions", out var output))
+            {
+                var exceptionNames = output.Split(' ');
+                foreach (var exceptionName in exceptionNames)
+                {
+                    this.EExceptions.Add(this.EResource.GetEObject<EClassifier>(exceptionName));
+                }
+            }
+
+            foreach (var genericException in this.EGenericExceptions)
+            {
+                genericException.SetProperties();
+
+                // keep the erased exception view complete: add the raw classifier of each generic exception
+                if (genericException.EClassifier != null && !this.EExceptions.Contains(genericException.EClassifier))
+                {
+                    this.EExceptions.Add(genericException.EClassifier);
+                }
+            }
         }
 
         /// <summary>
@@ -123,6 +170,20 @@ namespace ECoreNetto
                 var parameter = new EParameter(this.EResource, this.loggerFactory);
                 this.EParameters.Add(parameter);
                 parameter.ReadXml(reader);
+            }
+
+            if (reader.Name == "eTypeParameters" && reader.NodeType == XmlNodeType.Element)
+            {
+                var typeParameter = new ETypeParameter(this.EResource, this.loggerFactory);
+                this.ETypeParameters.Add(typeParameter);
+                typeParameter.ReadXml(reader);
+            }
+
+            if (reader.Name == "eGenericExceptions" && reader.NodeType == XmlNodeType.Element)
+            {
+                var genericException = new EGenericType(this.EResource, this.loggerFactory);
+                this.EGenericExceptions.Add(genericException);
+                genericException.ReadXml(reader);
             }
         }
     }


### PR DESCRIPTION
## Summary

Fixes #97. EcoreNetto silently dropped the Ecore **generics** facility, and `EOperation.EExceptions`
was declared but never populated — a model using bounded/parameterized types or operation exceptions
lost that information with no diagnostic. EMF's own `Ecore.ecore` uses generics, so EcoreNetto could
read it (post #96) but discarded the generic type information.

## What's added

Two new model classes and deserialization of every generic containment:

- **`EGenericType`** — `eClassifier`, `eTypeParameter`, `eTypeArguments`, `eUpperBound`, `eLowerBound`.
- **`ETypeParameter`** — `eBounds`.
- Containers wired up: `ETypedElement.eGenericType` (features/operations/parameters),
  `EClass.eGenericSuperTypes`, `EClassifier.eTypeParameters`, `EOperation.eTypeParameters`,
  `EOperation.eGenericExceptions`, and the `eExceptions` attribute.

## Design notes

- `EGenericType` is **not** an `ENamedElement`, so it is not registered in the resource cache and the
  second-pass loop never visits it directly. Its cross-references (`eClassifier`, `eTypeParameter`) are
  resolved by the containing element **propagating `SetProperties`** into it (the same pattern
  `EModelElement` uses for `EAnnotation`s); `EGenericType` recurses into its own nested generic types.
- `eClassifier`, `eTypeParameter` and `eExceptions` are added to the reference-attribute rewrite so
  implicit `#//` references get the resource segment prepended and resolve like `eType`/`eSuperTypes`.
- `ETypeParameter` is name-based (`<container>#//Class/E`), so type-variable references resolve by
  direct cache hit.
- **Erased views kept complete:** `EType` is derived from a generic type's raw classifier when the type
  is expressed only generically; generic super types also feed `ESuperTypes`; generic exceptions also
  feed `EExceptions`. So existing consumers of `EType`/`ESuperTypes`/`EExceptions` keep working.
- No existing identifiers or behaviour change — models without generics are unaffected.

## Changes

- New: `ECoreNetto/ModelElement/EGenericType.cs`, `ECoreNetto/ModelElement/NamedElement/ETypeParameter.cs`.
- Edited: `EObject.cs` (reference-attribute list), `ETypedElement.cs` (`eGenericType` + `EType`
  derivation), `EClassifier.cs` (`eTypeParameters`), `EClass.cs` (`eGenericSuperTypes` + `ESuperTypes`
  derivation), `EOperation.cs` (`EExceptions`, `eTypeParameters`, `eGenericExceptions`).
- New test: `ECoreNetto.Tests/Resource/GenericTypeTestFixture.cs` (6 tests).

## Verification

Full solution test suite is green:

```
Passed! - ECoreNetto.Tests.dll: 99
Passed! - ECoreNetto.Extensions.Tests.dll: 30
Passed! - ECoreNetto.HandleBars.Tests.dll: 43
Passed! - ECoreNetto.Reporting.Tests.dll: 48
Passed! - ECoreNetto.Tools.Tests.dll: 42
```

End-to-end: `ecoretools inspect -i <EMF>/model/Ecore.ecore` completes (exit 0) — EcoreNetto reads the
canonical Ecore metamodel, now including its `eTypeParameters`/`eGenericType`/`eTypeArguments`.

Closes #97
