### PR TITLE
[Docs] Update Ecore version info and link Java reference implementation in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -93,7 +93,11 @@ Development | ![Build Status](https://github.com/STARIONGROUP/EcoreNetto/actions
 
 ## Ecore Documentation
 
-http://download.eclipse.org/modeling/emf/emf/javadoc/2.10.0/index.html?org/eclipse/emf/ecore/EObject.html
+ECoreNetto targets the **Ecore 2.0 metamodel** (namespace `http://www.eclipse.org/emf/2002/Ecore`), the core metamodel of the [Eclipse Modeling Framework (EMF)](https://eclipse.dev/emf/). This metamodel has been stable since EMF 2.0 and is the same one used by current EMF releases. The Java reference implementation is the `org.eclipse.emf.ecore` bundle maintained by the Eclipse Foundation; as of the EMF 2.46.0 distribution (December 2025) the `org.eclipse.emf.ecore` runtime is at version 2.42.0 and `org.eclipse.emf.ecore.xmi` at 2.40.0.
+
+- EMF project &amp; current documentation: https://eclipse.dev/emf/
+- Java reference implementation (Ecore source, `org.eclipse.emf.ecore`): https://github.com/eclipse-emf/org.eclipse.emf
+- Ecore API reference (EMF Javadoc, v2.10.0): https://download.eclipse.org/modeling/emf/emf/javadoc/2.10.0/index.html?org/eclipse/emf/ecore/EObject.html
 
 ## Software Bill of Materials (SBOM)
 


### PR DESCRIPTION
## Summary

Updates the **Ecore Documentation** section of the README with accurate version information and a link to the Java reference implementation.

The section previously contained only a bare, decade-old EMF Javadoc link (v2.10.0, from 2014). It now:

- States that ECoreNetto targets the **Ecore 2.0 metamodel** (`http://www.eclipse.org/emf/2002/Ecore`), which has been stable since EMF 2.0 — clarifying that the *metamodel* is versioned separately from the EMF *library*.
- Notes the current EMF reference implementation versions: `org.eclipse.emf.ecore` 2.42.0 and `org.eclipse.emf.ecore.xmi` 2.40.0, from the EMF 2.46.0 distribution (December 2025).
- Adds links to the [EMF project site](https://eclipse.dev/emf/) and the [`org.eclipse.emf.ecore` Java reference implementation source](https://github.com/eclipse-emf/org.eclipse.emf).
- Keeps the still-live v2.10.0 Javadoc link, now honestly labelled with its version.

## Notes

- Documentation-only change; no code, build, or test impact.
- `CLAUDE.md` contains the same stale `2.10.0` link inline; left unchanged in this PR (can follow up if desired).
