### PR TITLE
[Fix] resolve references into the XMLType namespace; fixes #98

### DIFF
--- a/ECoreNetto.Tests/Resource/XmlTypeResolutionTestFixture.cs
+++ b/ECoreNetto.Tests/Resource/XmlTypeResolutionTestFixture.cs
@@ -1,0 +1,101 @@
+// ------------------------------------------------------------------------------------------------
+// <copyright file="XmlTypeResolutionTestFixture.cs" company="Starion Group S.A.">
+//
+//   Copyright 2017-2026 Starion Group S.A.
+//   SPDX-License-Identifier: Apache-2.0
+//
+// </copyright>
+// ------------------------------------------------------------------------------------------------
+
+namespace ECoreNetto.Tests.Resource
+{
+    using System;
+    using System.IO;
+    using System.Linq;
+
+    using ECoreNetto.Resource;
+
+    using NUnit.Framework;
+
+    /// <summary>
+    /// Suite of tests that verify references into the <c>http://www.eclipse.org/emf/2003/XMLType</c>
+    /// namespace resolve to their built-in data types without a backing file (see issue #98), the way EMF
+    /// resolves them through its package registry.
+    /// </summary>
+    [TestFixture]
+    public class XmlTypeResolutionTestFixture
+    {
+        private const string XmlTypeNamespace = "http://www.eclipse.org/emf/2003/XMLType";
+
+        private ResourceSet resourceSet = null!;
+
+        [SetUp]
+        public void SetUp()
+        {
+            this.resourceSet = new ResourceSet();
+        }
+
+        [TestCase("String")]
+        [TestCase("Int")]
+        [TestCase("Boolean")]
+        [TestCase("AnySimpleType")]
+        [TestCase("QName")]
+        [TestCase("Date")]
+        [TestCase("IDREFS")]
+        public void Verify_that_a_fully_qualified_XMLType_reference_resolves_to_the_data_type(string typeName)
+        {
+            var resource = new Resource();
+
+            var resolved = resource.GetEObject($"{XmlTypeNamespace}#//{typeName}");
+
+            Assert.That(resolved, Is.InstanceOf<EDataType>());
+            Assert.That(((EDataType)resolved!).Name, Is.EqualTo(typeName));
+        }
+
+        [Test]
+        public void Verify_that_a_model_referencing_XMLType_data_types_loads_and_resolves_the_attribute_type()
+        {
+            var path = Path.Combine(TestContext.CurrentContext.TestDirectory, "xmltype.ecore");
+            File.WriteAllText(path, Model);
+
+            var resource = this.resourceSet.CreateResource(new Uri(path));
+
+            EPackage root = null!;
+            Assert.That(() => root = resource.Load(null), Throws.Nothing);
+
+            Assert.That(resource.Errors, Is.Empty, string.Join("; ", resource.Errors.Select(e => e.Message)));
+
+            var value = root.EClassifiers
+                .OfType<EClass>()
+                .Single(c => c.Name == "Node")
+                .EStructuralFeatures
+                .OfType<EAttribute>()
+                .Single(a => a.Name == "value");
+
+            Assert.That(value.EType, Is.InstanceOf<EDataType>());
+            Assert.That(value.EType!.Name, Is.EqualTo("String"));
+        }
+
+        [Test]
+        public void Verify_that_an_unknown_XMLType_reference_does_not_resolve()
+        {
+            var resource = new Resource();
+
+            var resolved = resource.GetEObject($"{XmlTypeNamespace}#//NotARealType");
+
+            Assert.That(resolved, Is.Null);
+        }
+
+        private const string Model =
+            "<?xml version=\"1.0\" encoding=\"UTF-8\"?>\r\n" +
+            "<ecore:EPackage xmi:version=\"2.0\" xmlns:xmi=\"http://www.omg.org/XMI\" " +
+            "xmlns:xsi=\"http://www.w3.org/2001/XMLSchema-instance\" " +
+            "xmlns:ecore=\"http://www.eclipse.org/emf/2002/Ecore\" " +
+            "name=\"xmltype\" nsURI=\"xmltype\" nsPrefix=\"xmltype\">\r\n" +
+            "  <eClassifiers xsi:type=\"ecore:EClass\" name=\"Node\">\r\n" +
+            "    <eStructuralFeatures xsi:type=\"ecore:EAttribute\" name=\"value\" " +
+            "eType=\"ecore:EDataType http://www.eclipse.org/emf/2003/XMLType#//String\"/>\r\n" +
+            "  </eClassifiers>\r\n" +
+            "</ecore:EPackage>";
+    }
+}

--- a/ECoreNetto/Resource/Resource.cs
+++ b/ECoreNetto/Resource/Resource.cs
@@ -155,6 +155,14 @@ namespace ECoreNetto.Resource
                 { "//EInvocationTargetException", ecoreObjectFactory.EInvocationTargetException}
             };
 
+            // register the XMLType data types (keyed by their fully-qualified nsURI reference) so that
+            // references into the 'http://www.eclipse.org/emf/2003/XMLType' namespace resolve without a
+            // backing file, the way EMF resolves them through its package registry.
+            foreach (var xmlType in XmlTypeObjectFactory.CreateDataTypes(this, this.loggerFactory))
+            {
+                this.eCoreTypes.Add(xmlType.Key, xmlType.Value);
+            }
+
             this.Cache = new Dictionary<string, EObject>();
 
             this.isLoaded = false;

--- a/ECoreNetto/Utils/XmlTypeObjectFactory.cs
+++ b/ECoreNetto/Utils/XmlTypeObjectFactory.cs
@@ -1,0 +1,69 @@
+// ------------------------------------------------------------------------------------------------
+// <copyright file="XmlTypeObjectFactory.cs" company="Starion Group S.A.">
+//
+//   Copyright 2017-2026 Starion Group S.A.
+//   SPDX-License-Identifier: Apache-2.0
+//
+// </copyright>
+// ------------------------------------------------------------------------------------------------
+
+namespace ECoreNetto.Utils
+{
+    using System.Collections.Generic;
+
+    using ECoreNetto.Resource;
+
+    using Microsoft.Extensions.Logging;
+
+    /// <summary>
+    /// Instantiates the built-in <c>XMLType</c> data types (the Ecore mapping of the XML Schema simple
+    /// types) so that references into the <c>http://www.eclipse.org/emf/2003/XMLType</c> namespace resolve
+    /// without a backing file, mirroring how EMF's <c>EPackage.Registry</c> makes them resolvable.
+    /// </summary>
+    internal static class XmlTypeObjectFactory
+    {
+        /// <summary>
+        /// The namespace URI under which the <c>XMLType</c> data types are referenced.
+        /// </summary>
+        public const string NamespaceUri = "http://www.eclipse.org/emf/2003/XMLType";
+
+        /// <summary>
+        /// The names of the <c>XMLType</c> data types, taken verbatim from EMF's
+        /// <c>org.eclipse.emf.ecore.xml.type.impl.XMLTypePackageImpl</c>.
+        /// </summary>
+        private static readonly string[] DataTypeNames =
+        {
+            "AnySimpleType", "AnyURI", "Base64Binary", "Boolean", "BooleanObject", "Byte", "ByteObject",
+            "Date", "DateTime", "Decimal", "Double", "DoubleObject", "Duration", "ENTITIES", "ENTITIESBase",
+            "ENTITY", "Float", "FloatObject", "GDay", "GMonth", "GMonthDay", "GYear", "GYearMonth",
+            "HexBinary", "ID", "IDREF", "IDREFS", "IDREFSBase", "Int", "Integer", "IntObject", "Language",
+            "Long", "LongObject", "Name", "NCName", "NegativeInteger", "NMTOKEN", "NMTOKENS", "NMTOKENSBase",
+            "NonNegativeInteger", "NonPositiveInteger", "NormalizedString", "NOTATION", "PositiveInteger",
+            "QName", "Short", "ShortObject", "String", "Time", "Token", "UnsignedByte", "UnsignedByteObject",
+            "UnsignedInt", "UnsignedIntObject", "UnsignedLong", "UnsignedShort", "UnsignedShortObject"
+        };
+
+        /// <summary>
+        /// Creates the <c>XMLType</c> data types, each keyed by its fully-qualified reference
+        /// (<c>http://www.eclipse.org/emf/2003/XMLType#//&lt;Name&gt;</c>).
+        /// </summary>
+        /// <param name="resource">
+        /// The <see cref="Resource"/> that owns the created data types.
+        /// </param>
+        /// <param name="loggerFactory">
+        /// The (injected) <see cref="ILoggerFactory"/> used to set up logging.
+        /// </param>
+        /// <returns>
+        /// The keyed <c>XMLType</c> data types.
+        /// </returns>
+        public static IEnumerable<KeyValuePair<string, EObject>> CreateDataTypes(Resource resource, ILoggerFactory? loggerFactory)
+        {
+            foreach (var name in DataTypeNames)
+            {
+                yield return new KeyValuePair<string, EObject>(
+                    $"{NamespaceUri}#//{name}",
+                    new EDataType(resource, loggerFactory) { Name = name });
+            }
+        }
+    }
+}


### PR DESCRIPTION
## Summary

Fixes #98. EcoreNetto resolved built-in types only through the per-resource `eCoreTypes` dictionary,
which covered just the Ecore namespace. A reference into the **XMLType** namespace
(`http://www.eclipse.org/emf/2003/XMLType#//String`, `…#//Int`, `…#//AnySimpleType`, …) missed that
dictionary, fell into the file-resolution path of `Resource.GetEObject`, and failed
(`Path.HasExtension("…XMLType")` is false) — aborting the load of any otherwise-valid metamodel derived
from an XSD.

## Fix

Register the **58 XMLType data types** (names taken verbatim from EMF's `XMLTypePackageImpl`) in the
resource's built-in-type dictionary, keyed by their fully-qualified nsURI reference
(`http://www.eclipse.org/emf/2003/XMLType#//<Name>`).

No lookup change is needed: the exact-match resolution added in #83 normalizes only the Ecore
namespace prefix, so a non-Ecore fragment is looked up verbatim and now hits the registered XMLType
key. This mirrors how EMF resolves these types through its `EPackage.Registry` without a backing file.

## Changes

- `ECoreNetto/Utils/XmlTypeObjectFactory.cs` — new; creates the keyed XMLType data types.
- `ECoreNetto/Resource/Resource.cs` — register them in the constructor after the Ecore built-ins.
- `ECoreNetto.Tests/Resource/XmlTypeResolutionTestFixture.cs` — new (9 cases): a representative set of
  XMLType references resolve by fully-qualified fragment; a model whose attribute is typed
  `ecore:EDataType http://www.eclipse.org/emf/2003/XMLType#//String` loads with no errors and resolves
  its attribute type; an unknown XMLType name does not resolve.

Out of scope (noted for a possible follow-up): the four XMLType *structural* classes (`AnyType`,
`ProcessingInstruction`, `SimpleAnyType`, `XMLTypeDocumentRoot`) are not registered — they are rarely
used as attribute/reference types and modelling them properly (with their features) is a separate
effort. A pluggable per-`ResourceSet` package registry (issue's longer-term suggestion) is also left
for later.

## Verification

Full solution test suite is green:

```
Passed! - ECoreNetto.Tests.dll: 108
Passed! - ECoreNetto.Extensions.Tests.dll: 30
Passed! - ECoreNetto.HandleBars.Tests.dll: 43
Passed! - ECoreNetto.Reporting.Tests.dll: 48
Passed! - ECoreNetto.Tools.Tests.dll: 42
```

Closes #98
