### PR TITLE
[Feature] Resolve positional @feature.index and bare xmi:id URI fragments (#106)

### DIFF
--- a/ECoreNetto.Tests/Resource/PositionalAndIdFragmentTestFixture.cs
+++ b/ECoreNetto.Tests/Resource/PositionalAndIdFragmentTestFixture.cs
@@ -1,0 +1,263 @@
+// ------------------------------------------------------------------------------------------------
+// <copyright file="PositionalAndIdFragmentTestFixture.cs" company="Starion Group S.A.">
+//
+//   Copyright 2017-2026 Starion Group S.A.
+//   SPDX-License-Identifier: Apache-2.0
+//
+// </copyright>
+// ------------------------------------------------------------------------------------------------
+
+namespace ECoreNetto.Tests.Resource
+{
+    using System;
+    using System.IO;
+    using System.Linq;
+
+    using ECoreNetto.Resource;
+
+    using NUnit.Framework;
+
+    /// <summary>
+    /// Suite of tests for the EMF URI-fragment-resolution items of issue #106: positional
+    /// <c>//@feature.index</c> fragments (resolved by structural navigation) and bare <c>xmi:id</c>
+    /// fragments (resolved through an id-to-object map), both same-file and cross-file.
+    /// </summary>
+    [TestFixture]
+    public class PositionalAndIdFragmentTestFixture
+    {
+        private ResourceSet resourceSet = null!;
+
+        [SetUp]
+        public void SetUp()
+        {
+            this.resourceSet = new ResourceSet();
+        }
+
+        [Test]
+        public void Verify_that_same_file_positional_fragments_resolve()
+        {
+            var root = this.Load("positional.ecore", PositionalModel);
+
+            var alpha = Class(root, "Alpha");
+            var beta = Class(root, "Beta");
+            var text = root.EClassifiers.OfType<EDataType>().Single(c => c.Name == "Text");
+
+            var toBeta = alpha.EStructuralFeatures.OfType<EReference>().Single(r => r.Name == "toBeta");
+            var label = beta.EStructuralFeatures.OfType<EAttribute>().Single(a => a.Name == "label");
+
+            Assert.Multiple(() =>
+            {
+                // eType="#//@eClassifiers.1" -> the second classifier, Beta
+                Assert.That(toBeta.EType, Is.SameAs(beta));
+
+                // eType="#//@eClassifiers.2" -> the third classifier, the Text data type
+                Assert.That(label.EType, Is.SameAs(text));
+            });
+        }
+
+        [Test]
+        public void Verify_that_a_deep_positional_fragment_resolves_to_a_structural_feature()
+        {
+            var root = this.Load("positional.ecore", PositionalModel);
+            var resource = this.resourceSet.Resources.Single();
+
+            var toBeta = Class(root, "Alpha").EStructuralFeatures.Single(f => f.Name == "toBeta");
+
+            var resolved = resource.GetEObject("positional.ecore#//@eClassifiers.0/@eStructuralFeatures.0");
+
+            Assert.That(resolved, Is.SameAs(toBeta));
+        }
+
+        [Test]
+        public void Verify_that_out_of_range_and_unknown_positional_fragments_do_not_resolve()
+        {
+            this.Load("positional.ecore", PositionalModel);
+            var resource = this.resourceSet.Resources.Single();
+
+            Assert.Multiple(() =>
+            {
+                // index beyond the number of classifiers
+                Assert.That(resource.GetEObject("positional.ecore#//@eClassifiers.99"), Is.Null);
+
+                // a containment feature that Alpha does not have
+                Assert.That(resource.GetEObject("positional.ecore#//@eClassifiers.0/@eOperations.0"), Is.Null);
+
+                // an unknown containment feature name
+                Assert.That(resource.GetEObject("positional.ecore#//@eClassifiers.0/@bogus.0"), Is.Null);
+
+                // a navigation segment that is not of the '@feature.index' form
+                Assert.That(resource.GetEObject("positional.ecore#//@eClassifiers.0/plain"), Is.Null);
+
+                // an '@feature' segment without an index
+                Assert.That(resource.GetEObject("positional.ecore#//@eClassifiers"), Is.Null);
+
+                // an '@feature.index' segment with a non-numeric index
+                Assert.That(resource.GetEObject("positional.ecore#//@eClassifiers.x"), Is.Null);
+
+                // a name-based path that does not exist (structural navigation is only for '@' segments)
+                Assert.That(resource.GetEObject("positional.ecore#//NoSuchClass"), Is.Null);
+
+                // an empty in-document fragment
+                Assert.That(resource.GetEObject("positional.ecore#"), Is.Null);
+
+                // an unknown xmi:id
+                Assert.That(resource.GetEObject("#_missing"), Is.Null);
+            });
+        }
+
+        [Test]
+        public void Verify_that_positional_fragments_navigate_every_containment_feature()
+        {
+            this.Load("rich.ecore", RichModel);
+            var resource = this.resourceSet.Resources.Single();
+
+            EObject? Resolve(string fragment) => resource.GetEObject($"rich.ecore#{fragment}");
+
+            Assert.Multiple(() =>
+            {
+                Assert.That(((EPackage)Resolve("//@eSubpackages.0")!).Name, Is.EqualTo("sub"));
+                Assert.That(((EClass)Resolve("//@eSubpackages.0/@eClassifiers.0")!).Name, Is.EqualTo("InSub"));
+                Assert.That(Resolve("//@eClassifiers.0/@eAnnotations.0"), Is.InstanceOf<EAnnotation>());
+                Assert.That(((ETypeParameter)Resolve("//@eClassifiers.0/@eTypeParameters.0")!).Name, Is.EqualTo("T"));
+                Assert.That(Resolve("//@eClassifiers.0/@eTypeParameters.0/@eBounds.0"), Is.InstanceOf<EGenericType>());
+                Assert.That(((EOperation)Resolve("//@eClassifiers.0/@eOperations.0")!).Name, Is.EqualTo("doIt"));
+                Assert.That(((ETypeParameter)Resolve("//@eClassifiers.0/@eOperations.0/@eTypeParameters.0")!).Name, Is.EqualTo("U"));
+                Assert.That(((EParameter)Resolve("//@eClassifiers.0/@eOperations.0/@eParameters.0")!).Name, Is.EqualTo("arg"));
+                Assert.That(Resolve("//@eClassifiers.0/@eOperations.0/@eGenericExceptions.0"), Is.InstanceOf<EGenericType>());
+                Assert.That(Resolve("//@eClassifiers.1/@eGenericSuperTypes.0"), Is.InstanceOf<EGenericType>());
+                Assert.That(((EEnumLiteral)Resolve("//@eClassifiers.2/@eLiterals.0")!).Name, Is.EqualTo("RED"));
+            });
+        }
+
+        [Test]
+        public void Verify_that_a_same_file_xmi_id_fragment_resolves()
+        {
+            var root = this.Load("ids.ecore", XmiIdModel);
+
+            var node = Class(root, "Node");
+            var parent = node.EStructuralFeatures.OfType<EReference>().Single(r => r.Name == "parent");
+
+            // eType="#_node" is an intrinsic xmi:id reference; Node registers the id first, so a later
+            // duplicate xmi:id does not override it and the reference resolves back to Node
+            Assert.That(parent.EType, Is.SameAs(node));
+        }
+
+        [Test]
+        public void Verify_that_cross_file_positional_and_xmi_id_fragments_resolve()
+        {
+            // the target file must sit next to the source so the demand-load can find and load it; it is
+            // written to disk only (not pre-registered as a resource), mirroring real cross-file loading
+            WriteFile("target.ecore", TargetModel);
+            var root = this.Load("source.ecore", SourceModel);
+
+            var source = Class(root, "SourceClass");
+            var viaPosition = source.EStructuralFeatures.OfType<EReference>().Single(r => r.Name == "viaPosition");
+            var viaId = source.EStructuralFeatures.OfType<EReference>().Single(r => r.Name == "viaId");
+
+            Assert.Multiple(() =>
+            {
+                Assert.That(viaPosition.EType, Is.Not.Null);
+                Assert.That(viaPosition.EType!.Name, Is.EqualTo("TargetClass"));
+
+                // both forms address the same object in the target resource
+                Assert.That(viaId.EType, Is.SameAs(viaPosition.EType));
+            });
+        }
+
+        private static EClass Class(EPackage root, string name)
+        {
+            return root.EClassifiers.OfType<EClass>().Single(c => c.Name == name);
+        }
+
+        private static void WriteFile(string fileName, string content)
+        {
+            var path = Path.Combine(TestContext.CurrentContext.TestDirectory, fileName);
+            File.WriteAllText(path, content);
+        }
+
+        private Resource CreateResource(string fileName, string content)
+        {
+            var path = Path.Combine(TestContext.CurrentContext.TestDirectory, fileName);
+            File.WriteAllText(path, content);
+
+            return this.resourceSet.CreateResource(new Uri(path));
+        }
+
+        private EPackage Load(string fileName, string content)
+        {
+            var resource = this.CreateResource(fileName, content);
+            var root = resource.Load(null);
+
+            Assert.That(resource.Errors, Is.Empty, string.Join("; ", resource.Errors.Select(e => e.Message)));
+
+            return root;
+        }
+
+        private const string Header =
+            "<?xml version=\"1.0\" encoding=\"UTF-8\"?>\r\n" +
+            "<ecore:EPackage xmi:version=\"2.0\" xmlns:xmi=\"http://www.omg.org/XMI\" " +
+            "xmlns:xsi=\"http://www.w3.org/2001/XMLSchema-instance\" " +
+            "xmlns:ecore=\"http://www.eclipse.org/emf/2002/Ecore\" ";
+
+        private const string PositionalModel =
+            Header +
+            "name=\"positional\" nsURI=\"positional\" nsPrefix=\"positional\">\r\n" +
+            "  <eClassifiers xsi:type=\"ecore:EClass\" name=\"Alpha\">\r\n" +
+            "    <eStructuralFeatures xsi:type=\"ecore:EReference\" name=\"toBeta\" eType=\"#//@eClassifiers.1\"/>\r\n" +
+            "  </eClassifiers>\r\n" +
+            "  <eClassifiers xsi:type=\"ecore:EClass\" name=\"Beta\">\r\n" +
+            "    <eStructuralFeatures xsi:type=\"ecore:EAttribute\" name=\"label\" eType=\"#//@eClassifiers.2\"/>\r\n" +
+            "  </eClassifiers>\r\n" +
+            "  <eClassifiers xsi:type=\"ecore:EDataType\" name=\"Text\" instanceClassName=\"java.lang.String\"/>\r\n" +
+            "</ecore:EPackage>";
+
+        private const string RichModel =
+            Header +
+            "name=\"rich\" nsURI=\"rich\" nsPrefix=\"rich\">\r\n" +
+            "  <eSubpackages name=\"sub\" nsURI=\"sub\" nsPrefix=\"sub\">\r\n" +
+            "    <eClassifiers xsi:type=\"ecore:EClass\" name=\"InSub\"/>\r\n" +
+            "  </eSubpackages>\r\n" +
+            "  <eClassifiers xsi:type=\"ecore:EClass\" name=\"Container\">\r\n" +
+            "    <eAnnotations source=\"http://example.org/a\"/>\r\n" +
+            "    <eTypeParameters name=\"T\">\r\n" +
+            "      <eBounds eClassifier=\"#//Container\"/>\r\n" +
+            "    </eTypeParameters>\r\n" +
+            "    <eOperations name=\"doIt\">\r\n" +
+            "      <eTypeParameters name=\"U\"/>\r\n" +
+            "      <eParameters name=\"arg\" eType=\"#//Container\"/>\r\n" +
+            "      <eGenericExceptions eClassifier=\"#//Container\"/>\r\n" +
+            "    </eOperations>\r\n" +
+            "  </eClassifiers>\r\n" +
+            "  <eClassifiers xsi:type=\"ecore:EClass\" name=\"Derived\">\r\n" +
+            "    <eGenericSuperTypes eClassifier=\"#//Container\"/>\r\n" +
+            "  </eClassifiers>\r\n" +
+            "  <eClassifiers xsi:type=\"ecore:EEnum\" name=\"Color\">\r\n" +
+            "    <eLiterals name=\"RED\" value=\"0\"/>\r\n" +
+            "  </eClassifiers>\r\n" +
+            "</ecore:EPackage>";
+
+        private const string XmiIdModel =
+            Header +
+            "name=\"ids\" nsURI=\"ids\" nsPrefix=\"ids\">\r\n" +
+            "  <eClassifiers xsi:type=\"ecore:EClass\" name=\"Node\" xmi:id=\"_node\">\r\n" +
+            "    <eStructuralFeatures xsi:type=\"ecore:EReference\" name=\"parent\" eType=\"#_node\"/>\r\n" +
+            "  </eClassifiers>\r\n" +
+            "  <eClassifiers xsi:type=\"ecore:EClass\" name=\"Other\" xmi:id=\"_node\"/>\r\n" +
+            "</ecore:EPackage>";
+
+        private const string TargetModel =
+            Header +
+            "name=\"target\" nsURI=\"target\" nsPrefix=\"target\">\r\n" +
+            "  <eClassifiers xsi:type=\"ecore:EClass\" name=\"TargetClass\" xmi:id=\"_target\"/>\r\n" +
+            "</ecore:EPackage>";
+
+        private const string SourceModel =
+            Header +
+            "name=\"source\" nsURI=\"source\" nsPrefix=\"source\">\r\n" +
+            "  <eClassifiers xsi:type=\"ecore:EClass\" name=\"SourceClass\">\r\n" +
+            "    <eStructuralFeatures xsi:type=\"ecore:EReference\" name=\"viaPosition\" eType=\"target.ecore#//@eClassifiers.0\"/>\r\n" +
+            "    <eStructuralFeatures xsi:type=\"ecore:EReference\" name=\"viaId\" eType=\"target.ecore#_target\"/>\r\n" +
+            "  </eClassifiers>\r\n" +
+            "</ecore:EPackage>";
+    }
+}

--- a/ECoreNetto/ModelElement/EObject.cs
+++ b/ECoreNetto/ModelElement/EObject.cs
@@ -347,7 +347,21 @@ namespace ECoreNetto
         public virtual void ReadXml(XmlNode element)
         {
             this.SaveAttributes(element);
+            this.RegisterXmiId();
             this.ReadChildNodes(element);
+        }
+
+        /// <summary>
+        /// Registers this object in its <see cref="EResource"/> under its intrinsic <c>xmi:id</c>, when it
+        /// carries one, so that a reference of the bare <c>xmi:id</c> form (a URI fragment without a leading
+        /// slash, resolved by EMF through <c>getEObjectByID</c>) can be resolved to this object.
+        /// </summary>
+        private void RegisterXmiId()
+        {
+            if (this.Attributes.TryGetValue("xmi:id", out var id) && !string.IsNullOrEmpty(id))
+            {
+                this.EResource.RegisterEObjectId(id, this);
+            }
         }
 
         /// <summary>

--- a/ECoreNetto/Resource/Resource.cs
+++ b/ECoreNetto/Resource/Resource.cs
@@ -420,6 +420,36 @@ namespace ECoreNetto.Resource
         }
 
         /// <summary>
+        /// Resolves the given <paramref name="uriFragment"/> and returns it typed as <typeparamref name="T"/>.
+        /// </summary>
+        /// <typeparam name="T">
+        /// The expected <see cref="EObject"/> subtype of the resolved object.
+        /// </typeparam>
+        /// <param name="uriFragment">
+        /// the fragment to resolve.
+        /// </param>
+        /// <returns>
+        /// The resolved object, typed as <typeparamref name="T"/>.
+        /// </returns>
+        /// <exception cref="InvalidOperationException">
+        /// Thrown when the <paramref name="uriFragment"/> cannot be resolved, or resolves to an object
+        /// that is not a <typeparamref name="T"/>. The exception message names the offending fragment.
+        /// </exception>
+        public T GetEObject<T>(string uriFragment) where T : EObject
+        {
+            var eObject = this.GetEObject(uriFragment);
+
+            if (eObject is not T typedEObject)
+            {
+                throw new InvalidOperationException(
+                    $"The reference '{uriFragment}' could not be resolved to a '{typeof(T).Name}'; " +
+                    $"it resolved to '{(eObject == null ? "null (unresolved)" : eObject.GetType().Name)}'.");
+            }
+
+            return typedEObject;
+        }
+
+        /// <summary>
         /// Resolves an in-document URI fragment against this resource: a positional path of the
         /// <c>//@feature.index</c> form, or a bare <c>xmi:id</c>.
         /// </summary>
@@ -594,36 +624,6 @@ namespace ECoreNetto.Resource
                 default:
                     return null;
             }
-        }
-
-        /// <summary>
-        /// Resolves the given <paramref name="uriFragment"/> and returns it typed as <typeparamref name="T"/>.
-        /// </summary>
-        /// <typeparam name="T">
-        /// The expected <see cref="EObject"/> subtype of the resolved object.
-        /// </typeparam>
-        /// <param name="uriFragment">
-        /// the fragment to resolve.
-        /// </param>
-        /// <returns>
-        /// The resolved object, typed as <typeparamref name="T"/>.
-        /// </returns>
-        /// <exception cref="InvalidOperationException">
-        /// Thrown when the <paramref name="uriFragment"/> cannot be resolved, or resolves to an object
-        /// that is not a <typeparamref name="T"/>. The exception message names the offending fragment.
-        /// </exception>
-        public T GetEObject<T>(string uriFragment) where T : EObject
-        {
-            var eObject = this.GetEObject(uriFragment);
-
-            if (eObject is not T typedEObject)
-            {
-                throw new InvalidOperationException(
-                    $"The reference '{uriFragment}' could not be resolved to a '{typeof(T).Name}'; " +
-                    $"it resolved to '{(eObject == null ? "null (unresolved)" : eObject.GetType().Name)}'.");
-            }
-
-            return typedEObject;
         }
 
         /// <summary>

--- a/ECoreNetto/Resource/Resource.cs
+++ b/ECoreNetto/Resource/Resource.cs
@@ -66,6 +66,13 @@ namespace ECoreNetto.Resource
         private readonly Dictionary<string, EObject> eCoreTypes;
 
         /// <summary>
+        /// Maps the intrinsic <c>xmi:id</c> of an <see cref="EObject"/> to that object, populated while the
+        /// resource is read. It backs resolution of the bare <c>xmi:id</c> URI-fragment form (a fragment
+        /// without a leading slash), which EMF resolves through <c>getEObjectByID</c>.
+        /// </summary>
+        private readonly Dictionary<string, EObject> idToEObject;
+
+        /// <summary>
         /// The namespace URI prefix under which the built-in Ecore types are referenced, i.e. the part that
         /// precedes the <c>//EName</c> fragment in a fully-qualified reference such as
         /// <c>http://www.eclipse.org/emf/2002/Ecore#//EString</c>.
@@ -153,6 +160,7 @@ namespace ECoreNetto.Resource
             }
 
             this.Cache = new Dictionary<string, EObject>();
+            this.idToEObject = new Dictionary<string, EObject>();
 
             this.isLoaded = false;
 
@@ -342,13 +350,22 @@ namespace ECoreNetto.Resource
                 filePart = filePart.Substring(typePrefixIndex + 2);
             }
 
+            // the part after '#' is the in-document fragment: a name-based path ('//A/b'), a positional path
+            // ('//@eClassifiers.3'), or a bare xmi:id. When there is no '#', the whole value may itself be a
+            // bare xmi:id.
+            var inDocumentFragment = uriFragments.Length > 1 ? uriFragments[1] : filePart;
+
             if (!Path.HasExtension(filePart))
             {
-                // the fragment does not point at another resource file and was not found in this resource's
-                // cache or the known ECore types: it cannot be resolved.
-                this.logger.LogTrace("EObject using uri fragment '{0}' could not be resolved", uriFragment);
+                // the fragment does not point at another resource file: resolve a positional path or an
+                // xmi:id within this resource, otherwise it cannot be resolved.
+                var localResolved = this.ResolveInDocumentFragment(inDocumentFragment);
+                if (localResolved == null)
+                {
+                    this.logger.LogTrace("EObject using uri fragment '{0}' could not be resolved", uriFragment);
+                }
 
-                return null;
+                return localResolved;
             }
 
             // resolve the file part against the current resource URI (proper URI resolution handles escaped
@@ -378,6 +395,15 @@ namespace ECoreNetto.Resource
                 resource.Load(null);
             }
 
+            // a positional path or an xmi:id is resolved structurally within the owning resource. That owning
+            // resource is this resource itself for a same-file positional reference such as
+            // 'file.ecore#//@eClassifiers.3', which carries the file name after reference rewriting.
+            var withinResource = resource.ResolveInDocumentFragment(inDocumentFragment);
+            if (withinResource != null)
+            {
+                return withinResource;
+            }
+
             if (visitedResources.Contains(resource))
             {
                 // delegating to a resource already on the resolution path would repeat with the same
@@ -391,6 +417,183 @@ namespace ECoreNetto.Resource
             }
 
             return resource.GetEObject(uriFragment, visitedResources);
+        }
+
+        /// <summary>
+        /// Resolves an in-document URI fragment against this resource: a positional path of the
+        /// <c>//@feature.index</c> form, or a bare <c>xmi:id</c>.
+        /// </summary>
+        /// <param name="fragment">
+        /// The in-document fragment (the part after '#', or the whole value when there is no '#').
+        /// </param>
+        /// <returns>
+        /// The resolved <see cref="EObject"/>, or null when the fragment is not a positional path or a
+        /// known <c>xmi:id</c>. Pure name-based paths return null here because they are already resolved
+        /// through the identifier cache.
+        /// </returns>
+        private EObject? ResolveInDocumentFragment(string fragment)
+        {
+            if (string.IsNullOrEmpty(fragment))
+            {
+                return null;
+            }
+
+            if (fragment[0] == '/')
+            {
+                // a '/'-rooted path. Pure name paths are already covered by the identifier cache; only the
+                // positional '@feature.index' form needs structural navigation here.
+                return fragment.IndexOf('@') >= 0 ? this.ResolveStructuralFragment(fragment) : null;
+            }
+
+            // a fragment without a leading slash is an intrinsic xmi:id
+            return this.idToEObject.TryGetValue(fragment, out var byId) ? byId : null;
+        }
+
+        /// <summary>
+        /// Navigates a positional (structural) URI fragment such as
+        /// <c>//@eClassifiers.3/@eStructuralFeatures.1</c> from the root of this resource, indexing into the
+        /// containment feature named by each <c>@feature.index</c> segment. This mirrors EMF's
+        /// <c>eObjectForURIFragmentSegment</c>.
+        /// </summary>
+        /// <param name="fragment">
+        /// The positional path, starting with a leading slash.
+        /// </param>
+        /// <returns>
+        /// The resolved <see cref="EObject"/>, or null when the path does not address an existing object.
+        /// </returns>
+        private EObject? ResolveStructuralFragment(string fragment)
+        {
+            // 'fragment' has a leading slash: split yields an empty first element (before that slash), then the
+            // resource root-position segment, then the '@feature.index' navigation segments.
+            var parts = fragment.Split('/');
+            if (parts.Length < 2)
+            {
+                return null;
+            }
+
+            var rootSegment = parts[1];
+            if (rootSegment.Length != 0 && rootSegment != "0")
+            {
+                // a non-zero resource root position addresses a second root object; ECoreNetto resources are
+                // single-root, so this cannot be resolved.
+                return null;
+            }
+
+            var current = this.QueryRootObject();
+
+            for (var i = 2; i < parts.Length && current != null; i++)
+            {
+                current = NavigateContainmentSegment(current, parts[i]);
+            }
+
+            return current;
+        }
+
+        /// <summary>
+        /// Returns the root object of this resource, i.e. the object at position 0 of its contents.
+        /// </summary>
+        /// <returns>
+        /// The root <see cref="EObject"/>, or null when the resource has no contents.
+        /// </returns>
+        /// <remarks>
+        /// While the resource is still being loaded its <see cref="Contents"/> are not yet populated, so the
+        /// root is taken as the single cached object that has no container.
+        /// </remarks>
+        private EObject? QueryRootObject()
+        {
+            if (this.Contents.Count > 0)
+            {
+                return this.Contents[0];
+            }
+
+            return this.Cache.Values.FirstOrDefault(o => o.EContainer == null);
+        }
+
+        /// <summary>
+        /// Resolves a single positional navigation segment of the <c>@feature.index</c> form against the
+        /// given owner, returning the child at that index of the named containment feature.
+        /// </summary>
+        /// <param name="owner">
+        /// The object the segment is navigated from.
+        /// </param>
+        /// <param name="segment">
+        /// The <c>@feature.index</c> segment.
+        /// </param>
+        /// <returns>
+        /// The addressed child, or null when the segment is malformed, names an unknown containment feature,
+        /// or the index is out of range.
+        /// </returns>
+        private static EObject? NavigateContainmentSegment(EObject owner, string segment)
+        {
+            if (segment.Length == 0 || segment[0] != '@')
+            {
+                return null;
+            }
+
+            var body = segment.Substring(1);
+            var separator = body.LastIndexOf('.');
+            if (separator < 0)
+            {
+                return null;
+            }
+
+            var featureName = body.Substring(0, separator);
+            if (!int.TryParse(body.Substring(separator + 1), out var index) || index < 0)
+            {
+                return null;
+            }
+
+            var containment = QueryContainmentList(owner, featureName);
+            if (containment == null || index >= containment.Count)
+            {
+                return null;
+            }
+
+            return containment[index];
+        }
+
+        /// <summary>
+        /// Returns the ordered containment list of <paramref name="owner"/> for the containment feature named
+        /// <paramref name="featureName"/>, or null when the owner has no such containment feature.
+        /// </summary>
+        /// <param name="owner">
+        /// The object whose containment feature is requested.
+        /// </param>
+        /// <param name="featureName">
+        /// The Ecore name of the containment feature (e.g. <c>eClassifiers</c>, <c>eStructuralFeatures</c>).
+        /// </param>
+        /// <returns>
+        /// The containment list, or null.
+        /// </returns>
+        private static IReadOnlyList<EObject>? QueryContainmentList(EObject owner, string featureName)
+        {
+            switch (featureName)
+            {
+                case "eAnnotations":
+                    return (owner as EModelElement)?.EAnnotations;
+                case "eSubpackages":
+                    return (owner as EPackage)?.ESubPackages;
+                case "eClassifiers":
+                    return (owner as EPackage)?.EClassifiers;
+                case "eStructuralFeatures":
+                    return (owner as EClass)?.EStructuralFeatures;
+                case "eOperations":
+                    return (owner as EClass)?.EOperations;
+                case "eGenericSuperTypes":
+                    return (owner as EClass)?.EGenericSuperTypes;
+                case "eLiterals":
+                    return (owner as EEnum)?.ELiterals;
+                case "eParameters":
+                    return (owner as EOperation)?.EParameters;
+                case "eGenericExceptions":
+                    return (owner as EOperation)?.EGenericExceptions;
+                case "eTypeParameters":
+                    return (owner as EClassifier)?.ETypeParameters ?? (owner as EOperation)?.ETypeParameters;
+                case "eBounds":
+                    return (owner as ETypeParameter)?.EBounds;
+                default:
+                    return null;
+            }
         }
 
         /// <summary>
@@ -535,6 +738,28 @@ namespace ECoreNetto.Resource
         internal void AddError(string message)
         {
             this.errors.Add(new Diagnostic(0, 0, this.URI?.AbsoluteUri ?? string.Empty, message));
+        }
+
+        /// <summary>
+        /// Registers the given <see cref="EObject"/> under its intrinsic <c>xmi:id</c> so that a bare
+        /// <c>xmi:id</c> URI fragment can be resolved to it.
+        /// </summary>
+        /// <param name="id">
+        /// The <c>xmi:id</c> value carried by <paramref name="eObject"/>.
+        /// </param>
+        /// <param name="eObject">
+        /// The object to register.
+        /// </param>
+        /// <remarks>
+        /// The first registration for a given <paramref name="id"/> wins. A duplicate <c>xmi:id</c> is
+        /// invalid, but recording it must not abort the load, so later duplicates are ignored.
+        /// </remarks>
+        internal void RegisterEObjectId(string id, EObject eObject)
+        {
+            if (!this.idToEObject.ContainsKey(id))
+            {
+                this.idToEObject.Add(id, eObject);
+            }
         }
 
         /// <summary>


### PR DESCRIPTION
## What

Closes #106. Adds the two EMF URI-fragment-resolution forms that `Resource.GetEObject` did not previously support:

1. **Positional `@feature.index` fragments** — e.g. `#//@eClassifiers.3/@eStructuralFeatures.1`. Resolved by structural navigation from the resource root, indexing into the containment feature named by each segment (mirrors EMF's `eObjectForURIFragmentSegment`). Works same-file and cross-file.
2. **Bare `xmi:id` fragments** — a fragment without a leading slash (e.g. `#_node`), which EMF resolves via `getEObjectByID`. Any element carrying an `xmi:id` is now recorded in a per-resource id→object map during `ReadXml`, and consulted when the fragment is not a `/`-rooted path.

(The name-based `name.N` disambiguation form already resolved since #96, since the disambiguated identifier is the cache key.)

## How

- **`EObject.ReadXml`** now calls a small `RegisterXmiId()` after saving attributes: if the element has an `xmi:id`, it registers itself with the resource. Covers named and unnamed (`EGenericType`) objects alike.
- **`Resource`** gains an `idToEObject` map + `RegisterEObjectId` (first-writer-wins; a duplicate `xmi:id` is invalid but must not abort the load).
- **`Resource.GetEObject`** tail is restructured: after the cache and built-in-type lookups miss, it computes the in-document fragment and delegates to a new `ResolveInDocumentFragment`:
  - `/`-rooted **and** contains `@` → `ResolveStructuralFragment` (positional navigation).
  - `/`-rooted, no `@` → returns null (pure name paths are already covered by the identifier cache).
  - otherwise → `xmi:id` lookup.
  This runs for the owning resource, which is *this* resource for a same-file positional reference (rewritten to `file.ecore#//@…`) and a sibling for cross-file references. It is evaluated before the cross-resource delegation, so it never trips the cycle guard.
- Structural navigation maps each `@feature` name to the owning object's containment list (`eClassifiers`, `eSubpackages`, `eStructuralFeatures`, `eOperations`, `eGenericSuperTypes`, `eLiterals`, `eParameters`, `eGenericExceptions`, `eTypeParameters`, `eBounds`, `eAnnotations`) and indexes into it.

No existing behaviour changes: name-based and file-delegated resolution paths are unchanged; the new paths only fire on fragments that previously returned null.

## Tests

New `ECoreNetto.Tests/Resource/PositionalAndIdFragmentTestFixture.cs` (6 tests, synthetic models):
- same-file positional `eType` references;
- a deep positional path resolving to a structural feature via `GetEObject`;
- a comprehensive test navigating **every** supported containment feature;
- same-file `xmi:id` (including the duplicate-id first-wins case);
- cross-file positional **and** `xmi:id`;
- negatives: out-of-range index, unknown/missing feature, non-`@` segment, `@feature` without index, non-numeric index, missing name path, empty fragment, unknown `xmi:id`.

Full solution builds with 0 warnings; entire suite green (281 tests, +6).

## Scope

Splits from #106 as agreed; `EAnnotation.contents` (needs a dynamic `EObject`) remains tracked separately in #109.
