### PR TITLE
[Fix] Scope GitHub Actions write permissions to the build-test job (SonarCloud S8233)

### DIFF
--- a/.github/workflows/CodeQuality.yml
+++ b/.github/workflows/CodeQuality.yml
@@ -7,8 +7,6 @@ on:
 
 permissions:
   contents: read
-  checks: write          # dorny/test-reporter check run + annotations
-  pull-requests: write   # sticky coverage comment
 
 jobs:
   # SonarCloud analysis. Kept as a single instance on a single OS: running
@@ -61,6 +59,10 @@ jobs:
   # Needs no secrets, so it also produces signal on fork PRs (where SONAR_TOKEN is absent).
   build-test:
     name: Build & Test (${{ matrix.os }})
+    permissions:
+      contents: read
+      checks: write          # dorny/test-reporter check run + annotations
+      pull-requests: write   # sticky coverage comment
     strategy:
       fail-fast: false
       matrix:


### PR DESCRIPTION
## What

Resolves the 2 open SonarCloud **MAJOR** vulnerabilities (rule `githubactions:S8233`, "Move this write permission from workflow level to job level") on `.github/workflows/CodeQuality.yml`.

## Why

`checks: write` and `pull-requests: write` were declared at the **workflow** level, so every job in the workflow received them. Only the `build-test` job actually uses them:

- `checks: write` → `dorny/test-reporter`
- `pull-requests: write` → the sticky `code-coverage` comment (`marocchino/sticky-pull-request-comment`) and the coverage-summary steps

The `build` (SonarCloud) and `validate-tool` jobs only need read access — SonarCloud PR decoration is done via `SONAR_TOKEN`, not the GitHub token.

## Change

- Workflow-level `permissions` reduced to the read-only default `contents: read`.
- Added a job-level `permissions` block on **`build-test`** only (a job-level block overrides the workflow default, so `contents: read` is repeated for checkout):

```yaml
    permissions:
      contents: read
      checks: write          # dorny/test-reporter check run + annotations
      pull-requests: write   # sticky coverage comment
```

- `build` and `validate-tool` inherit the read-only default (all they need).

No CI behaviour changes: the test reporter check run and the sticky coverage comment still work because the scopes now live on the job that uses them.

## Verification

- YAML re-read; `build-test` has the three scopes, `build`/`validate-tool` have none.
- On this PR, confirm the dorny test-reporter check runs (both OS legs) and the sticky coverage comment posts — proving the moved scopes suffice — and that `build`/`validate-tool` succeed read-only.
- After this runs, the SonarCloud new-code `githubactions:S8233` count should drop from 2 → 0.
