### PR TITLE
[Feature] read eKeys/instanceTypeName/literal/annotation references and unwrap xmi:XMI (#99)

### DIFF
--- a/ECoreNetto.Tests/Resource/ReadingCompatibilityTestFixture.cs
+++ b/ECoreNetto.Tests/Resource/ReadingCompatibilityTestFixture.cs
@@ -1,0 +1,158 @@
+// ------------------------------------------------------------------------------------------------
+// <copyright file="ReadingCompatibilityTestFixture.cs" company="Starion Group S.A.">
+//
+//   Copyright 2017-2026 Starion Group S.A.
+//   SPDX-License-Identifier: Apache-2.0
+//
+// </copyright>
+// ------------------------------------------------------------------------------------------------
+
+namespace ECoreNetto.Tests.Resource
+{
+    using System;
+    using System.IO;
+    using System.Linq;
+
+    using ECoreNetto.Resource;
+
+    using NUnit.Framework;
+
+    /// <summary>
+    /// Suite of tests for the EMF reading-compatibility items of issue #99: the previously unread
+    /// features (<c>EReference.eKeys</c>, <c>EClassifier.instanceTypeName</c>, <c>EEnumLiteral.literal</c>,
+    /// <c>EAnnotation.references</c>) and unwrapping an <c>xmi:XMI</c> document root instead of returning a
+    /// silently empty package.
+    /// </summary>
+    [TestFixture]
+    public class ReadingCompatibilityTestFixture
+    {
+        private ResourceSet resourceSet = null!;
+
+        [SetUp]
+        public void SetUp()
+        {
+            this.resourceSet = new ResourceSet();
+        }
+
+        [Test]
+        public void Verify_that_eKeys_instanceTypeName_literal_and_annotation_references_are_read()
+        {
+            var root = this.Load("features.ecore", FeaturesModel);
+
+            var person = Class(root, "Person");
+            var ssn = person.EStructuralFeatures.OfType<EAttribute>().Single(a => a.Name == "ssn");
+            var manager = person.EStructuralFeatures.OfType<EReference>().Single(r => r.Name == "manager");
+            var idType = root.EClassifiers.OfType<EDataType>().Single(c => c.Name == "IdType");
+            var status = root.EClassifiers.OfType<EEnum>().Single(c => c.Name == "Status");
+            var annotated = Class(root, "Annotated");
+
+            Assert.Multiple(() =>
+            {
+                Assert.That(manager.EKeys, Does.Contain(ssn));
+                Assert.That(idType.InstanceTypeName, Is.EqualTo("java.lang.String"));
+                Assert.That(status.ELiterals.Single(l => l.Name == "ACTIVE").Literal, Is.EqualTo("active"));
+                Assert.That(annotated.EAnnotations.Single().References, Does.Contain(person));
+            });
+        }
+
+        [Test]
+        public void Verify_that_an_xmi_wrapped_single_package_is_unwrapped_and_read()
+        {
+            var root = this.Load("xmi-single.ecore", XmiWrappedSinglePackage);
+
+            Assert.Multiple(() =>
+            {
+                Assert.That(root.Name, Is.EqualTo("wrapped"));
+                Assert.That(root.EClassifiers.OfType<EClass>().Any(c => c.Name == "Widget"), Is.True);
+            });
+        }
+
+        [Test]
+        public void Verify_that_an_xmi_root_with_no_package_reports_a_clear_error()
+        {
+            var resource = this.CreateResource("xmi-empty.ecore", XmiWrappedNoPackage);
+
+            Assert.That(() => resource.Load(null), Throws.InstanceOf<InvalidOperationException>());
+            Assert.That(
+                resource.Errors.Select(e => e.Message),
+                Has.Some.Contains("no ecore:EPackage"));
+        }
+
+        [Test]
+        public void Verify_that_an_xmi_root_with_multiple_packages_reports_a_clear_error()
+        {
+            var resource = this.CreateResource("xmi-multi.ecore", XmiWrappedMultiplePackages);
+
+            Assert.That(() => resource.Load(null), Throws.InstanceOf<InvalidOperationException>());
+            Assert.That(
+                resource.Errors.Select(e => e.Message),
+                Has.Some.Contains("multiple root packages"));
+        }
+
+        private static EClass Class(EPackage root, string name)
+        {
+            return root.EClassifiers.OfType<EClass>().Single(c => c.Name == name);
+        }
+
+        private Resource CreateResource(string fileName, string content)
+        {
+            var path = Path.Combine(TestContext.CurrentContext.TestDirectory, fileName);
+            File.WriteAllText(path, content);
+
+            return this.resourceSet.CreateResource(new Uri(path));
+        }
+
+        private EPackage Load(string fileName, string content)
+        {
+            var resource = this.CreateResource(fileName, content);
+            var root = resource.Load(null);
+
+            Assert.That(resource.Errors, Is.Empty, string.Join("; ", resource.Errors.Select(e => e.Message)));
+
+            return root;
+        }
+
+        private const string FeaturesModel =
+            "<?xml version=\"1.0\" encoding=\"UTF-8\"?>\r\n" +
+            "<ecore:EPackage xmi:version=\"2.0\" xmlns:xmi=\"http://www.omg.org/XMI\" " +
+            "xmlns:xsi=\"http://www.w3.org/2001/XMLSchema-instance\" " +
+            "xmlns:ecore=\"http://www.eclipse.org/emf/2002/Ecore\" " +
+            "name=\"features\" nsURI=\"features\" nsPrefix=\"features\">\r\n" +
+            "  <eClassifiers xsi:type=\"ecore:EClass\" name=\"Person\">\r\n" +
+            "    <eStructuralFeatures xsi:type=\"ecore:EAttribute\" name=\"ssn\" eType=\"#//IdType\"/>\r\n" +
+            "    <eStructuralFeatures xsi:type=\"ecore:EReference\" name=\"manager\" eType=\"#//Person\" eKeys=\"#//Person/ssn\"/>\r\n" +
+            "  </eClassifiers>\r\n" +
+            "  <eClassifiers xsi:type=\"ecore:EDataType\" name=\"IdType\" instanceClassName=\"java.lang.String\" instanceTypeName=\"java.lang.String\"/>\r\n" +
+            "  <eClassifiers xsi:type=\"ecore:EEnum\" name=\"Status\">\r\n" +
+            "    <eLiterals name=\"ACTIVE\" value=\"0\" literal=\"active\"/>\r\n" +
+            "  </eClassifiers>\r\n" +
+            "  <eClassifiers xsi:type=\"ecore:EClass\" name=\"Annotated\">\r\n" +
+            "    <eAnnotations source=\"http://example.org/refs\" references=\"#//Person\"/>\r\n" +
+            "  </eClassifiers>\r\n" +
+            "</ecore:EPackage>";
+
+        private const string XmiHeader =
+            "<?xml version=\"1.0\" encoding=\"UTF-8\"?>\r\n" +
+            "<xmi:XMI xmi:version=\"2.0\" xmlns:xmi=\"http://www.omg.org/XMI\" " +
+            "xmlns:xsi=\"http://www.w3.org/2001/XMLSchema-instance\" " +
+            "xmlns:ecore=\"http://www.eclipse.org/emf/2002/Ecore\">\r\n";
+
+        private const string XmiWrappedSinglePackage =
+            XmiHeader +
+            "  <ecore:EPackage name=\"wrapped\" nsURI=\"wrapped\" nsPrefix=\"wrapped\">\r\n" +
+            "    <eClassifiers xsi:type=\"ecore:EClass\" name=\"Widget\"/>\r\n" +
+            "  </ecore:EPackage>\r\n" +
+            "</xmi:XMI>";
+
+        private const string XmiWrappedNoPackage =
+            XmiHeader +
+            "  <ecore:EAnnotation source=\"http://example.org\"/>\r\n" +
+            "</xmi:XMI>";
+
+        private const string XmiWrappedMultiplePackages =
+            XmiHeader +
+            "  <ecore:EPackage name=\"first\" nsURI=\"first\" nsPrefix=\"first\"/>\r\n" +
+            "  <ecore:EPackage name=\"second\" nsURI=\"second\" nsPrefix=\"second\"/>\r\n" +
+            "</xmi:XMI>";
+    }
+}

--- a/ECoreNetto/ECoreParser.cs
+++ b/ECoreNetto/ECoreParser.cs
@@ -20,6 +20,7 @@
 
 namespace ECoreNetto
 {
+    using System;
     using System.Diagnostics;
     using System.IO;
     using System.Linq;
@@ -125,9 +126,36 @@ namespace ECoreNetto
                 throw;
             }
 
+            // an .ecore document root is normally the ecore:EPackage itself, but some tools wrap it in an
+            // <xmi:XMI> element. Unwrap that so the root package is read rather than silently returning an
+            // empty, nameless package.
+            var rootElement = xmlDocument.DocumentElement;
+
+            if (rootElement.LocalName == "XMI")
+            {
+                var packageElements = rootElement.ChildNodes
+                    .OfType<XmlElement>()
+                    .Where(element => element.LocalName == "EPackage")
+                    .ToList();
+
+                if (packageElements.Count != 1)
+                {
+                    var message = packageElements.Count == 0
+                        ? $"The Ecore file '{fullPath}' has an XMI document root but contains no ecore:EPackage element."
+                        : $"The Ecore file '{fullPath}' has an XMI document root wrapping {packageElements.Count} ecore:EPackage elements; multiple root packages in a single resource are not supported.";
+
+                    this.resource.AddError(message);
+                    this.logger.LogError(message);
+
+                    throw new InvalidOperationException(message);
+                }
+
+                rootElement = packageElements[0];
+            }
+
             var package = new EPackage(this.resource, this.loggerFactory);
-            package.ReadXml(xmlDocument.DocumentElement);
-            
+            package.ReadXml(rootElement);
+
             foreach (var modelElement in this.resource.AllContents().ToArray())
             {
                 modelElement.SetProperties();

--- a/ECoreNetto/ModelElement/EAnnotation.cs
+++ b/ECoreNetto/ModelElement/EAnnotation.cs
@@ -51,6 +51,7 @@ namespace ECoreNetto
             this.logger = loggerFactory == null ? NullLogger<EAnnotation>.Instance : loggerFactory.CreateLogger<EAnnotation>();
 
             this.Details = new Dictionary<string, string>();
+            this.References = new List<EObject>();
         }
 
         /// <summary>
@@ -59,9 +60,15 @@ namespace ECoreNetto
         public string? Source { get; private set; }
 
         /// <summary>
-        /// Gets the 
+        /// Gets the
         /// </summary>
         public Dictionary<string, string> Details { get; private set; }
+
+        /// <summary>
+        /// Gets the <see cref="EObject"/>s referenced by this <see cref="EAnnotation"/> (the
+        /// <c>references</c> feature).
+        /// </summary>
+        public List<EObject> References { get; private set; }
 
         /// <summary>
         /// Gets the <see cref="EModelElement"/> that is annotated by the current <see cref="EAnnotation"/>
@@ -80,6 +87,18 @@ namespace ECoreNetto
             if (this.Attributes.TryGetValue("source", out var source))
             {
                 this.Source = source;
+            }
+
+            if (this.Attributes.TryGetValue("references", out var references))
+            {
+                foreach (var reference in references.Split(' '))
+                {
+                    var referenced = this.EResource.GetEObject(reference);
+                    if (referenced != null)
+                    {
+                        this.References.Add(referenced);
+                    }
+                }
             }
         }
 

--- a/ECoreNetto/ModelElement/EObject.cs
+++ b/ECoreNetto/ModelElement/EObject.cs
@@ -468,7 +468,7 @@ namespace ECoreNetto
         /// The names of the reference attributes whose values may contain implicit references
         /// that need to be rewritten to point at the current top package.
         /// </summary>
-        private static readonly string[] ReferenceAttributes = { "eType", "eSuperTypes", "eOpposite", "eClassifier", "eTypeParameter", "eExceptions" };
+        private static readonly string[] ReferenceAttributes = { "eType", "eSuperTypes", "eOpposite", "eClassifier", "eTypeParameter", "eExceptions", "eKeys", "references" };
 
         /// <summary>
         /// Process the attribute value and rewrite if required.

--- a/ECoreNetto/ModelElement/NamedElement/EClassifier.cs
+++ b/ECoreNetto/ModelElement/NamedElement/EClassifier.cs
@@ -66,6 +66,12 @@ namespace ECoreNetto
         public string? InstanceClassName { get; private set; }
 
         /// <summary>
+        /// Gets the instance type name (the <c>instanceTypeName</c> feature), which may include type
+        /// arguments and differs from <see cref="InstanceClassName"/> for parameterized instance types.
+        /// </summary>
+        public string? InstanceTypeName { get; private set; }
+
+        /// <summary>
         /// Gets the type parameters (type variables) declared by this <see cref="EClassifier"/>.
         /// </summary>
         public ContainerList<ETypeParameter> ETypeParameters { get; }
@@ -107,6 +113,11 @@ namespace ECoreNetto
             if (this.Attributes.TryGetValue("instanceClassName", out var output))
             {
                 this.InstanceClassName = output;
+            }
+
+            if (this.Attributes.TryGetValue("instanceTypeName", out output))
+            {
+                this.InstanceTypeName = output;
             }
         }
 

--- a/ECoreNetto/ModelElement/NamedElement/EEnumLiteral.cs
+++ b/ECoreNetto/ModelElement/NamedElement/EEnumLiteral.cs
@@ -53,9 +53,15 @@ namespace ECoreNetto
         public EEnum EEnum => (EEnum)this.EContainer!;
 
         /// <summary>
-        /// Gets or sets int value of an enumerator. 
+        /// Gets or sets int value of an enumerator.
         /// </summary>
         public int Value { get; private set; }
+
+        /// <summary>
+        /// Gets the literal string of this enumerator (the <c>literal</c> feature), i.e. the serialized
+        /// form, which may differ from the <see cref="ENamedElement.Name"/>.
+        /// </summary>
+        public string? Literal { get; private set; }
 
         /// <summary>
         /// The set properties.
@@ -69,6 +75,11 @@ namespace ECoreNetto
             if (this.Attributes.TryGetValue("value", out var output))
             {
                 this.Value = this.ParseInt32("value", output);
+            }
+
+            if (this.Attributes.TryGetValue("literal", out output))
+            {
+                this.Literal = output;
             }
         }
 

--- a/ECoreNetto/ModelElement/NamedElement/TypedElement/StructuralFeature/EReference.cs
+++ b/ECoreNetto/ModelElement/NamedElement/TypedElement/StructuralFeature/EReference.cs
@@ -20,6 +20,8 @@
 
 namespace ECoreNetto
 {
+    using System.Collections.Generic;
+
     using Microsoft.Extensions.Logging;
     using Microsoft.Extensions.Logging.Abstractions;
 
@@ -52,6 +54,7 @@ namespace ECoreNetto
             this.logger = loggerFactory == null ? NullLogger<EReference>.Instance : loggerFactory.CreateLogger<EReference>();
 
             this.IsResolveProxies = true;
+            this.EKeys = new List<EAttribute>();
         }
 
         /// <summary>
@@ -93,6 +96,12 @@ namespace ECoreNetto
         public EReference? EOpposite { get; private set; }
 
         /// <summary>
+        /// Gets the <see cref="EAttribute"/>s that act as the key of this reference (the <c>eKeys</c> feature),
+        /// used to identify a referenced object by value.
+        /// </summary>
+        public List<EAttribute> EKeys { get; private set; }
+
+        /// <summary>
         /// Read the attributes of the current node
         /// </summary>
         internal override void SetProperties()
@@ -120,6 +129,14 @@ namespace ECoreNetto
             {
                 var typeName = output;
                 this.EOpposite = this.EResource.GetEObject<EReference>($"EStructuralFeature::{typeName}");
+            }
+
+            if (this.Attributes.TryGetValue("eKeys", out output))
+            {
+                foreach (var keyName in output.Split(' '))
+                {
+                    this.EKeys.Add(this.EResource.GetEObject<EAttribute>($"EStructuralFeature::{keyName}"));
+                }
             }
         }
     }


### PR DESCRIPTION
## Summary

Addresses #99 — the high-value, low-risk part of the EMF reading-compatibility gaps (scope confirmed:
minor feature reads + `xmi:XMI` handling; the rare positional/ID fragment forms are left as follow-ups).

## What's added

**Previously-dropped serialized features now read:**
- `EReference.eKeys` — the key attributes of a reference (resolved like `eOpposite`).
- `EClassifier.instanceTypeName`.
- `EEnumLiteral.literal` — the serialized literal when it differs from the name.
- `EAnnotation.references` — the objects referenced by an annotation.

`eKeys` and `references` are added to the reference-attribute rewrite so implicit `#//` references get
the resource segment prepended and resolve.

**`xmi:XMI` document root unwrapping** (`ECoreParser.ParseXml`):
- A wrapper around a **single** `ecore:EPackage` is unwrapped and read normally. Previously an
  `<xmi:XMI>`-wrapped `.ecore` produced a **silently empty, nameless package** (the `<ecore:EPackage>`
  children matched none of `EPackage.DeserializeChildNode`'s cases).
- A wrapper with **no** or **multiple** `ecore:EPackage` elements now records a clear `Diagnostic` and
  throws, instead of silently losing content. (Full multi-root support is deferred — ECoreNetto's root
  package identifier scheme is single-root; a clear error is the honest interim behaviour the issue
  calls for.)

## Out of scope (noted on the issue)

- `@feature.N` positional fragments and bare `xmi:id` fragment resolution in `GetEObject` — rare in
  `.ecore` (EMF defaults to name-based fragments).
- `EAnnotation.contents` — arbitrary `EObject` containment needs dynamic-object support (a larger,
  separate effort).
- `name.N` disambiguation fragments **already resolve** since #96 (the disambiguated identifier is the
  cache key).

## Changes

- `EObject.cs` (`eKeys`/`references` added to the reference-attribute list), `EReference.cs` (`EKeys`),
  `EClassifier.cs` (`InstanceTypeName`), `EEnumLiteral.cs` (`Literal`), `EAnnotation.cs` (`References`),
  `ECoreParser.cs` (`xmi:XMI` unwrap + clear error).
- New test: `ECoreNetto.Tests/Resource/ReadingCompatibilityTestFixture.cs` (4 tests).

## Verification

Full solution test suite is green:

```
Passed! - ECoreNetto.Tests.dll: 112
Passed! - ECoreNetto.Extensions.Tests.dll: 30
Passed! - ECoreNetto.HandleBars.Tests.dll: 43
Passed! - ECoreNetto.Reporting.Tests.dll: 48
Passed! - ECoreNetto.Tools.Tests.dll: 42
```

Refs #99 (partial — leaves the deferred fragment forms and `EAnnotation.contents` for follow-ups).
