### PR TITLE
[Feature] Bring the HTML report generator to parity with uml4net

### DIFF
--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -16,6 +16,7 @@
     <PackageVersion Include="Microsoft.Extensions.Hosting" Version="10.0.9" />
     <PackageVersion Include="Microsoft.Extensions.Http" Version="10.0.9" />
     <PackageVersion Include="Microsoft.Extensions.Logging.Abstractions" Version="6.0.0" />
+    <PackageVersion Include="Microsoft.Msagl" Version="1.1.6" />
     <PackageVersion Include="Microsoft.NET.Test.Sdk" Version="18.6.0" />
     <PackageVersion Include="Microsoft.Sbom.Targets" Version="4.1.5" />
     <PackageVersion Include="Microsoft.SourceLink.GitHub" Version="10.0.300" />
@@ -28,6 +29,7 @@
     <PackageVersion Include="Serilog.Sinks.Console" Version="6.1.1" />
     <PackageVersion Include="Serilog.Sinks.File" Version="7.0.0" />
     <PackageVersion Include="Spectre.Console" Version="0.57.0" />
+    <PackageVersion Include="Svg" Version="3.4.7" />
     <PackageVersion Include="System.CommandLine" Version="2.0.9" />
     <PackageVersion Include="System.IO.Packaging" Version="10.0.9" />
   </ItemGroup>

--- a/ECoreNetto.Extensions.Tests/AnchorExtensionsTestFixture.cs
+++ b/ECoreNetto.Extensions.Tests/AnchorExtensionsTestFixture.cs
@@ -1,0 +1,63 @@
+// ------------------------------------------------------------------------------------------------
+// <copyright file="AnchorExtensionsTestFixture.cs" company="Starion Group S.A.">
+//
+//   Copyright 2017-2026 Starion Group S.A.
+//   SPDX-License-Identifier: Apache-2.0
+//
+// </copyright>
+// ------------------------------------------------------------------------------------------------
+
+namespace ECoreNetto.Extensions.Tests
+{
+    using System.IO;
+    using System.Linq;
+
+    using ECoreNetto.Extensions;
+    using ECoreNetto.Resource;
+
+    using NUnit.Framework;
+
+    /// <summary>
+    /// Suite of tests for the <see cref="AnchorExtensions"/> class
+    /// </summary>
+    [TestFixture]
+    public class AnchorExtensionsTestFixture
+    {
+        private EPackage rootPackage = null!;
+
+        [SetUp]
+        public void SetUp()
+        {
+            var path = Path.Combine(TestContext.CurrentContext.TestDirectory, "Data", "recipe.ecore");
+            var uri = new System.Uri(Path.GetFullPath(path));
+
+            var resourceSet = new ResourceSet();
+            var resource = resourceSet.CreateResource(uri);
+
+            this.rootPackage = resource.Load(null);
+        }
+
+        [Test]
+        public void Verify_that_QueryAnchorId_returns_a_sanitized_slug()
+        {
+            var recipe = this.rootPackage.EClassifiers.OfType<EClass>().Single(x => x.Name == "Recipe");
+
+            var anchor = recipe.QueryAnchorId();
+
+            Assert.Multiple(() =>
+            {
+                // the slug contains only URL-safe characters and ends with the class name
+                Assert.That(anchor, Does.Match("^[A-Za-z0-9-]+$"));
+                Assert.That(anchor, Does.EndWith("Recipe"));
+            });
+        }
+
+        [Test]
+        public void Verify_that_QueryAnchorId_throws_when_argument_is_null()
+        {
+            EObject? eObject = null;
+
+            Assert.That(() => eObject!.QueryAnchorId(), Throws.ArgumentNullException);
+        }
+    }
+}

--- a/ECoreNetto.Extensions.Tests/ClassExtensionsFeaturesTestFixture.cs
+++ b/ECoreNetto.Extensions.Tests/ClassExtensionsFeaturesTestFixture.cs
@@ -1,0 +1,128 @@
+// ------------------------------------------------------------------------------------------------
+// <copyright file="ClassExtensionsFeaturesTestFixture.cs" company="Starion Group S.A.">
+//
+//   Copyright 2017-2026 Starion Group S.A.
+//   SPDX-License-Identifier: Apache-2.0
+//
+// </copyright>
+// ------------------------------------------------------------------------------------------------
+
+namespace ECoreNetto.Extensions.Tests
+{
+    using System.Collections.Generic;
+    using System.IO;
+    using System.Linq;
+
+    using ECoreNetto.Extensions;
+    using ECoreNetto.Resource;
+
+    using NUnit.Framework;
+
+    /// <summary>
+    /// Suite of tests for the report-parity extension methods on <see cref="ClassExtensions"/> that are
+    /// exercised against the feature-rich synthetic model.
+    /// </summary>
+    [TestFixture]
+    public class ClassExtensionsFeaturesTestFixture
+    {
+        private EPackage rootPackage = null!;
+        private List<EClass> allClasses = null!;
+
+        [SetUp]
+        public void SetUp()
+        {
+            var path = Path.Combine(TestContext.CurrentContext.TestDirectory, "Data", "report-features.ecore");
+            var uri = new System.Uri(Path.GetFullPath(path));
+
+            var resourceSet = new ResourceSet();
+            var resource = resourceSet.CreateResource(uri);
+
+            this.rootPackage = resource.Load(null);
+            this.allClasses = this.rootPackage.EClassifiers.OfType<EClass>().ToList();
+        }
+
+        [Test]
+        public void Verify_that_QueryContainers_returns_the_containing_classes()
+        {
+            var address = this.allClasses.Single(x => x.Name == "Address");
+
+            var containers = address.QueryContainers(this.allClasses).ToList();
+
+            // Person owns a containment reference (addresses) whose type is Address
+            Assert.That(containers.Select(x => x.Name), Is.EquivalentTo(new[] { "Person" }));
+        }
+
+        [Test]
+        public void Verify_that_QueryContainers_returns_empty_when_no_containment_reference_targets_the_class()
+        {
+            var company = this.allClasses.Single(x => x.Name == "Company");
+
+            var containers = company.QueryContainers(this.allClasses);
+
+            Assert.That(containers, Is.Empty);
+        }
+
+        [Test]
+        public void Verify_that_QueryContainers_throws_when_argument_is_null()
+        {
+            EClass? @class = null;
+
+            Assert.That(() => @class!.QueryContainers(this.allClasses), Throws.ArgumentNullException);
+        }
+
+        [Test]
+        public void Verify_that_QueryAllDescendantSpecializations_returns_all_subclasses()
+        {
+            var describable = this.allClasses.Single(x => x.Name == "Describable");
+
+            var descendants = describable.QueryAllDescendantSpecializations(this.allClasses).ToList();
+
+            Assert.That(descendants.Select(x => x.Name), Is.EquivalentTo(new[] { "Person" }));
+        }
+
+        [Test]
+        public void Verify_that_QueryAllDescendantSpecializations_throws_when_argument_is_null()
+        {
+            EClass? @class = null;
+
+            Assert.That(() => @class!.QueryAllDescendantSpecializations(this.allClasses), Throws.ArgumentNullException);
+        }
+
+        [Test]
+        public void Verify_that_QueryConstraints_reads_the_constraint_and_its_ocl_body()
+        {
+            var person = this.allClasses.Single(x => x.Name == "Person");
+
+            var constraints = person.QueryConstraints().ToList();
+
+            Assert.That(constraints, Has.Count.EqualTo(1));
+
+            var constraint = constraints.Single();
+
+            Assert.Multiple(() =>
+            {
+                Assert.That(constraint.Name, Is.EqualTo("hasFullName"));
+                Assert.That(constraint.Language, Is.EqualTo("OCL"));
+                Assert.That(constraint.Body, Is.EqualTo("self.fullName.notEmpty()"));
+            });
+        }
+
+        [Test]
+        public void Verify_that_QueryConstraints_returns_empty_when_no_constraints_are_declared()
+        {
+            var address = this.allClasses.Single(x => x.Name == "Address");
+
+            var constraints = address.QueryConstraints();
+
+            Assert.That(constraints, Is.Empty);
+        }
+
+        [Test]
+        public void Verify_that_QueryConstraints_throws_when_argument_is_null()
+        {
+            EClass? @class = null;
+
+            Assert.That(() => @class!.QueryConstraints(), Throws.ArgumentNullException);
+        }
+    }
+}

--- a/ECoreNetto.Extensions.Tests/ECoreNetto.Extensions.Tests.csproj
+++ b/ECoreNetto.Extensions.Tests/ECoreNetto.Extensions.Tests.csproj
@@ -40,6 +40,9 @@
 		<None Include="..\TestData\wizardEcore.ecore" Link="Data\wizardEcore.ecore">
 			<CopyToOutputDirectory>Always</CopyToOutputDirectory>
 		</None>
+		<None Include="..\TestData\report-features.ecore" Link="Data\report-features.ecore">
+			<CopyToOutputDirectory>Always</CopyToOutputDirectory>
+		</None>
 	</ItemGroup>
 
 </Project>

--- a/ECoreNetto.Extensions/AnchorExtensions.cs
+++ b/ECoreNetto.Extensions/AnchorExtensions.cs
@@ -18,6 +18,12 @@ namespace ECoreNetto.Extensions
     public static class AnchorExtensions
     {
         /// <summary>
+        /// The <see cref="Regex"/> that matches every run of characters that are not valid in an HTML
+        /// fragment identifier. A match timeout guards against pathological input.
+        /// </summary>
+        private static readonly Regex NonAnchorCharacters = new Regex("[^A-Za-z0-9]+", RegexOptions.None, TimeSpan.FromSeconds(1));
+
+        /// <summary>
         /// Queries a stable, unique HTML anchor identifier for the provided <see cref="EObject"/>, derived
         /// from its (unique) <see cref="EObject.Identifier"/> by replacing every run of characters that are
         /// not valid in an HTML fragment with a single dash.
@@ -47,7 +53,7 @@ namespace ECoreNetto.Extensions
                 ? detachedClassifier.Name ?? string.Empty
                 : eObject.Identifier ?? string.Empty;
 
-            var sanitized = Regex.Replace(identifier, "[^A-Za-z0-9]+", "-").Trim('-');
+            var sanitized = NonAnchorCharacters.Replace(identifier, "-").Trim('-');
 
             return string.IsNullOrEmpty(sanitized) ? "anchor" : sanitized;
         }

--- a/ECoreNetto.Extensions/AnchorExtensions.cs
+++ b/ECoreNetto.Extensions/AnchorExtensions.cs
@@ -1,0 +1,55 @@
+// ------------------------------------------------------------------------------------------------
+// <copyright file="AnchorExtensions.cs" company="Starion Group S.A.">
+//
+//   Copyright 2017-2026 Starion Group S.A.
+//   SPDX-License-Identifier: Apache-2.0
+//
+// </copyright>
+// ------------------------------------------------------------------------------------------------
+
+namespace ECoreNetto.Extensions
+{
+    using System;
+    using System.Text.RegularExpressions;
+
+    /// <summary>
+    /// Extension methods that produce stable, collision-free HTML anchors for <see cref="EObject"/>s.
+    /// </summary>
+    public static class AnchorExtensions
+    {
+        /// <summary>
+        /// Queries a stable, unique HTML anchor identifier for the provided <see cref="EObject"/>, derived
+        /// from its (unique) <see cref="EObject.Identifier"/> by replacing every run of characters that are
+        /// not valid in an HTML fragment with a single dash.
+        /// </summary>
+        /// <param name="eObject">
+        /// The <see cref="EObject"/> for which the anchor is computed.
+        /// </param>
+        /// <returns>
+        /// A sanitized anchor slug (e.g. <c>recipe-ecore-Recipe</c>), suitable for use as an <c>id</c>
+        /// attribute and as an <c>href="#..."</c> target.
+        /// </returns>
+        /// <exception cref="ArgumentNullException">
+        /// Thrown when <paramref name="eObject"/> is null.
+        /// </exception>
+        public static string QueryAnchorId(this EObject eObject)
+        {
+            if (eObject == null)
+            {
+                throw new ArgumentNullException(nameof(eObject));
+            }
+
+            // A classifier that is referenced across resources (e.g. a super-type, an inherited feature's
+            // containing class or a feature type defined in another .ecore) may be an unattached proxy with
+            // no EContainer. Computing its Identifier would dereference a null EPackage, so fall back to the
+            // simple name for such detached classifiers.
+            var identifier = eObject is EClassifier { EContainer: null } detachedClassifier
+                ? detachedClassifier.Name ?? string.Empty
+                : eObject.Identifier ?? string.Empty;
+
+            var sanitized = Regex.Replace(identifier, "[^A-Za-z0-9]+", "-").Trim('-');
+
+            return string.IsNullOrEmpty(sanitized) ? "anchor" : sanitized;
+        }
+    }
+}

--- a/ECoreNetto.Extensions/ClassExtensions.cs
+++ b/ECoreNetto.Extensions/ClassExtensions.cs
@@ -44,6 +44,129 @@ namespace ECoreNetto.Extensions
         }
 
         /// <summary>
+        /// The annotation source under which Ecore declares the names of a classifier's constraints.
+        /// </summary>
+        private const string EcoreAnnotationSource = "http://www.eclipse.org/emf/2002/Ecore";
+
+        /// <summary>
+        /// The annotation source under which Ecore stores the OCL body of each named constraint.
+        /// </summary>
+        private const string OclAnnotationSource = "http://www.eclipse.org/emf/2002/Ecore/OCL";
+
+        /// <summary>
+        /// Queries all (transitive) specializations (direct and indirect sub classes) of the subject <see cref="EClass"/>.
+        /// </summary>
+        /// <param name="class">
+        /// The <see cref="EClass"/> for which the descendant specializations are computed.
+        /// </param>
+        /// <param name="allClasses">
+        /// The <see cref="IEnumerable{EClass}"/> from which the specializations are computed.
+        /// </param>
+        /// <returns>
+        /// An <see cref="IEnumerable{EClass}"/> that contains all direct and indirect sub classes of the subject <see cref="EClass"/>.
+        /// </returns>
+        public static IEnumerable<EClass> QueryAllDescendantSpecializations(this EClass @class, IEnumerable<EClass> allClasses)
+        {
+            if (@class == null)
+            {
+                throw new ArgumentNullException(nameof(@class));
+            }
+
+            var classes = allClasses.ToList();
+
+            var result = new List<EClass>();
+            var queue = new Queue<EClass>(@class.QuerySpecializations(classes));
+
+            while (queue.Count > 0)
+            {
+                var specialization = queue.Dequeue();
+
+                if (result.Contains(specialization) || specialization == @class)
+                {
+                    continue;
+                }
+
+                result.Add(specialization);
+
+                foreach (var deeper in specialization.QuerySpecializations(classes))
+                {
+                    queue.Enqueue(deeper);
+                }
+            }
+
+            return result;
+        }
+
+        /// <summary>
+        /// Queries the classes that contain the subject <see cref="EClass"/> through a containment <see cref="EReference"/>.
+        /// </summary>
+        /// <param name="class">
+        /// The <see cref="EClass"/> for which the containers are computed.
+        /// </param>
+        /// <param name="allClasses">
+        /// The <see cref="IEnumerable{EClass}"/> from which the containers are computed.
+        /// </param>
+        /// <returns>
+        /// An <see cref="IEnumerable{EClass}"/> that owns a containment reference whose type is the subject <see cref="EClass"/>.
+        /// </returns>
+        public static IEnumerable<EClass> QueryContainers(this EClass @class, IEnumerable<EClass> allClasses)
+        {
+            if (@class == null)
+            {
+                throw new ArgumentNullException(nameof(@class));
+            }
+
+            return allClasses
+                .Where(candidate => candidate.EStructuralFeatures
+                    .OfType<EReference>()
+                    .Any(reference => reference.IsContainment && reference.EType == @class));
+        }
+
+        /// <summary>
+        /// Queries the constraints (rules) declared on the subject <see cref="EClass"/> through its Ecore
+        /// constraint annotation, pairing each constraint name with its OCL body when present.
+        /// </summary>
+        /// <param name="class">
+        /// The <see cref="EClass"/> whose constraints are read.
+        /// </param>
+        /// <returns>
+        /// An <see cref="IEnumerable{ConstraintInfo}"/>, one per declared constraint name; empty when the
+        /// class declares no constraints.
+        /// </returns>
+        public static IEnumerable<ConstraintInfo> QueryConstraints(this EClass @class)
+        {
+            if (@class == null)
+            {
+                throw new ArgumentNullException(nameof(@class));
+            }
+
+            var result = new List<ConstraintInfo>();
+
+            var constraintsAnnotation = @class.EAnnotations.FirstOrDefault(a => a.Source == EcoreAnnotationSource);
+            if (constraintsAnnotation == null || !constraintsAnnotation.Details.TryGetValue("constraints", out var names))
+            {
+                return result;
+            }
+
+            var oclAnnotation = @class.EAnnotations.FirstOrDefault(a => a.Source == OclAnnotationSource);
+
+            foreach (var name in names.Split(' '))
+            {
+                if (string.IsNullOrWhiteSpace(name))
+                {
+                    continue;
+                }
+
+                string? body = null;
+                oclAnnotation?.Details.TryGetValue(name, out body);
+
+                result.Add(new ConstraintInfo(name, body ?? string.Empty, oclAnnotation != null ? "OCL" : string.Empty));
+            }
+
+            return result;
+        }
+
+        /// <summary>
         /// Queries the type hierarchy (chain of super classes) of the provided <see cref="EClass"/>
         /// </summary>
         /// <param name="class">

--- a/ECoreNetto.Extensions/ConstraintInfo.cs
+++ b/ECoreNetto.Extensions/ConstraintInfo.cs
@@ -1,0 +1,52 @@
+// ------------------------------------------------------------------------------------------------
+// <copyright file="ConstraintInfo.cs" company="Starion Group S.A.">
+//
+//   Copyright 2017-2026 Starion Group S.A.
+//   SPDX-License-Identifier: Apache-2.0
+//
+// </copyright>
+// ------------------------------------------------------------------------------------------------
+
+namespace ECoreNetto.Extensions
+{
+    /// <summary>
+    /// Represents a named constraint (rule) declared on an <see cref="EClass"/>, together with its
+    /// specification body and language, as read from the Ecore constraint/OCL annotations.
+    /// </summary>
+    public class ConstraintInfo
+    {
+        /// <summary>
+        /// Initializes a new instance of the <see cref="ConstraintInfo"/> class.
+        /// </summary>
+        /// <param name="name">
+        /// The name of the constraint.
+        /// </param>
+        /// <param name="body">
+        /// The specification body (e.g. the OCL expression), or an empty string when none is declared.
+        /// </param>
+        /// <param name="language">
+        /// The specification language (e.g. <c>OCL</c>), or an empty string when unknown.
+        /// </param>
+        public ConstraintInfo(string name, string body, string language)
+        {
+            this.Name = name;
+            this.Body = body;
+            this.Language = language;
+        }
+
+        /// <summary>
+        /// Gets the name of the constraint.
+        /// </summary>
+        public string Name { get; }
+
+        /// <summary>
+        /// Gets the specification body of the constraint (e.g. the OCL expression).
+        /// </summary>
+        public string Body { get; }
+
+        /// <summary>
+        /// Gets the specification language of the constraint (e.g. <c>OCL</c>).
+        /// </summary>
+        public string Language { get; }
+    }
+}

--- a/ECoreNetto.HandleBars.Tests/AnchorHelperTestFixture.cs
+++ b/ECoreNetto.HandleBars.Tests/AnchorHelperTestFixture.cs
@@ -1,0 +1,70 @@
+// ------------------------------------------------------------------------------------------------
+// <copyright file="AnchorHelperTestFixture.cs" company="Starion Group S.A.">
+//
+//   Copyright 2017-2026 Starion Group S.A.
+//   SPDX-License-Identifier: Apache-2.0
+//
+// </copyright>
+// ------------------------------------------------------------------------------------------------
+
+namespace ECoreNetto.HandleBars.Tests
+{
+    using System.IO;
+    using System.Linq;
+
+    using ECoreNetto;
+
+    using HandlebarsDotNet;
+
+    using NUnit.Framework;
+
+    /// <summary>
+    /// Suite of tests for the <see cref="AnchorHelper"/> class
+    /// </summary>
+    [TestFixture]
+    public class AnchorHelperTestFixture
+    {
+        private IHandlebars handlebarsContext = null!;
+
+        private EPackage root = null!;
+
+        [SetUp]
+        public void Setup()
+        {
+            this.handlebarsContext = Handlebars.Create();
+
+            AnchorHelper.RegisterAnchorHelper(this.handlebarsContext);
+
+            var path = Path.Combine(TestContext.CurrentContext.TestDirectory, "Data", "report-features.ecore");
+            this.root = ModelLoader.Load(path);
+        }
+
+        [Test]
+        public void Verify_that_Anchor_writes_the_sanitized_slug()
+        {
+            var template = "{{ Anchor this }}";
+            var action = this.handlebarsContext.Compile(template);
+
+            var person = this.root.EClassifiers.OfType<EClass>().Single(x => x.Name == "Person");
+
+            var result = action(person);
+
+            Assert.Multiple(() =>
+            {
+                Assert.That(result, Does.Match("^[A-Za-z0-9-]+$"));
+                Assert.That(result, Does.EndWith("Person"));
+            });
+        }
+
+        [Test]
+        public void Verify_that_Anchor_throws_when_not_exactly_one_argument()
+        {
+            var template = "{{ Anchor this that }}";
+            var action = this.handlebarsContext.Compile(template);
+
+            var person = this.root.EClassifiers.OfType<EClass>().Single(x => x.Name == "Person");
+
+            Assert.Throws<HandlebarsException>(() => action(new { this_ = person, that = person }));
+        }
+    }
+}

--- a/ECoreNetto.HandleBars.Tests/ClassHelperTestFixture.cs
+++ b/ECoreNetto.HandleBars.Tests/ClassHelperTestFixture.cs
@@ -1,0 +1,155 @@
+// ------------------------------------------------------------------------------------------------
+// <copyright file="ClassHelperTestFixture.cs" company="Starion Group S.A.">
+//
+//   Copyright 2017-2026 Starion Group S.A.
+//   SPDX-License-Identifier: Apache-2.0
+//
+// </copyright>
+// ------------------------------------------------------------------------------------------------
+
+namespace ECoreNetto.HandleBars.Tests
+{
+    using System.Collections.Generic;
+    using System.IO;
+    using System.Linq;
+
+    using ECoreNetto;
+    using ECoreNetto.Extensions;
+
+    using HandlebarsDotNet;
+    using HandlebarsDotNet.Helpers;
+
+    using NUnit.Framework;
+
+    /// <summary>
+    /// Suite of tests for the <see cref="ClassHelper"/> class
+    /// </summary>
+    [TestFixture]
+    public class ClassHelperTestFixture
+    {
+        private IHandlebars handlebarsContext = null!;
+
+        private EPackage root = null!;
+
+        private List<EClass> allClasses = null!;
+
+        [SetUp]
+        public void Setup()
+        {
+            this.handlebarsContext = Handlebars.Create();
+            HandlebarsHelpers.Register(this.handlebarsContext);
+
+            ClassHelper.RegisterClassHelper(this.handlebarsContext);
+
+            var path = Path.Combine(TestContext.CurrentContext.TestDirectory, "Data", "report-features.ecore");
+            this.root = ModelLoader.Load(path);
+            this.allClasses = this.root.EClassifiers.OfType<EClass>().ToList();
+        }
+
+        private EClass Class(string name)
+        {
+            return this.allClasses.Single(x => x.Name == name);
+        }
+
+        [Test]
+        public void Verify_that_QuerySpecializations_returns_the_subclasses()
+        {
+            var template = "{{#each (Class.QuerySpecializations subject all) as | c |}}{{c.Name}};{{/each}}";
+            var action = this.handlebarsContext.Compile(template);
+
+            var result = action(new { subject = this.Class("Describable"), all = this.allClasses });
+
+            Assert.That(result, Is.EqualTo("Person;"));
+        }
+
+        [Test]
+        public void Verify_that_QueryContainers_returns_the_containing_classes()
+        {
+            var template = "{{#each (Class.QueryContainers subject all) as | c |}}{{c.Name}};{{/each}}";
+            var action = this.handlebarsContext.Compile(template);
+
+            var result = action(new { subject = this.Class("Address"), all = this.allClasses });
+
+            Assert.That(result, Is.EqualTo("Person;"));
+        }
+
+        [Test]
+        public void Verify_that_QueryConstraints_returns_the_constraints()
+        {
+            var template = "{{#each (Class.QueryConstraints subject) as | c |}}{{c.Name}}:{{c.Language}};{{/each}}";
+            var action = this.handlebarsContext.Compile(template);
+
+            var result = action(new { subject = this.Class("Person") });
+
+            Assert.That(result, Is.EqualTo("hasFullName:OCL;"));
+        }
+
+        [Test]
+        public void Verify_that_RenderInheritanceDiagram_renders_the_diagram_when_present()
+        {
+            var template = "{{#Class.RenderInheritanceDiagram subject diagrams}}{{{this}}}{{/Class.RenderInheritanceDiagram}}";
+            var action = this.handlebarsContext.Compile(template);
+
+            var person = this.Class("Person");
+            var diagrams = new Dictionary<string, string> { { person.QueryAnchorId(), "<svg>DIAGRAM</svg>" } };
+
+            var result = action(new { subject = person, diagrams });
+
+            Assert.That(result, Does.Contain("DIAGRAM"));
+        }
+
+        [Test]
+        public void Verify_that_RenderInheritanceDiagram_renders_nothing_when_absent()
+        {
+            var template = "{{#Class.RenderInheritanceDiagram subject diagrams}}{{{this}}}{{/Class.RenderInheritanceDiagram}}";
+            var action = this.handlebarsContext.Compile(template);
+
+            var diagrams = new Dictionary<string, string>();
+
+            var result = action(new { subject = this.Class("Person"), diagrams });
+
+            Assert.That(result, Is.Empty);
+        }
+
+        [Test]
+        public void Verify_that_RenderAssociationDiagram_renders_the_diagram_when_present()
+        {
+            var template = "{{#Class.RenderAssociationDiagram subject diagrams}}{{{this}}}{{/Class.RenderAssociationDiagram}}";
+            var action = this.handlebarsContext.Compile(template);
+
+            var person = this.Class("Person");
+            var diagrams = new Dictionary<string, string> { { person.QueryAnchorId(), "<svg>ASSOC</svg>" } };
+
+            var result = action(new { subject = person, diagrams });
+
+            Assert.That(result, Does.Contain("ASSOC"));
+        }
+
+        [Test]
+        public void Verify_that_QuerySpecializations_throws_when_not_exactly_two_arguments()
+        {
+            var template = "{{#each (Class.QuerySpecializations subject) as | c |}}{{c.Name}}{{/each}}";
+            var action = this.handlebarsContext.Compile(template);
+
+            Assert.Throws<HandlebarsException>(() => action(new { subject = this.Class("Describable") }));
+        }
+
+        [Test]
+        public void Verify_that_QueryContainers_throws_when_not_exactly_two_arguments()
+        {
+            var template = "{{#each (Class.QueryContainers subject) as | c |}}{{c.Name}}{{/each}}";
+            var action = this.handlebarsContext.Compile(template);
+
+            Assert.Throws<HandlebarsException>(() => action(new { subject = this.Class("Address") }));
+        }
+
+        [Test]
+        public void Verify_that_QueryConstraints_throws_when_not_exactly_one_argument()
+        {
+            var template = "{{#each (Class.QueryConstraints subject all) as | c |}}{{c.Name}}{{/each}}";
+            var action = this.handlebarsContext.Compile(template);
+
+            Assert.Throws<HandlebarsException>(() => action(new { subject = this.Class("Person"), all = this.allClasses }));
+        }
+    }
+}

--- a/ECoreNetto.HandleBars.Tests/ECoreNetto.HandleBars.Tests.csproj
+++ b/ECoreNetto.HandleBars.Tests/ECoreNetto.HandleBars.Tests.csproj
@@ -36,6 +36,9 @@
         <None Include="..\TestData\wizardEcore.ecore" Link="Data\wizardEcore.ecore">
             <CopyToOutputDirectory>Always</CopyToOutputDirectory>
         </None>
+        <None Include="..\TestData\report-features.ecore" Link="Data\report-features.ecore">
+            <CopyToOutputDirectory>Always</CopyToOutputDirectory>
+        </None>
     </ItemGroup>
 
 </Project>

--- a/ECoreNetto.HandleBars.Tests/IEnumerableHelperTestFixture.cs
+++ b/ECoreNetto.HandleBars.Tests/IEnumerableHelperTestFixture.cs
@@ -1,0 +1,78 @@
+// ------------------------------------------------------------------------------------------------
+// <copyright file="IEnumerableHelperTestFixture.cs" company="Starion Group S.A.">
+//
+//   Copyright 2017-2026 Starion Group S.A.
+//   SPDX-License-Identifier: Apache-2.0
+//
+// </copyright>
+// ------------------------------------------------------------------------------------------------
+
+namespace ECoreNetto.HandleBars.Tests
+{
+    using System.Collections.Generic;
+
+    using HandlebarsDotNet;
+    using HandlebarsDotNet.Helpers;
+
+    using NUnit.Framework;
+
+    /// <summary>
+    /// Suite of tests for the <see cref="IEnumerableHelper"/> class
+    /// </summary>
+    [TestFixture]
+    public class IEnumerableHelperTestFixture
+    {
+        private IHandlebars handlebarsContext = null!;
+
+        [SetUp]
+        public void Setup()
+        {
+            this.handlebarsContext = Handlebars.Create();
+            HandlebarsHelpers.Register(this.handlebarsContext);
+
+            IEnumerableHelper.RegisterIEnumerableHelper(this.handlebarsContext);
+        }
+
+        [Test]
+        public void Verify_that_IsEmpty_returns_true_for_an_empty_enumerable()
+        {
+            var template = "{{#if (IEnumerable.IsEmpty items)}}EMPTY{{else}}NOT{{/if}}";
+            var action = this.handlebarsContext.Compile(template);
+
+            var result = action(new { items = new List<string>() });
+
+            Assert.That(result, Is.EqualTo("EMPTY"));
+        }
+
+        [Test]
+        public void Verify_that_IsEmpty_returns_false_for_a_non_empty_enumerable()
+        {
+            var template = "{{#if (IEnumerable.IsEmpty items)}}EMPTY{{else}}NOT{{/if}}";
+            var action = this.handlebarsContext.Compile(template);
+
+            var result = action(new { items = new List<string> { "one" } });
+
+            Assert.That(result, Is.EqualTo("NOT"));
+        }
+
+        [Test]
+        public void Verify_that_IsEmpty_returns_true_when_the_argument_is_not_an_enumerable()
+        {
+            var template = "{{#if (IEnumerable.IsEmpty item)}}EMPTY{{else}}NOT{{/if}}";
+            var action = this.handlebarsContext.Compile(template);
+
+            var result = action(new { item = 42 });
+
+            Assert.That(result, Is.EqualTo("EMPTY"));
+        }
+
+        [Test]
+        public void Verify_that_IsEmpty_throws_when_not_exactly_one_argument()
+        {
+            var template = "{{#if (IEnumerable.IsEmpty a b)}}EMPTY{{else}}NOT{{/if}}";
+            var action = this.handlebarsContext.Compile(template);
+
+            Assert.Throws<HandlebarsException>(() => action(new { a = new List<string>(), b = new List<string>() }));
+        }
+    }
+}

--- a/ECoreNetto.HandleBars.Tests/ParameterHelperTestFixture.cs
+++ b/ECoreNetto.HandleBars.Tests/ParameterHelperTestFixture.cs
@@ -1,0 +1,137 @@
+// ------------------------------------------------------------------------------------------------
+// <copyright file="ParameterHelperTestFixture.cs" company="Starion Group S.A.">
+//
+//   Copyright 2017-2026 Starion Group S.A.
+//   SPDX-License-Identifier: Apache-2.0
+//
+// </copyright>
+// ------------------------------------------------------------------------------------------------
+
+namespace ECoreNetto.HandleBars.Tests
+{
+    using System.IO;
+    using System.Linq;
+
+    using ECoreNetto;
+
+    using HandlebarsDotNet;
+    using HandlebarsDotNet.Helpers;
+
+    using NUnit.Framework;
+
+    /// <summary>
+    /// Suite of tests for the <see cref="ParameterHelper"/> class
+    /// </summary>
+    [TestFixture]
+    public class ParameterHelperTestFixture
+    {
+        private IHandlebars handlebarsContext = null!;
+
+        private EPackage root = null!;
+
+        [SetUp]
+        public void Setup()
+        {
+            this.handlebarsContext = Handlebars.Create();
+            HandlebarsHelpers.Register(this.handlebarsContext);
+
+            ParameterHelper.RegisterParameterHelper(this.handlebarsContext);
+
+            var path = Path.Combine(TestContext.CurrentContext.TestDirectory, "Data", "report-features.ecore");
+            this.root = ModelLoader.Load(path);
+        }
+
+        private EOperation Operation(string className, string operationName)
+        {
+            return this.root.EClassifiers.OfType<EClass>().Single(x => x.Name == className)
+                .EOperations.Single(x => x.Name == operationName);
+        }
+
+        [Test]
+        public void Verify_that_WriteTypeAndName_renders_type_name_and_multiplicity()
+        {
+            var template = "{{ Parameter.WriteTypeAndName this }}";
+            var action = this.handlebarsContext.Compile(template);
+
+            var greeting = this.Operation("Person", "greet").EParameters.Single(x => x.Name == "greeting");
+
+            var result = action(greeting);
+
+            Assert.Multiple(() =>
+            {
+                Assert.That(result, Does.Contain("EString"));
+                Assert.That(result, Does.Contain("greeting"));
+                Assert.That(result, Does.Contain("[0..*]"));
+            });
+        }
+
+        [Test]
+        public void Verify_that_WriteTypeAndName_renders_void_for_a_typeless_parameter()
+        {
+            var template = "{{ Parameter.WriteTypeAndName this }}";
+            var action = this.handlebarsContext.Compile(template);
+
+            var target = this.Operation("Company", "clear").EParameters.Single(x => x.Name == "target");
+
+            var result = action(target);
+
+            Assert.Multiple(() =>
+            {
+                Assert.That(result, Does.Contain("void"));
+                Assert.That(result, Does.Contain("target"));
+            });
+        }
+
+        [Test]
+        public void Verify_that_WriteReturnType_renders_type_name_and_multiplicity()
+        {
+            var template = "{{ TypedElement.WriteReturnType this }}";
+            var action = this.handlebarsContext.Compile(template);
+
+            var greet = this.Operation("Person", "greet");
+
+            var result = action(greet);
+
+            Assert.Multiple(() =>
+            {
+                Assert.That(result, Does.Contain("EString"));
+                Assert.That(result, Does.Contain("[1..1]"));
+            });
+        }
+
+        [Test]
+        public void Verify_that_WriteReturnType_renders_void_when_there_is_no_return_type()
+        {
+            var template = "{{ TypedElement.WriteReturnType this }}";
+            var action = this.handlebarsContext.Compile(template);
+
+            var clear = this.Operation("Company", "clear");
+
+            var result = action(clear);
+
+            Assert.That(result, Is.EqualTo("void"));
+        }
+
+        [Test]
+        public void Verify_that_WriteTypeAndName_throws_when_not_exactly_one_argument()
+        {
+            var template = "{{ Parameter.WriteTypeAndName this that }}";
+            var action = this.handlebarsContext.Compile(template);
+
+            var greeting = this.Operation("Person", "greet").EParameters.Single(x => x.Name == "greeting");
+
+            Assert.Throws<HandlebarsException>(() => action(new { that = greeting }));
+        }
+
+        [Test]
+        public void Verify_that_WriteReturnType_throws_when_not_exactly_one_argument()
+        {
+            var template = "{{ TypedElement.WriteReturnType this that }}";
+            var action = this.handlebarsContext.Compile(template);
+
+            var greet = this.Operation("Person", "greet");
+
+            Assert.Throws<HandlebarsException>(() => action(new { that = greet }));
+        }
+    }
+}

--- a/ECoreNetto.HandleBars.Tests/StructuralFeatureHelperFeaturesTestFixture.cs
+++ b/ECoreNetto.HandleBars.Tests/StructuralFeatureHelperFeaturesTestFixture.cs
@@ -1,0 +1,120 @@
+// ------------------------------------------------------------------------------------------------
+// <copyright file="StructuralFeatureHelperFeaturesTestFixture.cs" company="Starion Group S.A.">
+//
+//   Copyright 2017-2026 Starion Group S.A.
+//   SPDX-License-Identifier: Apache-2.0
+//
+// </copyright>
+// ------------------------------------------------------------------------------------------------
+
+namespace ECoreNetto.HandleBars.Tests
+{
+    using System.IO;
+    using System.Linq;
+
+    using ECoreNetto;
+
+    using HandlebarsDotNet;
+    using HandlebarsDotNet.Helpers;
+
+    using NUnit.Framework;
+
+    /// <summary>
+    /// Suite of tests for the identity and opposite helpers on <see cref="StructuralFeatureHelper"/>, exercised
+    /// against the feature-rich synthetic model.
+    /// </summary>
+    [TestFixture]
+    public class StructuralFeatureHelperFeaturesTestFixture
+    {
+        private IHandlebars handlebarsContext = null!;
+
+        private EPackage root = null!;
+
+        [SetUp]
+        public void Setup()
+        {
+            this.handlebarsContext = Handlebars.Create();
+            HandlebarsHelpers.Register(this.handlebarsContext);
+
+            StructuralFeatureHelper.RegisterStructuralFeatureHelper(this.handlebarsContext);
+
+            var path = Path.Combine(TestContext.CurrentContext.TestDirectory, "Data", "report-features.ecore");
+            this.root = ModelLoader.Load(path);
+        }
+
+        private EStructuralFeature Feature(string className, string featureName)
+        {
+            return this.root.EClassifiers.OfType<EClass>().Single(x => x.Name == className)
+                .EStructuralFeatures.Single(x => x.Name == featureName);
+        }
+
+        [Test]
+        public void Verify_that_QueryIsId_returns_true_for_an_id_attribute()
+        {
+            var template = "{{ #StructuralFeature.QueryIsId this }}";
+            var action = this.handlebarsContext.Compile(template);
+
+            Assert.Multiple(() =>
+            {
+                Assert.That(action(this.Feature("Person", "identifier")), Is.EqualTo("True"));
+                Assert.That(action(this.Feature("Person", "tags")), Is.EqualTo("False"));
+                Assert.That(action(this.Feature("Person", "employer")), Is.EqualTo("False"));
+            });
+        }
+
+        [Test]
+        public void Verify_that_QueryIsId_throws_when_not_exactly_one_argument()
+        {
+            var template = "{{ #StructuralFeature.QueryIsId this that }}";
+            var action = this.handlebarsContext.Compile(template);
+
+            Assert.Throws<HandlebarsException>(() => action(new { that = this.Feature("Person", "identifier") }));
+        }
+
+        [Test]
+        public void Verify_that_WriteOpposite_renders_the_opposite_reference()
+        {
+            var template = "{{ StructuralFeature.WriteOpposite this }}";
+            var action = this.handlebarsContext.Compile(template);
+
+            var result = action(this.Feature("Person", "employer"));
+
+            Assert.Multiple(() =>
+            {
+                Assert.That(result, Does.Contain("{opposite:"));
+                Assert.That(result, Does.Contain("employees"));
+            });
+        }
+
+        [Test]
+        public void Verify_that_WriteOpposite_renders_nothing_for_a_reference_without_an_opposite()
+        {
+            var template = "{{ StructuralFeature.WriteOpposite this }}";
+            var action = this.handlebarsContext.Compile(template);
+
+            var result = action(this.Feature("Person", "addresses"));
+
+            Assert.That(result, Is.Empty);
+        }
+
+        [Test]
+        public void Verify_that_WriteOpposite_renders_nothing_for_an_attribute()
+        {
+            var template = "{{ StructuralFeature.WriteOpposite this }}";
+            var action = this.handlebarsContext.Compile(template);
+
+            var result = action(this.Feature("Person", "tags"));
+
+            Assert.That(result, Is.Empty);
+        }
+
+        [Test]
+        public void Verify_that_WriteOpposite_throws_when_not_exactly_one_argument()
+        {
+            var template = "{{ StructuralFeature.WriteOpposite this that }}";
+            var action = this.handlebarsContext.Compile(template);
+
+            Assert.Throws<HandlebarsException>(() => action(new { that = this.Feature("Person", "employer") }));
+        }
+    }
+}

--- a/ECoreNetto.HandleBars/AnchorHelper.cs
+++ b/ECoreNetto.HandleBars/AnchorHelper.cs
@@ -1,0 +1,43 @@
+// ------------------------------------------------------------------------------------------------
+// <copyright file="AnchorHelper.cs" company="Starion Group S.A.">
+//
+//   Copyright 2017-2026 Starion Group S.A.
+//   SPDX-License-Identifier: Apache-2.0
+//
+// </copyright>
+// ------------------------------------------------------------------------------------------------
+
+namespace ECoreNetto.HandleBars
+{
+    using ECoreNetto;
+    using ECoreNetto.Extensions;
+
+    using HandlebarsDotNet;
+
+    /// <summary>
+    /// A handlebars helper that writes a stable, unique HTML anchor for an <see cref="EObject"/>.
+    /// </summary>
+    public static class AnchorHelper
+    {
+        /// <summary>
+        /// Registers the <see cref="AnchorHelper"/>
+        /// </summary>
+        /// <param name="handlebars">
+        /// The <see cref="IHandlebars"/> context with which the helper needs to be registered
+        /// </param>
+        public static void RegisterAnchorHelper(this IHandlebars handlebars)
+        {
+            handlebars.RegisterHelper("Anchor", (writer, _, arguments) =>
+            {
+                if (arguments.Length != 1)
+                {
+                    throw new HandlebarsException("{{Anchor}} helper must have exactly one argument");
+                }
+
+                var eObject = (EObject)arguments[0]!;
+
+                writer.WriteSafeString(eObject.QueryAnchorId());
+            });
+        }
+    }
+}

--- a/ECoreNetto.HandleBars/ClassHelper.cs
+++ b/ECoreNetto.HandleBars/ClassHelper.cs
@@ -1,0 +1,123 @@
+// ------------------------------------------------------------------------------------------------
+// <copyright file="ClassHelper.cs" company="Starion Group S.A.">
+//
+//   Copyright 2017-2026 Starion Group S.A.
+//   SPDX-License-Identifier: Apache-2.0
+//
+// </copyright>
+// ------------------------------------------------------------------------------------------------
+
+namespace ECoreNetto.HandleBars
+{
+    using System.Collections.Generic;
+    using System.Linq;
+
+    using ECoreNetto;
+    using ECoreNetto.Extensions;
+
+    using HandlebarsDotNet;
+
+    /// <summary>
+    /// Handlebars helpers for the <see cref="EClass"/> class: specialization/container/constraint queries
+    /// and per-class diagram rendering.
+    /// </summary>
+    public static class ClassHelper
+    {
+        /// <summary>
+        /// Registers the <see cref="ClassHelper"/>
+        /// </summary>
+        /// <param name="handlebars">
+        /// The <see cref="IHandlebars"/> context with which the helper needs to be registered
+        /// </param>
+        public static void RegisterClassHelper(this IHandlebars handlebars)
+        {
+            handlebars.RegisterHelper("Class.QuerySpecializations", (_, arguments) =>
+            {
+                if (arguments.Length != 2)
+                {
+                    throw new HandlebarsException("{{Class.QuerySpecializations}} helper must have exactly two arguments");
+                }
+
+                var @class = (EClass)arguments[0]!;
+                var allClasses = ((IEnumerable<EClass>)arguments[1]!).ToList();
+
+                return @class.QuerySpecializations(allClasses).OrderBy(x => x.Name);
+            });
+
+            handlebars.RegisterHelper("Class.QueryContainers", (_, arguments) =>
+            {
+                if (arguments.Length != 2)
+                {
+                    throw new HandlebarsException("{{Class.QueryContainers}} helper must have exactly two arguments");
+                }
+
+                var @class = (EClass)arguments[0]!;
+                var allClasses = ((IEnumerable<EClass>)arguments[1]!).ToList();
+
+                return @class.QueryContainers(allClasses).OrderBy(x => x.Name);
+            });
+
+            handlebars.RegisterHelper("Class.QueryConstraints", (_, arguments) =>
+            {
+                if (arguments.Length != 1)
+                {
+                    throw new HandlebarsException("{{Class.QueryConstraints}} helper must have exactly one argument");
+                }
+
+                var @class = (EClass)arguments[0]!;
+
+                return @class.QueryConstraints();
+            });
+
+            handlebars.RegisterHelper("Class.RenderInheritanceDiagram", (output, options, _, arguments) =>
+            {
+                if (!TryGetDiagram(arguments, out var svg))
+                {
+                    return;
+                }
+
+                options.Template(output, svg);
+            });
+
+            handlebars.RegisterHelper("Class.RenderAssociationDiagram", (output, options, _, arguments) =>
+            {
+                if (!TryGetDiagram(arguments, out var svg))
+                {
+                    return;
+                }
+
+                options.Template(output, svg);
+            });
+        }
+
+        /// <summary>
+        /// Attempts to resolve the pre-rendered diagram SVG for the class passed as the first argument, from
+        /// the anchor-keyed dictionary passed as the second argument.
+        /// </summary>
+        /// <param name="arguments">
+        /// The block-helper arguments: an <see cref="EClass"/> and an anchor-keyed diagram dictionary.
+        /// </param>
+        /// <param name="svg">
+        /// The resolved SVG string when present.
+        /// </param>
+        /// <returns>
+        /// True when a diagram exists for the class; otherwise false.
+        /// </returns>
+        private static bool TryGetDiagram(Arguments arguments, out string? svg)
+        {
+            svg = null;
+
+            if (arguments.Length < 2)
+            {
+                return false;
+            }
+
+            if (!(arguments[0] is EClass @class) || !(arguments[1] is IDictionary<string, string> diagrams))
+            {
+                return false;
+            }
+
+            return diagrams.TryGetValue(@class.QueryAnchorId(), out svg);
+        }
+    }
+}

--- a/ECoreNetto.HandleBars/IEnumerableHelper.cs
+++ b/ECoreNetto.HandleBars/IEnumerableHelper.cs
@@ -1,0 +1,42 @@
+// ------------------------------------------------------------------------------------------------
+// <copyright file="IEnumerableHelper.cs" company="Starion Group S.A.">
+//
+//   Copyright 2017-2026 Starion Group S.A.
+//   SPDX-License-Identifier: Apache-2.0
+//
+// </copyright>
+// ------------------------------------------------------------------------------------------------
+
+namespace ECoreNetto.HandleBars
+{
+    using System.Collections;
+    using System.Linq;
+
+    using HandlebarsDotNet;
+
+    /// <summary>
+    /// A handlebars helper that reports whether an <see cref="IEnumerable"/> is empty, used to guard the
+    /// empty-state messages of the report sections.
+    /// </summary>
+    public static class IEnumerableHelper
+    {
+        /// <summary>
+        /// Registers the <see cref="IEnumerableHelper"/>
+        /// </summary>
+        /// <param name="handlebars">
+        /// The <see cref="IHandlebars"/> context with which the helper needs to be registered
+        /// </param>
+        public static void RegisterIEnumerableHelper(this IHandlebars handlebars)
+        {
+            handlebars.RegisterHelper("IEnumerable.IsEmpty", (_, arguments) =>
+            {
+                if (arguments.Length != 1)
+                {
+                    throw new HandlebarsException("{{#IEnumerable.IsEmpty}} helper must have exactly one argument");
+                }
+
+                return !(arguments[0] is IEnumerable enumerable) || !enumerable.Cast<object>().Any();
+            });
+        }
+    }
+}

--- a/ECoreNetto.HandleBars/ParameterHelper.cs
+++ b/ECoreNetto.HandleBars/ParameterHelper.cs
@@ -1,0 +1,93 @@
+// ------------------------------------------------------------------------------------------------
+// <copyright file="ParameterHelper.cs" company="Starion Group S.A.">
+//
+//   Copyright 2017-2026 Starion Group S.A.
+//   SPDX-License-Identifier: Apache-2.0
+//
+// </copyright>
+// ------------------------------------------------------------------------------------------------
+
+namespace ECoreNetto.HandleBars
+{
+    using ECoreNetto;
+    using ECoreNetto.Extensions;
+
+    using HandlebarsDotNet;
+
+    /// <summary>
+    /// Handlebars helpers that render <see cref="EParameter"/>s and <see cref="ETypedElement"/> return
+    /// types (type link, name and multiplicity).
+    /// </summary>
+    public static class ParameterHelper
+    {
+        /// <summary>
+        /// Registers the <see cref="ParameterHelper"/>
+        /// </summary>
+        /// <param name="handlebars">
+        /// The <see cref="IHandlebars"/> context with which the helper needs to be registered
+        /// </param>
+        public static void RegisterParameterHelper(this IHandlebars handlebars)
+        {
+            handlebars.RegisterHelper("Parameter.WriteTypeAndName", (writer, _, arguments) =>
+            {
+                if (arguments.Length != 1)
+                {
+                    throw new HandlebarsException("{{Parameter.WriteTypeAndName}} helper must have exactly one argument");
+                }
+
+                var parameter = (EParameter)arguments[0]!;
+
+                if (parameter.EType == null)
+                {
+                    writer.WriteSafeString("void");
+                }
+                else
+                {
+                    writer.WriteSafeString($"<a href=\"#{parameter.EType.QueryAnchorId()}\">{parameter.EType.Name}</a>");
+                }
+
+                writer.WriteSafeString($" {parameter.Name}");
+                writer.WriteSafeString($" {FormatMultiplicity(parameter.LowerBound, parameter.UpperBound)}");
+            });
+
+            handlebars.RegisterHelper("TypedElement.WriteReturnType", (writer, _, arguments) =>
+            {
+                if (arguments.Length != 1)
+                {
+                    throw new HandlebarsException("{{TypedElement.WriteReturnType}} helper must have exactly one argument");
+                }
+
+                var typedElement = (ETypedElement)arguments[0]!;
+
+                if (typedElement.EType == null)
+                {
+                    writer.WriteSafeString("void");
+                    return;
+                }
+
+                writer.WriteSafeString($"<a href=\"#{typedElement.EType.QueryAnchorId()}\">{typedElement.EType.Name}</a>");
+                writer.WriteSafeString($" {FormatMultiplicity(typedElement.LowerBound, typedElement.UpperBound)}");
+            });
+        }
+
+        /// <summary>
+        /// Formats the multiplicity of a typed element as <c>[lower..upper]</c>, using <c>*</c> for the
+        /// unbounded upper bound (-1).
+        /// </summary>
+        /// <param name="lowerBound">
+        /// The lower bound.
+        /// </param>
+        /// <param name="upperBound">
+        /// The upper bound (-1 means unbounded).
+        /// </param>
+        /// <returns>
+        /// The formatted multiplicity string.
+        /// </returns>
+        private static string FormatMultiplicity(int lowerBound, int upperBound)
+        {
+            var upper = upperBound == -1 ? "*" : upperBound.ToString();
+
+            return $"[{lowerBound}..{upper}]";
+        }
+    }
+}

--- a/ECoreNetto.HandleBars/StructuralFeatureHelper.cs
+++ b/ECoreNetto.HandleBars/StructuralFeatureHelper.cs
@@ -212,6 +212,30 @@ namespace ECoreNetto.HandleBars
 
                 writer.WriteSafeString($"{typeName}");
             });
+
+            handlebars.RegisterHelper("StructuralFeature.QueryIsId", (_, arguments) =>
+            {
+                if (arguments.Length != 1)
+                {
+                    throw new HandlebarsException("{{#StructuralFeature.QueryIsId}} helper must have exactly one argument");
+                }
+
+                return arguments.Single() is EAttribute eAttribute && eAttribute.ID;
+            });
+
+            handlebars.RegisterHelper("StructuralFeature.WriteOpposite", (writer, _, arguments) =>
+            {
+                if (arguments.Length != 1)
+                {
+                    throw new HandlebarsException("{{StructuralFeature.WriteOpposite}} helper must have exactly one argument");
+                }
+
+                if (arguments.Single() is EReference eReference && eReference.EOpposite != null)
+                {
+                    var opposite = eReference.EOpposite;
+                    writer.WriteSafeString($" {{opposite: <a href=\"#{opposite.QueryAnchorId()}\">{opposite.Name}</a>}}");
+                }
+            });
         }
     }
 }

--- a/ECoreNetto.Reporting.Tests/Drawing/DiagramRendererTestFixture.cs
+++ b/ECoreNetto.Reporting.Tests/Drawing/DiagramRendererTestFixture.cs
@@ -1,0 +1,112 @@
+// ------------------------------------------------------------------------------------------------
+// <copyright file="DiagramRendererTestFixture.cs" company="Starion Group S.A.">
+//
+//   Copyright 2017-2026 Starion Group S.A.
+//   SPDX-License-Identifier: Apache-2.0
+//
+// </copyright>
+// ------------------------------------------------------------------------------------------------
+
+namespace ECoreNetto.Tools.Tests.Drawing
+{
+    using System.IO;
+    using System.Linq;
+
+    using ECoreNetto;
+    using ECoreNetto.Reporting.Drawing;
+    using ECoreNetto.Reporting.Payload;
+    using ECoreNetto.Resource;
+
+    using NUnit.Framework;
+
+    /// <summary>
+    /// Suite of smoke tests for the <see cref="InheritanceDiagramRenderer"/> and
+    /// <see cref="AssociationDiagramRenderer"/> classes.
+    /// </summary>
+    [TestFixture]
+    public class DiagramRendererTestFixture
+    {
+        private HandlebarsPayload payload = null!;
+
+        [SetUp]
+        public void SetUp()
+        {
+            var path = Path.Combine(TestContext.CurrentContext.TestDirectory, "Data", "report-features.ecore");
+            var uri = new System.Uri(Path.GetFullPath(path));
+
+            var resourceSet = new ResourceSet();
+            var resource = resourceSet.CreateResource(uri);
+            var root = resource.Load(null);
+
+            var enums = root.EClassifiers.OfType<EEnum>();
+            var dataTypes = root.EClassifiers.OfType<EDataType>().Where(x => !(x is EEnum)).ToList();
+            var classes = root.EClassifiers.OfType<EClass>().ToList();
+
+            this.payload = new HandlebarsPayload(
+                root,
+                enums,
+                dataTypes.Where(x => !string.IsNullOrEmpty(x.InstanceClassName)),
+                dataTypes.Where(x => string.IsNullOrEmpty(x.InstanceClassName)),
+                classes,
+                classes.Where(x => x.Interface));
+        }
+
+        [Test]
+        public void Verify_that_the_inheritance_renderer_renders_the_whole_model()
+        {
+            var renderer = new InheritanceDiagramRenderer();
+
+            var svg = renderer.SvgRender(this.payload);
+
+            Assert.Multiple(() =>
+            {
+                Assert.That(svg, Does.Contain("<svg"));
+                Assert.That(svg, Does.Contain("inheritance-diagram"));
+            });
+        }
+
+        [Test]
+        public void Verify_that_the_inheritance_renderer_renders_a_per_class_tree()
+        {
+            var renderer = new InheritanceDiagramRenderer();
+
+            var person = this.payload.Classes.Single(x => x.Name == "Person");
+
+            var svg = renderer.SvgRenderForClass(person, this.payload);
+
+            Assert.Multiple(() =>
+            {
+                Assert.That(svg, Does.Contain("<svg"));
+                Assert.That(svg, Does.Contain("inheritance-tree-"));
+            });
+        }
+
+        [Test]
+        public void Verify_that_the_association_renderer_renders_a_connected_class()
+        {
+            var renderer = new AssociationDiagramRenderer();
+
+            var person = this.payload.Classes.Single(x => x.Name == "Person");
+
+            var svg = renderer.SvgRenderForClass(person, this.payload);
+
+            Assert.Multiple(() =>
+            {
+                Assert.That(svg, Does.Contain("<svg"));
+                Assert.That(svg, Does.Contain("association-diagram-"));
+            });
+        }
+
+        [Test]
+        public void Verify_that_the_association_renderer_returns_empty_for_a_class_without_associations()
+        {
+            var renderer = new AssociationDiagramRenderer();
+
+            var describable = this.payload.Classes.Single(x => x.Name == "Describable");
+
+            var svg = renderer.SvgRenderForClass(describable, this.payload);
+
+            Assert.That(svg, Is.Empty);
+        }
+    }
+}

--- a/ECoreNetto.Reporting.Tests/ECoreNetto.Reporting.Tests.csproj
+++ b/ECoreNetto.Reporting.Tests/ECoreNetto.Reporting.Tests.csproj
@@ -36,6 +36,9 @@
         <None Include="..\TestData\wizardEcore.ecore" Link="Data\wizardEcore.ecore">
             <CopyToOutputDirectory>Always</CopyToOutputDirectory>
         </None>
+        <None Include="..\TestData\report-features.ecore" Link="Data\report-features.ecore">
+            <CopyToOutputDirectory>Always</CopyToOutputDirectory>
+        </None>
         <None Include="..\TestData\capella\*.ecore" Link="Data\capella\%(Filename)%(Extension)">
             <CopyToOutputDirectory>Always</CopyToOutputDirectory>
         </None>

--- a/ECoreNetto.Reporting.Tests/Generators/HtmlReportGeneratorTestFixture.cs
+++ b/ECoreNetto.Reporting.Tests/Generators/HtmlReportGeneratorTestFixture.cs
@@ -84,6 +84,96 @@ namespace ECoreNetto.Tools.Tests.Generators
         }
 
         [Test]
+        public void Verify_that_the_generated_html_renders_the_rich_feature_set()
+        {
+            var modelFileInfo = new FileInfo(Path.Combine(TestContext.CurrentContext.TestDirectory, "Data", "report-features.ecore"));
+
+            var html = this.htmlReportGenerator.GenerateReport(modelFileInfo);
+
+            Assert.Multiple(() =>
+            {
+                // sections and type classification
+                Assert.That(html, Does.Contain("[Primitive Type]"));
+                Assert.That(html, Does.Contain("[Data Type]"));
+                Assert.That(html, Does.Contain("[Interface]"));
+                Assert.That(html, Does.Contain("[Enumeration]"));
+
+                // enum literal value + literal columns
+                Assert.That(html, Does.Contain("active"));
+
+                // feature flag chips
+                Assert.That(html, Does.Contain("{ordered}"));
+                Assert.That(html, Does.Contain("{unique}"));
+                Assert.That(html, Does.Contain("{id}"));
+                Assert.That(html, Does.Contain("{readonly}"));
+                Assert.That(html, Does.Contain("{transient}"));
+                Assert.That(html, Does.Contain("{volatile}"));
+                Assert.That(html, Does.Contain("{unsettable}"));
+                Assert.That(html, Does.Contain("{derived}"));
+                Assert.That(html, Does.Contain("{composite}"));
+                Assert.That(html, Does.Contain("{opposite:"));
+
+                // specializations / containers
+                Assert.That(html, Does.Contain("Specializations"));
+                Assert.That(html, Does.Contain("Containers"));
+
+                // operations table with a rendered parameter and return type
+                Assert.That(html, Does.Contain("Operations"));
+                Assert.That(html, Does.Contain("greet"));
+                Assert.That(html, Does.Contain("greeting"));
+
+                // OCL constraint (rule)
+                Assert.That(html, Does.Contain("hasFullName"));
+                Assert.That(html, Does.Contain("self.fullName"));
+
+                // collapsible UX, diagrams, custom-HTML injection point and Open Graph metadata
+                Assert.That(html, Does.Contain("collapsible-section"));
+                Assert.That(html, Does.Contain("expand-all"));
+                Assert.That(html, Does.Contain("inheritance-diagram"));
+                Assert.That(html, Does.Contain("inheritance-tree-"));
+                Assert.That(html, Does.Contain("association-diagram-"));
+                Assert.That(html, Does.Contain("download-svg"));
+                Assert.That(html, Does.Contain("og:title"));
+            });
+        }
+
+        [Test]
+        public void Verify_that_an_existing_report_file_is_overwritten()
+        {
+            var modelFileInfo = new FileInfo(Path.Combine(TestContext.CurrentContext.TestDirectory, "Data", "recipe.ecore"));
+
+            var reportFileInfo = new FileInfo(Path.Combine(TestContext.CurrentContext.TestDirectory, "html-report.overwrite.html"));
+
+            this.htmlReportGenerator.GenerateReport(modelFileInfo, reportFileInfo);
+
+            // a second generation to the same path must overwrite the existing file without throwing
+            Assert.That(() => this.htmlReportGenerator.GenerateReport(modelFileInfo, reportFileInfo), Throws.Nothing);
+            Assert.That(reportFileInfo.Exists, Is.True);
+        }
+
+        [Test]
+        public void Verify_that_the_custom_html_is_injected_into_the_report()
+        {
+            var modelFileInfo = new FileInfo(Path.Combine(TestContext.CurrentContext.TestDirectory, "Data", "recipe.ecore"));
+
+            const string customHtml = "<div id=\"my-injected-block\">custom-content-marker</div>";
+
+            var html = this.htmlReportGenerator.GenerateReport(modelFileInfo, customHtml);
+
+            Assert.That(html, Does.Contain("custom-content-marker"));
+        }
+
+        [Test]
+        public void Verify_that_the_default_constructor_generates_a_report()
+        {
+            var generator = new HtmlReportGenerator();
+
+            var modelFileInfo = new FileInfo(Path.Combine(TestContext.CurrentContext.TestDirectory, "Data", "recipe.ecore"));
+
+            Assert.That(() => generator.GenerateReport(modelFileInfo), Throws.Nothing);
+        }
+
+        [Test]
         public void Verify_that_when_modelpath_is_null_exception_is_thrown()
         {
             FileInfo? modelFileInfo = null;

--- a/ECoreNetto.Reporting/Drawing/AssociationDiagramRenderer.cs
+++ b/ECoreNetto.Reporting/Drawing/AssociationDiagramRenderer.cs
@@ -1,0 +1,650 @@
+// ------------------------------------------------------------------------------------------------
+// <copyright file="AssociationDiagramRenderer.cs" company="Starion Group S.A.">
+//
+//   Copyright 2017-2026 Starion Group S.A.
+//   SPDX-License-Identifier: Apache-2.0
+//
+// </copyright>
+// ------------------------------------------------------------------------------------------------
+
+namespace ECoreNetto.Reporting.Drawing
+{
+    using System;
+    using System.Collections.Generic;
+    using System.IO;
+    using System.Linq;
+
+    using ECoreNetto.Extensions;
+    using ECoreNetto.Reporting.Payload;
+
+    using Microsoft.Extensions.Logging;
+    using Microsoft.Extensions.Logging.Abstractions;
+    using Microsoft.Msagl.Core.Geometry.Curves;
+    using Microsoft.Msagl.Core.Layout;
+    using Microsoft.Msagl.Core.Routing;
+    using Microsoft.Msagl.Layout.Layered;
+
+    using Svg;
+    using Svg.DataTypes;
+    using Svg.Pathing;
+
+    /// <summary>
+    /// The purpose of the <see cref="AssociationDiagramRenderer"/> is to render an Ecore association diagram
+    /// that shows a class and all its first-order neighbours connected by typed references.
+    /// </summary>
+    public class AssociationDiagramRenderer : IAssociationDiagramRenderer
+    {
+        /// <summary>
+        /// The <see cref="ILogger"/> used to log
+        /// </summary>
+        private readonly ILogger<AssociationDiagramRenderer> logger;
+
+        /// <summary>
+        /// Initializes a new instance of the <see cref="AssociationDiagramRenderer"/> class
+        /// </summary>
+        /// <param name="loggerFactory">
+        /// The (injected) <see cref="ILoggerFactory"/> used to set up logging
+        /// </param>
+        public AssociationDiagramRenderer(ILoggerFactory? loggerFactory = null)
+        {
+            this.logger = loggerFactory == null ? NullLogger<AssociationDiagramRenderer>.Instance : loggerFactory.CreateLogger<AssociationDiagramRenderer>();
+        }
+
+        /// <summary>
+        /// Renders a per-class association SVG diagram that shows the target class and all classes connected
+        /// to it via typed references.
+        /// </summary>
+        /// <param name="targetClass">
+        /// The <see cref="EClass"/> for which to render the association diagram.
+        /// </param>
+        /// <param name="payload">
+        /// The <see cref="HandlebarsPayload"/> that contains the Ecore content.
+        /// </param>
+        /// <returns>
+        /// a string that contains the per-class association diagram in SVG format, or an empty string when
+        /// the class has no associations.
+        /// </returns>
+        public string SvgRenderForClass(EClass targetClass, HandlebarsPayload payload)
+        {
+            var classSet = new HashSet<EClass>(payload.Classes);
+
+            var associationEdges = CollectAssociationEdges(targetClass, payload.Classes, classSet);
+
+            if (associationEdges.Count == 0)
+            {
+                return string.Empty;
+            }
+
+            var involvedClasses = new HashSet<EClass> { targetClass };
+
+            foreach (var edge in associationEdges)
+            {
+                involvedClasses.Add(edge.OwnerClass);
+                involvedClasses.Add(edge.TypeClass);
+            }
+
+            var geometryGraph = this.GenerateGeometryGraph(involvedClasses.ToList(), associationEdges);
+
+            var svgDocument = this.GenerateSvg(geometryGraph, targetClass);
+
+            using var ms = new MemoryStream();
+            svgDocument.Write(ms);
+            ms.Position = 0;
+            using var reader = new StreamReader(ms);
+            return reader.ReadToEnd();
+        }
+
+        /// <summary>
+        /// Collects all association edges (reference-based relationships) for the target class.
+        /// </summary>
+        /// <param name="targetClass">
+        /// The <see cref="EClass"/> for which to collect associations.
+        /// </param>
+        /// <param name="allClasses">
+        /// All classes in the payload.
+        /// </param>
+        /// <param name="classSet">
+        /// A <see cref="HashSet{T}"/> of all classes for fast lookup.
+        /// </param>
+        /// <returns>
+        /// A list of <see cref="AssociationEdgeInfo"/> representing all associations.
+        /// </returns>
+        private static List<AssociationEdgeInfo> CollectAssociationEdges(EClass targetClass, IEnumerable<EClass> allClasses, HashSet<EClass> classSet)
+        {
+            var edges = new List<AssociationEdgeInfo>();
+
+            foreach (var reference in targetClass.EStructuralFeatures.OfType<EReference>())
+            {
+                if (reference.EType is EClass typeClass && classSet.Contains(typeClass))
+                {
+                    edges.Add(new AssociationEdgeInfo(targetClass, typeClass, reference));
+                }
+            }
+
+            foreach (var otherClass in allClasses)
+            {
+                if (otherClass == targetClass)
+                {
+                    continue;
+                }
+
+                foreach (var reference in otherClass.EStructuralFeatures.OfType<EReference>())
+                {
+                    if (reference.EType is EClass typeClass && typeClass == targetClass)
+                    {
+                        edges.Add(new AssociationEdgeInfo(otherClass, targetClass, reference));
+                    }
+                }
+            }
+
+            return edges;
+        }
+
+        /// <summary>
+        /// Generates a laid-out <see cref="GeometryGraph"/> for the association diagram.
+        /// </summary>
+        /// <param name="classes">
+        /// The classes to include in the graph.
+        /// </param>
+        /// <param name="associationEdges">
+        /// The association edges to include.
+        /// </param>
+        /// <returns>
+        /// an instance of <see cref="GeometryGraph"/>.
+        /// </returns>
+        private GeometryGraph GenerateGeometryGraph(List<EClass> classes, List<AssociationEdgeInfo> associationEdges)
+        {
+            var geometryGraph = new GeometryGraph();
+
+            foreach (var @class in classes)
+            {
+                var (height, width) = SvgDrawingHelper.EstimateBoxSize(@class.Name);
+
+                var curve = CurveFactory.CreateRectangle(width, height, new Microsoft.Msagl.Core.Geometry.Point());
+
+                var node = new Node(curve, @class);
+
+                geometryGraph.Nodes.Add(node);
+            }
+
+            foreach (var assocEdge in associationEdges)
+            {
+                var sourceNode = geometryGraph.FindNodeByUserData(assocEdge.OwnerClass);
+                var targetNode = geometryGraph.FindNodeByUserData(assocEdge.TypeClass);
+
+                if (sourceNode != null && targetNode != null)
+                {
+                    var edge = new Edge(sourceNode, targetNode)
+                    {
+                        UserData = assocEdge
+                    };
+
+                    geometryGraph.Edges.Add(edge);
+                }
+            }
+
+            var settings = new SugiyamaLayoutSettings
+            {
+                LayerSeparation = 180,
+                NodeSeparation = 120,
+                EdgeRoutingSettings = new EdgeRoutingSettings
+                {
+                    EdgeRoutingMode = EdgeRoutingMode.Rectilinear,
+                },
+            };
+
+            var layoutEngine = new LayeredLayout(geometryGraph, settings);
+            layoutEngine.Run();
+
+            return geometryGraph;
+        }
+
+        /// <summary>
+        /// Generates an SVG document for the association diagram.
+        /// </summary>
+        /// <param name="geometryGraph">
+        /// The subject <see cref="GeometryGraph"/>.
+        /// </param>
+        /// <param name="targetClass">
+        /// The <see cref="EClass"/> that should be highlighted in the diagram.
+        /// </param>
+        /// <returns>
+        /// The generated <see cref="SvgDocument"/>.
+        /// </returns>
+        private SvgDocument GenerateSvg(GeometryGraph geometryGraph, EClass targetClass)
+        {
+            const float padding = 40f;
+
+            var bbox = geometryGraph.BoundingBox;
+
+            var width = (float)(bbox.Width + 2 * padding);
+            var height = (float)(bbox.Height + 2 * padding);
+
+            var anchor = targetClass.QueryAnchorId();
+
+            var svgDocument = new SvgDocument
+            {
+                Width = width,
+                Height = height,
+                ViewBox = new SvgViewBox(
+                    (float)(bbox.Left - padding),
+                    (float)(bbox.Bottom - padding),
+                    width,
+                    height),
+                ID = $"association-diagram-{anchor}"
+            };
+
+            svgDocument.Children.Add(new SvgRectangle
+            {
+                X = (float)(bbox.Left - padding),
+                Y = (float)(bbox.Bottom - padding),
+                Width = width,
+                Height = height,
+                Fill = SvgPaintServer.None,
+                Stroke = new SvgColourServer(System.Drawing.Color.Black),
+                StrokeWidth = 1
+            });
+
+            this.AddMarkerDefinitions(svgDocument, anchor);
+
+            foreach (var node in geometryGraph.Nodes)
+            {
+                var @class = (EClass)node.UserData;
+                svgDocument.Children.Add(this.ConvertNodeToRectangleAndLabel(node, @class == targetClass));
+            }
+
+            foreach (var edge in geometryGraph.Edges)
+            {
+                var group = this.ConvertEdgeToSvgGroup(edge, anchor);
+                if (group != null)
+                {
+                    svgDocument.Children.Add(group);
+                }
+            }
+
+            return svgDocument;
+        }
+
+        /// <summary>
+        /// Adds SVG marker definitions for the composition diamond and the navigability arrow.
+        /// </summary>
+        /// <param name="svgDocument">
+        /// The <see cref="SvgDocument"/> to add markers to.
+        /// </param>
+        /// <param name="idPrefix">
+        /// A prefix for marker ids to ensure uniqueness.
+        /// </param>
+        private void AddMarkerDefinitions(SvgDocument svgDocument, string idPrefix)
+        {
+            var compositionMarker = new SvgMarker
+            {
+                ID = $"composition-diamond-{idPrefix}",
+                MarkerUnits = SvgMarkerUnits.StrokeWidth,
+                MarkerWidth = 12,
+                MarkerHeight = 8,
+                RefX = 0,
+                RefY = 4,
+                Orient = new SvgOrient { IsAuto = true }
+            };
+
+            compositionMarker.Children.Add(new SvgPath
+            {
+                Stroke = new SvgColourServer(System.Drawing.Color.Black),
+                Fill = new SvgColourServer(System.Drawing.Color.Black),
+                StrokeWidth = 1,
+                PathData = SvgPathBuilder.Parse("M0,4 L6,0 L12,4 L6,8 Z".AsSpan())
+            });
+
+            svgDocument.Children.Add(compositionMarker);
+
+            var arrowMarker = new SvgMarker
+            {
+                ID = $"navigable-arrow-{idPrefix}",
+                MarkerUnits = SvgMarkerUnits.StrokeWidth,
+                MarkerWidth = 10,
+                MarkerHeight = 10,
+                RefX = 10,
+                RefY = 5,
+                Orient = new SvgOrient { IsAuto = true }
+            };
+
+            arrowMarker.Children.Add(new SvgPath
+            {
+                Stroke = new SvgColourServer(System.Drawing.Color.Black),
+                Fill = SvgPaintServer.None,
+                StrokeWidth = 1,
+                PathData = SvgPathBuilder.Parse("M0,0 L10,5 L0,10".AsSpan())
+            });
+
+            svgDocument.Children.Add(arrowMarker);
+        }
+
+        /// <summary>
+        /// Converts a <see cref="Node"/> to an <see cref="SvgGroup"/> containing a rectangle, label and tooltip.
+        /// </summary>
+        /// <param name="node">
+        /// The <see cref="Node"/> that represents an <see cref="EClass"/> in the association diagram.
+        /// </param>
+        /// <param name="isTarget">
+        /// Whether this node represents the target class that should be highlighted.
+        /// </param>
+        /// <returns>
+        /// the <see cref="SvgGroup"/>.
+        /// </returns>
+        private SvgGroup ConvertNodeToRectangleAndLabel(Node node, bool isTarget)
+        {
+            var box = node.BoundingBox;
+            var @class = (EClass)node.UserData;
+
+            var fillColor = isTarget ? System.Drawing.Color.FromArgb(5, 166, 229) : System.Drawing.Color.White;
+            var textColor = isTarget ? System.Drawing.Color.White : System.Drawing.Color.Black;
+
+            var anchor = new SvgAnchor
+            {
+                Href = $"#{@class.QueryAnchorId()}"
+            };
+
+            var rectangle = new SvgRectangle
+            {
+                X = (float)box.Left,
+                Y = (float)box.Bottom,
+                Width = (float)box.Width,
+                Height = (float)box.Height,
+                Fill = new SvgColourServer(fillColor),
+                Stroke = new SvgColourServer(System.Drawing.Color.Black)
+            };
+
+            var label = new SvgText(@class.Name)
+            {
+                X = { (float)box.Center.X },
+                Y = { (float)box.Center.Y + 4 },
+                TextAnchor = SvgTextAnchor.Middle,
+                FontSize = 12,
+                FontFamily = "sans-serif",
+                Fill = new SvgColourServer(textColor),
+                FontStyle = @class.Abstract ? SvgFontStyle.Italic : SvgFontStyle.Normal
+            };
+
+            anchor.Children.Add(rectangle);
+            anchor.Children.Add(label);
+            anchor.Children.Add(new SvgTitle { Content = $"Name: {@class.Name}\nIs Abstract: {@class.Abstract}" });
+
+            var group = new SvgGroup();
+            group.Children.Add(anchor);
+
+            return group;
+        }
+
+        /// <summary>
+        /// Converts an <see cref="Edge"/> into an <see cref="SvgGroup"/> containing the edge path, markers,
+        /// multiplicity labels and role name.
+        /// </summary>
+        /// <param name="edge">
+        /// The subject <see cref="Edge"/> that is to be converted.
+        /// </param>
+        /// <param name="idPrefix">
+        /// A prefix for marker reference ids.
+        /// </param>
+        /// <returns>
+        /// the resulting <see cref="SvgGroup"/>, or null when the edge has no curve.
+        /// </returns>
+        private SvgGroup? ConvertEdgeToSvgGroup(Edge edge, string idPrefix)
+        {
+            var curve = edge.Curve;
+            if (curve == null)
+            {
+                return null;
+            }
+
+            var assocEdge = (AssociationEdgeInfo)edge.UserData;
+            var reference = assocEdge.Reference;
+
+            var segments = new SvgPathSegmentList();
+
+            segments.Add(new SvgMoveToSegment(false, SvgDrawingHelper.ToPointF(curve.Start)));
+
+            switch (curve)
+            {
+                case Curve compound:
+                    foreach (var segment in compound.Segments)
+                    {
+                        this.AddSegment(segments, segment);
+                    }
+
+                    break;
+
+                case LineSegment line:
+                    segments.Add(new SvgLineSegment(false, SvgDrawingHelper.ToPointF(line.End)));
+                    break;
+
+                case CubicBezierSegment bezier:
+                    segments.Add(new SvgCubicCurveSegment(
+                        false,
+                        SvgDrawingHelper.ToPointF(bezier.B(0)),
+                        SvgDrawingHelper.ToPointF(bezier.B(1)),
+                        SvgDrawingHelper.ToPointF(bezier.B(3))));
+                    break;
+
+                case Polyline polyline:
+                    foreach (var point in polyline.Skip(1))
+                    {
+                        segments.Add(new SvgLineSegment(false, SvgDrawingHelper.ToPointF(point)));
+                    }
+
+                    break;
+
+                default:
+                    this.logger.LogWarning("Unsupported Curve type encountered: {CurveType}", curve.GetType().FullName);
+                    return null;
+            }
+
+            var svgPath = new SvgPath
+            {
+                Stroke = new SvgColourServer(System.Drawing.Color.Black),
+                Fill = SvgPaintServer.None,
+                PathData = segments,
+                MarkerEnd = new Uri($"url(#navigable-arrow-{idPrefix})", UriKind.Relative)
+            };
+
+            if (reference.IsContainment)
+            {
+                svgPath.MarkerStart = new Uri($"url(#composition-diamond-{idPrefix})", UriKind.Relative);
+            }
+
+            var group = new SvgGroup();
+
+            var hitArea = new SvgPath
+            {
+                Stroke = new SvgColourServer(System.Drawing.Color.Transparent),
+                Fill = SvgPaintServer.None,
+                PathData = segments,
+                StrokeWidth = 12
+            };
+
+            group.Children.Add(hitArea);
+            group.Children.Add(svgPath);
+
+            var multiplicity = FormatMultiplicity(reference.LowerBound, reference.UpperBound);
+
+            group.Children.Add(new SvgTitle
+            {
+                Content = $"Source: {assocEdge.OwnerClass.Name}\n" +
+                          $"Target: {assocEdge.TypeClass.Name}\n" +
+                          $"Reference: {reference.Name}\n" +
+                          $"Multiplicity: {multiplicity}\n" +
+                          $"Containment: {reference.IsContainment}"
+            });
+
+            var endPoint = curve.End;
+            var penultimatePoint = GetPenultimatePoint(curve);
+            var (labelOffsetX, labelOffsetY, textAnchor) = ComputeLabelOffset(endPoint, penultimatePoint);
+
+            group.Children.Add(new SvgText(multiplicity)
+            {
+                X = { (float)(endPoint.X + labelOffsetX) },
+                Y = { (float)(endPoint.Y + labelOffsetY - 10) },
+                TextAnchor = textAnchor,
+                FontSize = 10,
+                FontFamily = "sans-serif",
+                Fill = new SvgColourServer(System.Drawing.Color.DarkBlue)
+            });
+
+            if (!string.IsNullOrEmpty(reference.Name))
+            {
+                group.Children.Add(new SvgText(reference.Name)
+                {
+                    X = { (float)(endPoint.X + labelOffsetX) },
+                    Y = { (float)(endPoint.Y + labelOffsetY + 4) },
+                    TextAnchor = textAnchor,
+                    FontSize = 10,
+                    FontFamily = "sans-serif",
+                    Fill = new SvgColourServer(System.Drawing.Color.DarkGray)
+                });
+            }
+
+            return group;
+        }
+
+        /// <summary>
+        /// Adds a segment to the given <see cref="SvgPathSegmentList"/> based on the specified MSAGL curve segment.
+        /// </summary>
+        /// <param name="segments">
+        /// The <see cref="SvgPathSegmentList"/> to which the SVG path segment will be added.
+        /// </param>
+        /// <param name="segment">
+        /// The MSAGL <see cref="ICurve"/> segment to convert into an SVG path segment.
+        /// </param>
+        private void AddSegment(SvgPathSegmentList segments, ICurve segment)
+        {
+            switch (segment)
+            {
+                case LineSegment line:
+                    segments.Add(new SvgLineSegment(false, SvgDrawingHelper.ToPointF(line.End)));
+                    break;
+
+                case CubicBezierSegment bezier:
+                    segments.Add(new SvgCubicCurveSegment(
+                        false,
+                        SvgDrawingHelper.ToPointF(bezier.B(0)),
+                        SvgDrawingHelper.ToPointF(bezier.B(1)),
+                        SvgDrawingHelper.ToPointF(bezier.B(3))));
+                    break;
+
+                default:
+                    this.logger.LogWarning("Unsupported segment type encountered: {SegmentType}", segment.GetType().FullName);
+                    break;
+            }
+        }
+
+        /// <summary>
+        /// Gets the penultimate point on the curve (the point just before the end), used to determine the
+        /// direction the edge approaches its target.
+        /// </summary>
+        /// <param name="curve">
+        /// The <see cref="ICurve"/> from which to extract the penultimate point.
+        /// </param>
+        /// <returns>
+        /// The penultimate <see cref="Microsoft.Msagl.Core.Geometry.Point"/>.
+        /// </returns>
+        private static Microsoft.Msagl.Core.Geometry.Point GetPenultimatePoint(ICurve curve)
+        {
+            switch (curve)
+            {
+                case Curve compound when compound.Segments.Count > 0:
+                    return compound.Segments[compound.Segments.Count - 1].Start;
+
+                case Polyline polyline:
+                    var points = polyline.ToArray();
+                    return points.Length >= 2 ? points[points.Length - 2] : curve.Start;
+
+                default:
+                    return curve.Start;
+            }
+        }
+
+        /// <summary>
+        /// Computes the label offset and text anchor based on the direction the edge approaches the target node.
+        /// </summary>
+        /// <param name="endPoint">
+        /// The endpoint of the edge curve.
+        /// </param>
+        /// <param name="penultimatePoint">
+        /// The point just before the endpoint on the curve.
+        /// </param>
+        /// <returns>
+        /// A tuple of (offsetX, offsetY, textAnchor) for positioning the label.
+        /// </returns>
+        private static (double OffsetX, double OffsetY, SvgTextAnchor Anchor) ComputeLabelOffset(
+            Microsoft.Msagl.Core.Geometry.Point endPoint,
+            Microsoft.Msagl.Core.Geometry.Point penultimatePoint)
+        {
+            var dx = endPoint.X - penultimatePoint.X;
+            var dy = endPoint.Y - penultimatePoint.Y;
+
+            if (Math.Abs(dx) > Math.Abs(dy))
+            {
+                if (dx > 0)
+                {
+                    return (-20, -14, SvgTextAnchor.End);
+                }
+
+                return (20, -14, SvgTextAnchor.Start);
+            }
+
+            if (dy > 0)
+            {
+                return (10, -24, SvgTextAnchor.Start);
+            }
+
+            return (10, 28, SvgTextAnchor.Start);
+        }
+
+        /// <summary>
+        /// Formats the multiplicity of a reference as <c>[lower..upper]</c>, using <c>*</c> for the unbounded
+        /// upper bound (-1).
+        /// </summary>
+        /// <param name="lowerBound">the lower bound.</param>
+        /// <param name="upperBound">the upper bound (-1 means unbounded).</param>
+        /// <returns>the formatted multiplicity string.</returns>
+        private static string FormatMultiplicity(int lowerBound, int upperBound)
+        {
+            var upper = upperBound == -1 ? "*" : upperBound.ToString();
+
+            return $"[{lowerBound}..{upper}]";
+        }
+
+        /// <summary>
+        /// Represents an association edge between two classes via a reference.
+        /// </summary>
+        private class AssociationEdgeInfo
+        {
+            /// <summary>
+            /// Initializes a new instance of the <see cref="AssociationEdgeInfo"/> class.
+            /// </summary>
+            /// <param name="ownerClass">The class that owns the reference.</param>
+            /// <param name="typeClass">The class that is the type of the reference.</param>
+            /// <param name="reference">The reference that defines the relationship.</param>
+            public AssociationEdgeInfo(EClass ownerClass, EClass typeClass, EReference reference)
+            {
+                this.OwnerClass = ownerClass;
+                this.TypeClass = typeClass;
+                this.Reference = reference;
+            }
+
+            /// <summary>
+            /// Gets the class that owns the reference.
+            /// </summary>
+            public EClass OwnerClass { get; }
+
+            /// <summary>
+            /// Gets the class that is the type of the reference.
+            /// </summary>
+            public EClass TypeClass { get; }
+
+            /// <summary>
+            /// Gets the reference that defines the relationship.
+            /// </summary>
+            public EReference Reference { get; }
+        }
+    }
+}

--- a/ECoreNetto.Reporting/Drawing/IAssociationDiagramRenderer.cs
+++ b/ECoreNetto.Reporting/Drawing/IAssociationDiagramRenderer.cs
@@ -1,0 +1,36 @@
+// ------------------------------------------------------------------------------------------------
+// <copyright file="IAssociationDiagramRenderer.cs" company="Starion Group S.A.">
+//
+//   Copyright 2017-2026 Starion Group S.A.
+//   SPDX-License-Identifier: Apache-2.0
+//
+// </copyright>
+// ------------------------------------------------------------------------------------------------
+
+namespace ECoreNetto.Reporting.Drawing
+{
+    using ECoreNetto.Reporting.Payload;
+
+    /// <summary>
+    /// Definition of a service that renders a per-class Ecore association diagram as SVG.
+    /// </summary>
+    public interface IAssociationDiagramRenderer
+    {
+        /// <summary>
+        /// Renders a per-class association SVG diagram that shows the target class and all classes connected
+        /// to it via typed references, with multiplicity labels and UML notation (composition diamonds and
+        /// navigability arrows).
+        /// </summary>
+        /// <param name="targetClass">
+        /// The <see cref="EClass"/> for which to render the association diagram.
+        /// </param>
+        /// <param name="payload">
+        /// The <see cref="HandlebarsPayload"/> that contains the Ecore content.
+        /// </param>
+        /// <returns>
+        /// a string that contains the per-class association diagram in SVG format, or an empty string when
+        /// the class has no associations.
+        /// </returns>
+        string SvgRenderForClass(EClass targetClass, HandlebarsPayload payload);
+    }
+}

--- a/ECoreNetto.Reporting/Drawing/IInheritanceDiagramRenderer.cs
+++ b/ECoreNetto.Reporting/Drawing/IInheritanceDiagramRenderer.cs
@@ -1,0 +1,45 @@
+// ------------------------------------------------------------------------------------------------
+// <copyright file="IInheritanceDiagramRenderer.cs" company="Starion Group S.A.">
+//
+//   Copyright 2017-2026 Starion Group S.A.
+//   SPDX-License-Identifier: Apache-2.0
+//
+// </copyright>
+// ------------------------------------------------------------------------------------------------
+
+namespace ECoreNetto.Reporting.Drawing
+{
+    using ECoreNetto.Reporting.Payload;
+
+    /// <summary>
+    /// Definition of a service that renders an Ecore class inheritance diagram as SVG.
+    /// </summary>
+    public interface IInheritanceDiagramRenderer
+    {
+        /// <summary>
+        /// Renders a model-wide inheritance diagram for the classes in the provided <see cref="HandlebarsPayload"/>.
+        /// </summary>
+        /// <param name="payload">
+        /// The <see cref="HandlebarsPayload"/> that contains the Ecore content.
+        /// </param>
+        /// <returns>
+        /// a string that contains the diagram in SVG format.
+        /// </returns>
+        string SvgRender(HandlebarsPayload payload);
+
+        /// <summary>
+        /// Renders a per-class inheritance tree SVG diagram that highlights the target class and shows all
+        /// its ancestors and descendants.
+        /// </summary>
+        /// <param name="targetClass">
+        /// The <see cref="EClass"/> for which to render the inheritance tree.
+        /// </param>
+        /// <param name="payload">
+        /// The <see cref="HandlebarsPayload"/> that contains the Ecore content.
+        /// </param>
+        /// <returns>
+        /// a string that contains the per-class inheritance diagram in SVG format.
+        /// </returns>
+        string SvgRenderForClass(EClass targetClass, HandlebarsPayload payload);
+    }
+}

--- a/ECoreNetto.Reporting/Drawing/InheritanceDiagramRenderer.cs
+++ b/ECoreNetto.Reporting/Drawing/InheritanceDiagramRenderer.cs
@@ -1,0 +1,507 @@
+// ------------------------------------------------------------------------------------------------
+// <copyright file="InheritanceDiagramRenderer.cs" company="Starion Group S.A.">
+//
+//   Copyright 2017-2026 Starion Group S.A.
+//   SPDX-License-Identifier: Apache-2.0
+//
+// </copyright>
+// ------------------------------------------------------------------------------------------------
+
+namespace ECoreNetto.Reporting.Drawing
+{
+    using System;
+    using System.Collections.Generic;
+    using System.IO;
+    using System.Linq;
+
+    using ECoreNetto.Extensions;
+    using ECoreNetto.Reporting.Payload;
+
+    using Microsoft.Extensions.Logging;
+    using Microsoft.Extensions.Logging.Abstractions;
+    using Microsoft.Msagl.Core.Geometry.Curves;
+    using Microsoft.Msagl.Core.Layout;
+    using Microsoft.Msagl.Core.Routing;
+    using Microsoft.Msagl.Layout.Layered;
+
+    using Svg;
+    using Svg.DataTypes;
+    using Svg.Pathing;
+
+    /// <summary>
+    /// The purpose of the <see cref="InheritanceDiagramRenderer"/> is to render an Ecore class diagram
+    /// that shows the inheritance of the classes in an Ecore model.
+    /// </summary>
+    public class InheritanceDiagramRenderer : IInheritanceDiagramRenderer
+    {
+        /// <summary>
+        /// The <see cref="ILogger"/> used to log
+        /// </summary>
+        private readonly ILogger<InheritanceDiagramRenderer> logger;
+
+        /// <summary>
+        /// Initializes a new instance of the <see cref="InheritanceDiagramRenderer"/> class
+        /// </summary>
+        /// <param name="loggerFactory">
+        /// The (injected) <see cref="ILoggerFactory"/> used to set up logging
+        /// </param>
+        public InheritanceDiagramRenderer(ILoggerFactory? loggerFactory = null)
+        {
+            this.logger = loggerFactory == null ? NullLogger<InheritanceDiagramRenderer>.Instance : loggerFactory.CreateLogger<InheritanceDiagramRenderer>();
+        }
+
+        /// <summary>
+        /// Renders a model-wide inheritance diagram for the classes in the provided <see cref="HandlebarsPayload"/>.
+        /// </summary>
+        /// <param name="payload">
+        /// The <see cref="HandlebarsPayload"/> that contains the Ecore content.
+        /// </param>
+        /// <returns>
+        /// a string that contains the diagram in SVG format.
+        /// </returns>
+        public string SvgRender(HandlebarsPayload payload)
+        {
+            var geometryGraph = this.GenerateGeometryGraphForClasses(payload.Classes.ToList());
+
+            var svgDocument = this.GenerateSvg(geometryGraph);
+
+            return Serialize(svgDocument);
+        }
+
+        /// <summary>
+        /// Renders a per-class inheritance tree SVG diagram that highlights the target class and shows all
+        /// its ancestors and descendants.
+        /// </summary>
+        /// <param name="targetClass">
+        /// The <see cref="EClass"/> for which to render the inheritance tree.
+        /// </param>
+        /// <param name="payload">
+        /// The <see cref="HandlebarsPayload"/> that contains the Ecore content.
+        /// </param>
+        /// <returns>
+        /// a string that contains the per-class inheritance diagram in SVG format.
+        /// </returns>
+        public string SvgRenderForClass(EClass targetClass, HandlebarsPayload payload)
+        {
+            var ancestors = targetClass.QueryTypeHierarchy().ToList();
+            var descendants = targetClass.QueryAllDescendantSpecializations(payload.Classes).ToList();
+
+            var treeClasses = new HashSet<EClass>(ancestors) { targetClass };
+
+            foreach (var descendant in descendants)
+            {
+                treeClasses.Add(descendant);
+            }
+
+            var filteredClasses = payload.Classes.Where(c => treeClasses.Contains(c)).ToList();
+
+            var geometryGraph = this.GenerateGeometryGraphForClasses(filteredClasses);
+
+            var svgDocument = this.GenerateSvgForClass(geometryGraph, targetClass);
+
+            return Serialize(svgDocument);
+        }
+
+        /// <summary>
+        /// Serializes an <see cref="SvgDocument"/> to an SVG string.
+        /// </summary>
+        /// <param name="svgDocument">
+        /// The subject <see cref="SvgDocument"/>.
+        /// </param>
+        /// <returns>
+        /// the SVG document as a string.
+        /// </returns>
+        private static string Serialize(SvgDocument svgDocument)
+        {
+            using var ms = new MemoryStream();
+            svgDocument.Write(ms);
+            ms.Position = 0;
+            using var reader = new StreamReader(ms);
+            return reader.ReadToEnd();
+        }
+
+        /// <summary>
+        /// Generate a laid-out <see cref="GeometryGraph"/> for the provided classes, with an inheritance
+        /// edge for each super type.
+        /// </summary>
+        /// <param name="classes">
+        /// The classes to include in the graph.
+        /// </param>
+        /// <returns>
+        /// an instance of <see cref="GeometryGraph"/>.
+        /// </returns>
+        private GeometryGraph GenerateGeometryGraphForClasses(List<EClass> classes)
+        {
+            var geometryGraph = new GeometryGraph();
+
+            foreach (var @class in classes)
+            {
+                var (height, width) = SvgDrawingHelper.EstimateBoxSize(@class.Name);
+
+                var curve = CurveFactory.CreateRectangle(width, height, new Microsoft.Msagl.Core.Geometry.Point());
+
+                var node = new Node(curve, @class);
+
+                geometryGraph.Nodes.Add(node);
+            }
+
+            foreach (var @class in classes)
+            {
+                foreach (var superClass in @class.ESuperTypes)
+                {
+                    var sourceNode = geometryGraph.FindNodeByUserData(@class);
+                    var targetNode = geometryGraph.FindNodeByUserData(superClass);
+
+                    if (sourceNode != null && targetNode != null)
+                    {
+                        var edge = new Edge(sourceNode, targetNode);
+
+                        geometryGraph.Edges.Add(edge);
+                    }
+                }
+            }
+
+            this.logger.LogInformation("inheritance edges count: {Edges}", geometryGraph.Edges.Count);
+
+            var settings = new SugiyamaLayoutSettings
+            {
+                LayerSeparation = 30,
+                NodeSeparation = 10,
+                EdgeRoutingSettings = new EdgeRoutingSettings
+                {
+                    EdgeRoutingMode = EdgeRoutingMode.Rectilinear,
+                },
+            };
+
+            var layoutEngine = new LayeredLayout(geometryGraph, settings);
+            layoutEngine.Run();
+
+            return geometryGraph;
+        }
+
+        /// <summary>
+        /// Generates an SVG document for the whole-model inheritance diagram.
+        /// </summary>
+        /// <param name="geometryGraph">
+        /// the subject <see cref="GeometryGraph"/>.
+        /// </param>
+        /// <returns>
+        /// The generated <see cref="SvgDocument"/>.
+        /// </returns>
+        private SvgDocument GenerateSvg(GeometryGraph geometryGraph)
+        {
+            const float padding = 10f;
+
+            var bbox = geometryGraph.BoundingBox;
+
+            var width = (float)(bbox.Width + 2 * padding);
+            var height = (float)(bbox.Height + 2 * padding);
+
+            var svgDocument = new SvgDocument
+            {
+                Width = width,
+                Height = height,
+                ViewBox = new SvgViewBox(
+                    (float)(bbox.Left - padding),
+                    (float)(bbox.Bottom - padding),
+                    width,
+                    height),
+                ID = "inheritance-diagram"
+            };
+
+            svgDocument.Children.Add(new SvgTitle { Content = "Ecore Inheritance Diagram" });
+            svgDocument.Children.Add(new SvgDescription
+            {
+                Content = "An Ecore diagram showing class inheritance relationships - generated with EcoreNetto"
+            });
+
+            svgDocument.Children.Add(CreateBorder(bbox, padding, width, height));
+
+            svgDocument.Children.Add(CreateArrowMarker("generalization-arrow"));
+
+            foreach (var node in geometryGraph.Nodes)
+            {
+                svgDocument.Children.Add(this.ConvertNodeToRectangleAndLabel(node, false));
+            }
+
+            foreach (var edge in geometryGraph.Edges)
+            {
+                var svgPath = this.ConvertEdgeToSvgPath(edge, "generalization-arrow");
+                if (svgPath != null)
+                {
+                    svgDocument.Children.Add(svgPath);
+                }
+            }
+
+            return svgDocument;
+        }
+
+        /// <summary>
+        /// Generates an SVG document for a per-class inheritance tree with the target class highlighted.
+        /// </summary>
+        /// <param name="geometryGraph">
+        /// the subject <see cref="GeometryGraph"/>.
+        /// </param>
+        /// <param name="targetClass">
+        /// The <see cref="EClass"/> that should be highlighted in the diagram.
+        /// </param>
+        /// <returns>
+        /// The generated <see cref="SvgDocument"/>.
+        /// </returns>
+        private SvgDocument GenerateSvgForClass(GeometryGraph geometryGraph, EClass targetClass)
+        {
+            const float padding = 10f;
+
+            var bbox = geometryGraph.BoundingBox;
+
+            var width = (float)(bbox.Width + 2 * padding);
+            var height = (float)(bbox.Height + 2 * padding);
+
+            var anchor = targetClass.QueryAnchorId();
+            var markerId = $"gen-arrow-{anchor}";
+
+            var svgDocument = new SvgDocument
+            {
+                Width = width,
+                Height = height,
+                ViewBox = new SvgViewBox(
+                    (float)(bbox.Left - padding),
+                    (float)(bbox.Bottom - padding),
+                    width,
+                    height),
+                ID = $"inheritance-tree-{anchor}"
+            };
+
+            svgDocument.Children.Add(CreateBorder(bbox, padding, width, height));
+            svgDocument.Children.Add(CreateArrowMarker(markerId));
+
+            foreach (var node in geometryGraph.Nodes)
+            {
+                var @class = (EClass)node.UserData;
+                svgDocument.Children.Add(this.ConvertNodeToRectangleAndLabel(node, @class == targetClass));
+            }
+
+            foreach (var edge in geometryGraph.Edges)
+            {
+                var svgPath = this.ConvertEdgeToSvgPath(edge, markerId);
+                if (svgPath != null)
+                {
+                    svgDocument.Children.Add(svgPath);
+                }
+            }
+
+            return svgDocument;
+        }
+
+        /// <summary>
+        /// Creates the diagram border rectangle.
+        /// </summary>
+        /// <param name="bbox">the bounding box of the graph.</param>
+        /// <param name="padding">the diagram padding.</param>
+        /// <param name="width">the diagram width.</param>
+        /// <param name="height">the diagram height.</param>
+        /// <returns>the border <see cref="SvgRectangle"/>.</returns>
+        private static SvgRectangle CreateBorder(Microsoft.Msagl.Core.Geometry.Rectangle bbox, float padding, float width, float height)
+        {
+            return new SvgRectangle
+            {
+                X = (float)(bbox.Left - padding),
+                Y = (float)(bbox.Bottom - padding),
+                Width = width,
+                Height = height,
+                Fill = SvgPaintServer.None,
+                Stroke = new SvgColourServer(System.Drawing.Color.Black),
+                StrokeWidth = 1
+            };
+        }
+
+        /// <summary>
+        /// Creates a hollow-triangle generalization arrow marker with the provided id.
+        /// </summary>
+        /// <param name="markerId">the marker id.</param>
+        /// <returns>the <see cref="SvgMarker"/>.</returns>
+        private static SvgMarker CreateArrowMarker(string markerId)
+        {
+            var arrowMarker = new SvgMarker
+            {
+                ID = markerId,
+                MarkerUnits = SvgMarkerUnits.StrokeWidth,
+                MarkerWidth = 10,
+                MarkerHeight = 10,
+                RefX = 10,
+                RefY = 5,
+                Orient = new SvgOrient { IsAuto = true }
+            };
+
+            arrowMarker.Children.Add(new SvgPath
+            {
+                Stroke = new SvgColourServer(System.Drawing.Color.Black),
+                Fill = new SvgColourServer(System.Drawing.Color.White),
+                StrokeWidth = 1,
+                PathData = SvgPathBuilder.Parse("M0,0 L10,5 L0,10 Z".AsSpan())
+            });
+
+            return arrowMarker;
+        }
+
+        /// <summary>
+        /// Converts a <see cref="Node"/> to an <see cref="SvgGroup"/> containing a rectangle, label and tooltip.
+        /// </summary>
+        /// <param name="node">
+        /// The <see cref="Node"/> that represents an <see cref="EClass"/> in the inheritance diagram.
+        /// </param>
+        /// <param name="isTarget">
+        /// Whether this node represents the target class that should be highlighted.
+        /// </param>
+        /// <returns>
+        /// the <see cref="SvgGroup"/>.
+        /// </returns>
+        private SvgGroup ConvertNodeToRectangleAndLabel(Node node, bool isTarget)
+        {
+            var box = node.BoundingBox;
+            var @class = (EClass)node.UserData;
+
+            var fillColor = isTarget ? System.Drawing.Color.FromArgb(5, 166, 229) : System.Drawing.Color.White;
+            var textColor = isTarget ? System.Drawing.Color.White : System.Drawing.Color.Black;
+
+            var anchor = new SvgAnchor
+            {
+                Href = $"#{@class.QueryAnchorId()}"
+            };
+
+            var rectangle = new SvgRectangle
+            {
+                X = (float)box.Left,
+                Y = (float)box.Bottom,
+                Width = (float)box.Width,
+                Height = (float)box.Height,
+                Fill = new SvgColourServer(fillColor),
+                Stroke = new SvgColourServer(System.Drawing.Color.Black)
+            };
+
+            var label = new SvgText(@class.Name)
+            {
+                X = { (float)box.Center.X },
+                Y = { (float)box.Center.Y + 4 },
+                TextAnchor = SvgTextAnchor.Middle,
+                FontSize = 12,
+                FontFamily = "sans-serif",
+                Fill = new SvgColourServer(textColor),
+                FontStyle = @class.Abstract ? SvgFontStyle.Italic : SvgFontStyle.Normal
+            };
+
+            var tooltipText = $"Name: {@class.Name}\n" +
+                              $"Is Abstract: {@class.Abstract}\n" +
+                              $"Superclasses: {string.Join(", ", @class.ESuperTypes.Select(c => c.Name))}\n" +
+                              $"Description: {@class.QueryRawDocumentation()}";
+
+            anchor.Children.Add(rectangle);
+            anchor.Children.Add(label);
+            anchor.Children.Add(new SvgTitle { Content = tooltipText });
+
+            var group = new SvgGroup();
+            group.Children.Add(anchor);
+
+            return group;
+        }
+
+        /// <summary>
+        /// Converts an <see cref="Edge"/> into an <see cref="SvgPath"/> using the specified marker id.
+        /// </summary>
+        /// <param name="edge">
+        /// The subject <see cref="Edge"/> that is to be converted.
+        /// </param>
+        /// <param name="markerId">
+        /// The id of the arrow marker to use.
+        /// </param>
+        /// <returns>
+        /// the resulting <see cref="SvgPath"/>, or null when the edge has no curve.
+        /// </returns>
+        private SvgPath? ConvertEdgeToSvgPath(Edge edge, string markerId)
+        {
+            var curve = edge.Curve;
+            if (curve == null)
+            {
+                return null;
+            }
+
+            var segments = new SvgPathSegmentList();
+
+            segments.Add(new SvgMoveToSegment(false, SvgDrawingHelper.ToPointF(curve.Start)));
+
+            switch (curve)
+            {
+                case Curve compound:
+                    foreach (var segment in compound.Segments)
+                    {
+                        this.AddSegment(segments, segment);
+                    }
+
+                    break;
+
+                case LineSegment line:
+                    segments.Add(new SvgLineSegment(false, SvgDrawingHelper.ToPointF(line.End)));
+                    break;
+
+                case CubicBezierSegment bezier:
+                    segments.Add(new SvgCubicCurveSegment(
+                        false,
+                        SvgDrawingHelper.ToPointF(bezier.B(0)),
+                        SvgDrawingHelper.ToPointF(bezier.B(1)),
+                        SvgDrawingHelper.ToPointF(bezier.B(3))));
+                    break;
+
+                case Polyline polyline:
+                    foreach (var point in polyline.Skip(1))
+                    {
+                        segments.Add(new SvgLineSegment(false, SvgDrawingHelper.ToPointF(point)));
+                    }
+
+                    break;
+
+                default:
+                    this.logger.LogWarning("Unsupported Curve type encountered: {CurveType}", curve.GetType().FullName);
+                    return null;
+            }
+
+            return new SvgPath
+            {
+                Stroke = new SvgColourServer(System.Drawing.Color.Black),
+                Fill = SvgPaintServer.None,
+                PathData = segments,
+                MarkerEnd = new Uri($"url(#{markerId})", UriKind.Relative)
+            };
+        }
+
+        /// <summary>
+        /// Adds a segment to the given <see cref="SvgPathSegmentList"/> based on the specified MSAGL curve segment.
+        /// </summary>
+        /// <param name="segments">
+        /// The <see cref="SvgPathSegmentList"/> to which the SVG path segment will be added.
+        /// </param>
+        /// <param name="segment">
+        /// The MSAGL <see cref="ICurve"/> segment to convert into an SVG path segment.
+        /// </param>
+        private void AddSegment(SvgPathSegmentList segments, ICurve segment)
+        {
+            switch (segment)
+            {
+                case LineSegment line:
+                    segments.Add(new SvgLineSegment(false, SvgDrawingHelper.ToPointF(line.End)));
+                    break;
+
+                case CubicBezierSegment bezier:
+                    segments.Add(new SvgCubicCurveSegment(
+                        false,
+                        SvgDrawingHelper.ToPointF(bezier.B(0)),
+                        SvgDrawingHelper.ToPointF(bezier.B(1)),
+                        SvgDrawingHelper.ToPointF(bezier.B(3))));
+                    break;
+
+                default:
+                    this.logger.LogWarning("Unsupported segment type encountered: {SegmentType}", segment.GetType().FullName);
+                    break;
+            }
+        }
+    }
+}

--- a/ECoreNetto.Reporting/Drawing/SvgDrawingHelper.cs
+++ b/ECoreNetto.Reporting/Drawing/SvgDrawingHelper.cs
@@ -1,0 +1,63 @@
+// ------------------------------------------------------------------------------------------------
+// <copyright file="SvgDrawingHelper.cs" company="Starion Group S.A.">
+//
+//   Copyright 2017-2026 Starion Group S.A.
+//   SPDX-License-Identifier: Apache-2.0
+//
+// </copyright>
+// ------------------------------------------------------------------------------------------------
+
+namespace ECoreNetto.Reporting.Drawing
+{
+    using System.Drawing;
+
+    /// <summary>
+    /// static class that provides helper methods for SVG drawing
+    /// </summary>
+    public static class SvgDrawingHelper
+    {
+        /// <summary>
+        /// Estimates the size of a box based on the text that is used as its label
+        /// </summary>
+        /// <param name="label">
+        /// the content of the label
+        /// </param>
+        /// <param name="fontSize">
+        /// The size of the used font
+        /// </param>
+        /// <param name="padding">
+        /// the padding surrounding the text
+        /// </param>
+        /// <returns>
+        /// the estimated height and width of the box
+        /// </returns>
+        /// <remarks>
+        /// The average character width is around 60% of the font size
+        /// </remarks>
+        public static (double Height, double Width) EstimateBoxSize(string label, double fontSize = 12, double padding = 10)
+        {
+            var avgCharWidth = 0.6 * fontSize;
+
+            var width = (label.Length * avgCharWidth) + 2 * padding;
+
+            var height = fontSize + 2 * padding;
+
+            return (height, width);
+        }
+
+        /// <summary>
+        /// Converts a <see cref="Microsoft.Msagl.Core.Geometry.Point"/> to a <see cref="System.Drawing.PointF"/>.
+        /// </summary>
+        /// <param name="pt">
+        /// The <see cref="Microsoft.Msagl.Core.Geometry.Point"/> to convert.
+        /// </param>
+        /// <returns>
+        /// A <see cref="System.Drawing.PointF"/> with the same X and Y coordinates as the input point,
+        /// cast to <see cref="float"/>.
+        /// </returns>
+        public static PointF ToPointF(Microsoft.Msagl.Core.Geometry.Point pt)
+        {
+            return new PointF((float)pt.X, (float)pt.Y);
+        }
+    }
+}

--- a/ECoreNetto.Reporting/ECoreNetto.Reporting.csproj
+++ b/ECoreNetto.Reporting/ECoreNetto.Reporting.csproj
@@ -41,6 +41,8 @@
 
     <ItemGroup>
         <PackageReference Include="ClosedXML" />
+        <PackageReference Include="Microsoft.Msagl" />
+        <PackageReference Include="Svg" />
     </ItemGroup>
 
     <ItemGroup Label="Transitive Dependency overrides">

--- a/ECoreNetto.Reporting/Generators/HandleBarsReportGenerator.cs
+++ b/ECoreNetto.Reporting/Generators/HandleBarsReportGenerator.cs
@@ -63,6 +63,11 @@ namespace ECoreNetto.Reporting.Generators
             ECoreNetto.HandleBars.StructuralFeatureHelper.RegisterStructuralFeatureHelper(this.Handlebars);
             ECoreNetto.HandleBars.GeneralizationHelper.RegisterGeneralizationHelper(this.Handlebars);
             ECoreNetto.HandleBars.DocumentationHelper.RegisteredDocumentationHelper(this.Handlebars);
+            ECoreNetto.HandleBars.AnchorHelper.RegisterAnchorHelper(this.Handlebars);
+            ECoreNetto.HandleBars.ParameterHelper.RegisterParameterHelper(this.Handlebars);
+            ECoreNetto.HandleBars.ClassHelper.RegisterClassHelper(this.Handlebars);
+            ECoreNetto.HandleBars.BooleanHelper.RegisterBooleanHelper(this.Handlebars);
+            ECoreNetto.HandleBars.IEnumerableHelper.RegisterIEnumerableHelper(this.Handlebars);
         }
 
         /// <summary>
@@ -110,17 +115,22 @@ namespace ECoreNetto.Reporting.Generators
 
                 dataTypes.AddRange(package.EClassifiers
                     .OfType<EDataType>()
-                    .Where(x => !(x is EEnum))
-                    .OrderBy(x => x.Name));
+                    .Where(x => !(x is EEnum)));
 
                 eClasses.AddRange(package.EClassifiers.OfType<EClass>());
             }
 
             var orderedEnums = enums.OrderBy(x => x.Name);
-            var orderedDataTypes = dataTypes.OrderBy(x => x.Name);
-            var orderedClasses = eClasses.OrderBy(x => x.Name);
 
-            var payload = new HandlebarsPayload(rootPackage, orderedEnums, orderedDataTypes, orderedClasses);
+            // a data type backed by an instance class (e.g. 'java.lang.String', 'int') is treated as a
+            // primitive type; a modeled data type without an instance class is an "other" data type.
+            var orderedPrimitiveTypes = dataTypes.Where(x => !string.IsNullOrEmpty(x.InstanceClassName)).OrderBy(x => x.Name);
+            var orderedDataTypes = dataTypes.Where(x => string.IsNullOrEmpty(x.InstanceClassName)).OrderBy(x => x.Name);
+
+            var orderedClasses = eClasses.OrderBy(x => x.Name);
+            var orderedInterfaces = eClasses.Where(x => x.Interface).OrderBy(x => x.Name);
+
+            var payload = new HandlebarsPayload(rootPackage, orderedEnums, orderedPrimitiveTypes, orderedDataTypes, orderedClasses, orderedInterfaces);
 
             return payload;
         }

--- a/ECoreNetto.Reporting/Generators/HtmlReportGenerator.cs
+++ b/ECoreNetto.Reporting/Generators/HtmlReportGenerator.cs
@@ -10,8 +10,13 @@
 namespace ECoreNetto.Reporting.Generators
 {
     using System;
+    using System.Collections.Generic;
     using System.Diagnostics;
     using System.IO;
+    using System.Linq;
+
+    using ECoreNetto.Extensions;
+    using ECoreNetto.Reporting.Drawing;
 
     using Microsoft.Extensions.Logging;
     using Microsoft.Extensions.Logging.Abstractions;
@@ -28,14 +33,44 @@ namespace ECoreNetto.Reporting.Generators
         private readonly ILogger<HtmlReportGenerator> logger;
 
         /// <summary>
+        /// The <see cref="IInheritanceDiagramRenderer"/> used to render the inheritance diagrams
+        /// </summary>
+        private readonly IInheritanceDiagramRenderer inheritanceDiagramRenderer;
+
+        /// <summary>
+        /// The <see cref="IAssociationDiagramRenderer"/> used to render the per-class association diagrams
+        /// </summary>
+        private readonly IAssociationDiagramRenderer associationDiagramRenderer;
+
+        /// <summary>
         /// Initializes a new instance of the <see cref="HtmlReportGenerator"/> class.
         /// </summary>
         /// <param name="loggerFactory">
         /// The (injected) <see cref="ILoggerFactory"/> used to set up logging
         /// </param>
-        public HtmlReportGenerator(ILoggerFactory? loggerFactory = null) : base(loggerFactory)
+        public HtmlReportGenerator(ILoggerFactory? loggerFactory = null)
+            : this(null, null, loggerFactory)
+        {
+        }
+
+        /// <summary>
+        /// Initializes a new instance of the <see cref="HtmlReportGenerator"/> class.
+        /// </summary>
+        /// <param name="inheritanceDiagramRenderer">
+        /// The (injected) <see cref="IInheritanceDiagramRenderer"/>; a default instance is used when null.
+        /// </param>
+        /// <param name="associationDiagramRenderer">
+        /// The (injected) <see cref="IAssociationDiagramRenderer"/>; a default instance is used when null.
+        /// </param>
+        /// <param name="loggerFactory">
+        /// The (injected) <see cref="ILoggerFactory"/> used to set up logging
+        /// </param>
+        public HtmlReportGenerator(IInheritanceDiagramRenderer? inheritanceDiagramRenderer, IAssociationDiagramRenderer? associationDiagramRenderer, ILoggerFactory? loggerFactory = null) : base(loggerFactory)
         {
             this.logger = loggerFactory == null ? NullLogger<HtmlReportGenerator>.Instance : loggerFactory.CreateLogger<HtmlReportGenerator>();
+
+            this.inheritanceDiagramRenderer = inheritanceDiagramRenderer ?? new InheritanceDiagramRenderer(loggerFactory);
+            this.associationDiagramRenderer = associationDiagramRenderer ?? new AssociationDiagramRenderer(loggerFactory);
         }
 
         /// <summary>
@@ -53,12 +88,15 @@ namespace ECoreNetto.Reporting.Generators
         /// Generates a table that contains all classes, attributes and their documentation
         /// </summary>
         /// <param name="modelPath">
-        /// /// the path to the Ecore model of which the report is to be generated.
+        /// the path to the Ecore model of which the report is to be generated.
+        /// </param>
+        /// <param name="customHtml">
+        /// optional custom HTML that is injected into the report at the custom-HTML injection point.
         /// </param>
         /// <returns>
         /// the content of an HTML report in a string
         /// </returns>
-        public string GenerateReport(FileInfo modelPath)
+        public string GenerateReport(FileInfo modelPath, string customHtml = "")
         {
             if (modelPath == null)
             {
@@ -75,7 +113,36 @@ namespace ECoreNetto.Reporting.Generators
 
             var payload = CreateHandlebarsPayload(rootPackage);
 
-            var generatedHtml = template(payload);
+            var inheritanceDiagramSvg = this.inheritanceDiagramRenderer.SvgRender(payload);
+
+            var classInheritanceDiagrams = new Dictionary<string, string>();
+            var classAssociationDiagrams = new Dictionary<string, string>();
+
+            foreach (var eClass in payload.Classes)
+            {
+                var anchor = eClass.QueryAnchorId();
+
+                // a per-class inheritance tree is only meaningful when the class participates in a hierarchy
+                if (eClass.ESuperTypes.Any() || eClass.QuerySpecializations(payload.Classes).Any())
+                {
+                    classInheritanceDiagrams[anchor] = this.inheritanceDiagramRenderer.SvgRenderForClass(eClass, payload);
+                }
+
+                var associationSvg = this.associationDiagramRenderer.SvgRenderForClass(eClass, payload);
+                if (!string.IsNullOrEmpty(associationSvg))
+                {
+                    classAssociationDiagrams[anchor] = associationSvg;
+                }
+            }
+
+            var generatedHtml = template(new
+            {
+                Payload = payload,
+                InheritanceDiagramSvg = inheritanceDiagramSvg,
+                ClassInheritanceDiagrams = classInheritanceDiagrams,
+                ClassAssociationDiagrams = classAssociationDiagrams,
+                CustomHtml = customHtml
+            });
 
             this.logger.LogInformation("Generated HTML report in {ElapsedTime} [ms]", sw.ElapsedMilliseconds);
 
@@ -93,6 +160,24 @@ namespace ECoreNetto.Reporting.Generators
         /// </param>
         public void GenerateReport(FileInfo modelPath, FileInfo outputPath)
         {
+            this.GenerateReport(modelPath, outputPath, string.Empty);
+        }
+
+        /// <summary>
+        /// Generates an HTML report and writes it to the provided <paramref name="outputPath"/>.
+        /// </summary>
+        /// <param name="modelPath">
+        /// the path to the Ecore model of which the report is to be generated.
+        /// </param>
+        /// <param name="outputPath">
+        /// the path, including filename, where the output is to be generated.
+        /// </param>
+        /// <param name="customHtml">
+        /// custom HTML that is injected into the report at the custom-HTML injection point; pass
+        /// <see cref="string.Empty"/> when none is required.
+        /// </param>
+        public void GenerateReport(FileInfo modelPath, FileInfo outputPath, string customHtml)
+        {
             if (modelPath == null)
             {
                 throw new ArgumentNullException(nameof(modelPath));
@@ -105,7 +190,7 @@ namespace ECoreNetto.Reporting.Generators
 
             var sw = Stopwatch.StartNew();
 
-            var generatedHtml = this.GenerateReport(modelPath);
+            var generatedHtml = this.GenerateReport(modelPath, customHtml);
 
             if (outputPath.Exists)
             {

--- a/ECoreNetto.Reporting/Generators/IHtmlReportGenerator.cs
+++ b/ECoreNetto.Reporting/Generators/IHtmlReportGenerator.cs
@@ -21,11 +21,29 @@ namespace ECoreNetto.Reporting.Generators
         /// Generates a table that contains all classes, attributes and their documentation
         /// </summary>
         /// <param name="modelPath">
-        /// /// the path to the Ecore model of which the report is to be generated.
+        /// the path to the Ecore model of which the report is to be generated.
+        /// </param>
+        /// <param name="customHtml">
+        /// optional custom HTML that is injected into the report at the custom-HTML injection point.
         /// </param>
         /// <returns>
         /// the content of an HTML report in a string
         /// </returns>
-        public string GenerateReport(FileInfo modelPath);
+        public string GenerateReport(FileInfo modelPath, string customHtml = "");
+
+        /// <summary>
+        /// Generates an HTML report and writes it to the provided <paramref name="outputPath"/>.
+        /// </summary>
+        /// <param name="modelPath">
+        /// the path to the Ecore model of which the report is to be generated.
+        /// </param>
+        /// <param name="outputPath">
+        /// the path, including filename, where the output is to be generated.
+        /// </param>
+        /// <param name="customHtml">
+        /// custom HTML that is injected into the report at the custom-HTML injection point; pass
+        /// <see cref="string.Empty"/> when none is required.
+        /// </param>
+        public void GenerateReport(FileInfo modelPath, FileInfo outputPath, string customHtml);
     }
 }

--- a/ECoreNetto.Reporting/Payload/HandlebarsPayload.cs
+++ b/ECoreNetto.Reporting/Payload/HandlebarsPayload.cs
@@ -30,18 +30,26 @@ namespace ECoreNetto.Reporting.Payload
         /// <param name="enums">
         /// the <see cref="EEnum"/>s in the ECore model
         /// </param>
+        /// <param name="primitiveTypes">
+        /// the primitive <see cref="EDataType"/>s in the ECore model (those backed by an instance class)
+        /// </param>
         /// <param name="dataTypes">
-        /// the <see cref="EDataType"/>s in the ECore model
+        /// the non-primitive <see cref="EDataType"/>s in the ECore model
         /// </param>
         /// <param name="classes">
         /// the <see cref="EClass"/>es in the ECore model
         /// </param>
-        public HandlebarsPayload(EPackage rootPackage, IEnumerable<EEnum> enums, IEnumerable<EDataType> dataTypes, IEnumerable<EClass> classes)
+        /// <param name="interfaces">
+        /// the <see cref="EClass"/>es in the ECore model that are marked as interfaces
+        /// </param>
+        public HandlebarsPayload(EPackage rootPackage, IEnumerable<EEnum> enums, IEnumerable<EDataType> primitiveTypes, IEnumerable<EDataType> dataTypes, IEnumerable<EClass> classes, IEnumerable<EClass> interfaces)
         {
             this.RootPackage = rootPackage;
             this.Enums = enums.ToArray();
+            this.PrimitiveTypes = primitiveTypes.ToArray();
             this.DataTypes = dataTypes.ToArray();
             this.Classes = classes.ToArray();
+            this.Interfaces = interfaces.ToArray();
         }
 
         /// <summary>
@@ -55,14 +63,24 @@ namespace ECoreNetto.Reporting.Payload
         public EEnum[] Enums { get; private set; }
 
         /// <summary>
-        /// Gets the array of <see cref="EDataType"/>
+        /// Gets the array of primitive <see cref="EDataType"/> (data types backed by an instance class)
+        /// </summary>
+        public EDataType[] PrimitiveTypes { get; private set; }
+
+        /// <summary>
+        /// Gets the array of non-primitive <see cref="EDataType"/>
         /// </summary>
         public EDataType[] DataTypes { get; private set; }
 
         /// <summary>
-        /// Gets the array of <see cref="EClass"/>
+        /// Gets the array of <see cref="EClass"/> (including those marked as interfaces)
         /// </summary>
         public EClass[] Classes { get; private set; }
+
+        /// <summary>
+        /// Gets the array of <see cref="EClass"/> that are marked as interfaces
+        /// </summary>
+        public EClass[] Interfaces { get; private set; }
 
         /// <summary>
         /// Gets the version of the reporting library

--- a/ECoreNetto.Reporting/Templates/ecore-to-html-docs.hbs
+++ b/ECoreNetto.Reporting/Templates/ecore-to-html-docs.hbs
@@ -52,8 +52,6 @@
             flex: 3;
             }
 
-            @charset 'UTF-8';
-
             .starion-table {
                 font-family: "Lucida Sans Unicode", "Lucida Grande", Sans-Serif;    
                 text-align: left;
@@ -93,7 +91,6 @@
             ol {
                 counter-reset: li; /* Initiate a counter */
                 list-style: none; /* Remove default numbering */
-                *list-style: decimal; /* Keep using default numbering for IE6/7 */
                 padding: 0;
                 margin-bottom: 4em;
                 text-shadow: 0 1px 0 rgba(255,255,255,.5);
@@ -111,86 +108,6 @@
                 margin: 0 0 0 2em; /* Add some left margin for inner lists */
             }
 
-            .rectangle-list li{
-                position: relative;
-                *padding: .4em;
-                margin: .5em 0 2.5em 0em;
-                color: #444;
-                text-decoration: none;
-                transition: all .3s ease-out;
-                letter-spacing: 1px;
-                font-size: 6pt;
-            }
-
-            .rectangle-list a{
-                position: relative;
-                padding: .4em .4em .4em .8em;
-                *padding: .4em;
-                margin: .5em 0 .5em 2.5em;
-                background: #fff;
-                color: #00A4E4;
-                font-weight: bold;
-                text-decoration: none;
-                transition: all .3s ease-out;
-                font-size: 8pt;	
-            }
-
-            .rectangle-list a:hover{
-                background: #eee;
-            }   
-
-            .rectangle-list a:before{
-                content: counter(li);
-                counter-increment: li;
-                position: absolute; 
-                left: -2.5em;
-                top: 50%;
-                margin-top: -1em;
-                background: #BFD9FF;
-                height: 2em;
-                width: 2em;
-                line-height: 2em;
-                text-align: center;
-                font-weight: bold;
-            }
-
-            ul.rectangle-list a:before{
-                content:"";
-                font-family: FontAwesome;
-                counter-increment: li;
-                position: absolute; 
-                left: -2.5em;
-                top: 50%;
-                margin-top: -1em;
-                background: #BFD9FF;
-                height: 2em;
-                width: 2em;
-                line-height: 2em;
-                text-align: center;
-                font-weight: bold;
-                
-                text-decoration: none;
-                font-style: normal;
-
-                -webkit-font-smoothing:antialiased;
-                -moz-osx-font-smoothing:grayscale;
-            }
-
-            .rectangle-list a:after{
-                position: absolute; 
-                content: '';
-                border: .5em solid transparent;
-                left: -1em;
-                top: 50%;
-                margin-top: -.5em;
-                transition: all .3s ease-out;               
-            }
-
-            .rectangle-list a:hover:after{
-                left: -.5em;
-                border-left-color: #BFD9FF;             
-            }
-
             h2 {
                 font-size: 1.8em;
                 font-weight: bold;
@@ -205,76 +122,130 @@
                 font-size: 1.2em;
                 font-weight: bold;
             }
+            /* ---- collapsible sections, diagrams and navigation (issue #91) ---- */
+            details.collapsible-section { margin: 0.5em 0; }
+            details.collapsible-section > summary { cursor: pointer; list-style: none; font-weight: bold; padding: 4px 0; }
+            details.collapsible-section > summary::-webkit-details-marker { display: none; }
+            details.collapsible-section > summary::before { content: "\25B6"; display: inline-block; margin-right: 6px; transition: transform 0.15s ease; }
+            details.collapsible-section[open] > summary::before { transform: rotate(90deg); }
+            details.collapsible-section > summary > H4 { display: inline; }
+            .section-toolbar { margin: 0.5em 0; }
+            .section-toolbar button { margin-right: 6px; cursor: pointer; }
+            .svg-scroll-container { overflow-x: auto; max-width: 100%; border: 1px solid #ddd; padding: 4px; }
+            .svg-scroll-container svg { max-width: none; }
+            .chip { display: inline-block; color: #05a6e5; font-size: 0.85em; white-space: nowrap; }
+            .download-svg { display: inline-block; margin-top: 6px; font-size: 0.9em; }
+            .empty-state { color: #666; font-style: italic; }
+            .nav-fab { position: fixed; right: 1.5em; width: 2.6em; height: 2.6em; border-radius: 50%; border: none; background: #05a6e5; color: #fff; font-size: 1em; cursor: pointer; display: none; z-index: 100; }
+            .back-to-top { bottom: 2em; }
+            .go-to-diagram { bottom: 5.5em; }
+            .sidebar-toggle { position: fixed; top: 0.6em; left: 0.6em; z-index: 101; border: none; background: #05a6e5; color: #fff; font-size: 1.1em; cursor: pointer; padding: 4px 8px; border-radius: 4px; }
+            aside.collapsed { display: none; }
+            .page-footer { margin-top: 2em; padding-top: 1em; border-top: 1px solid #ddd; font-size: 0.85em; color: #666; }
         </style>
 
-        <title>{{ this.RootPackage.Name }} - Ecore Model Documentation</title>
+        <title>{{ Payload.RootPackage.Name }} - Ecore Model Documentation</title>
+        <meta name="generator" content="EcoreNetto">
+        <meta name="description" content="{{ Payload.RootPackage.Name }} Ecore Model - HTML documentation generated with EcoreNetto">
+        <meta property="og:title" content="{{ Payload.RootPackage.Name }} - Ecore Model Documentation">
+        <meta property="og:description" content="HTML documentation of the {{ Payload.RootPackage.Name }} Ecore model, generated with EcoreNetto">
+        <meta property="og:type" content="website">
     </head>
     <body>
+        <button id="sidebar-toggle" class="sidebar-toggle" title="Toggle sidebar">&#9776;</button>
         <div class="wrap">
             <main>
-                <aside>
+                <aside id="sidebar">
                     <H2>Table of Contents</H2>
-                        <H3><a href="#Enumeration">1. EnumerationTypes ({{ this.Enums.Length }})</a></H3>
+                        <H3><a href="#Enumeration">1. Enumeration Types ({{ Payload.Enums.Length }})</a></H3>
                         <ul>
-                            {{#each this.Enums as | enum |}}
-                            <li><a href="#{{enum.Name}}">{{enum.Name}}</a></li>
+                            {{#each Payload.Enums as | enum |}}
+                            <li><a href="#{{Anchor enum}}">{{enum.Name}}</a></li>
                             {{/each}}
                         </ul>
-                        <H3><a href="#DataTypes">2. Data Types ({{ this.DataTypes.Length }})</a></H3>
+                        <H3><a href="#PrimitiveTypes">2. Primitive Types ({{ Payload.PrimitiveTypes.Length }})</a></H3>
                         <ul>
-                            {{#each this.DataTypes as | datatype |}}
-                            <li><a href="#{{datatype.Name}}">{{datatype.Name}}</a></li>
+                            {{#each Payload.PrimitiveTypes as | datatype |}}
+                            <li><a href="#{{Anchor datatype}}">{{datatype.Name}}</a></li>
                             {{/each}}
                         </ul>
-                        <H3><a href="#Classes">3. Classes ({{ this.Classes.Length }})</a></H3>
+                        <H3><a href="#DataTypes">3. Data Types ({{ Payload.DataTypes.Length }})</a></H3>
                         <ul>
-                            {{#each this.Classes as | class |}}
-                            <li><a href="#{{class.Name}}">{{class.Name}}</a></li>
+                            {{#each Payload.DataTypes as | datatype |}}
+                            <li><a href="#{{Anchor datatype}}">{{datatype.Name}}</a></li>
                             {{/each}}
                         </ul>
+                        <H3><a href="#Classes">4. Classes ({{ Payload.Classes.Length }})</a></H3>
+                        <ul>
+                            {{#each Payload.Classes as | class |}}
+                            {{#unless class.Interface}}
+                            <li><a href="#{{Anchor class}}">{{class.Name}}</a></li>
+                            {{/unless}}
+                            {{/each}}
+                        </ul>
+                        <H3><a href="#Interfaces">5. Interfaces ({{ Payload.Interfaces.Length }})</a></H3>
+                        <ul>
+                            {{#each Payload.Interfaces as | class |}}
+                            <li><a href="#{{Anchor class}}">{{class.Name}}</a></li>
+                            {{/each}}
+                        </ul>
+                        <H3><a href="#Diagrams">6. Diagrams</a></H3>
+                        <div id="customHtml">{{{ CustomHtml }}}</div>
                 </aside>
                 <article>
                     <div>
                         <a href="https://www.stariongroup.eu" target="_blank" rel="noopener noreferrer">
                             <img src="data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAABCQAAACCCAYAAACenBnpAAAACXBIWXMAAC4jAAAuIwF4pT92AAAPemlUWHRYTUw6Y29tLmFkb2JlLnhtcAAAAAAAPD94cGFja2V0IGJlZ2luPSLvu78iIGlkPSJXNU0wTXBDZWhpSHpyZVN6TlRjemtjOWQiPz4gPHg6eG1wbWV0YSB4bWxuczp4PSJhZG9iZTpuczptZXRhLyIgeDp4bXB0az0iQWRvYmUgWE1QIENvcmUgOS4xLWMwMDIgNzkuZjM1NGVmYzcwLCAyMDIzLzExLzA5LTEyOjA1OjUzICAgICAgICAiPiA8cmRmOlJERiB4bWxuczpyZGY9Imh0dHA6Ly93d3cudzMub3JnLzE5OTkvMDIvMjItcmRmLXN5bnRheC1ucyMiPiA8cmRmOkRlc2NyaXB0aW9uIHJkZjphYm91dD0iIiB4bWxuczpkYz0iaHR0cDovL3B1cmwub3JnL2RjL2VsZW1lbnRzLzEuMS8iIHhtbG5zOnhtcD0iaHR0cDovL25zLmFkb2JlLmNvbS94YXAvMS4wLyIgeG1sbnM6eG1wTU09Imh0dHA6Ly9ucy5hZG9iZS5jb20veGFwLzEuMC9tbS8iIHhtbG5zOnN0UmVmPSJodHRwOi8vbnMuYWRvYmUuY29tL3hhcC8xLjAvc1R5cGUvUmVzb3VyY2VSZWYjIiB4bWxuczpzdEV2dD0iaHR0cDovL25zLmFkb2JlLmNvbS94YXAvMS4wL3NUeXBlL1Jlc291cmNlRXZlbnQjIiB4bWxuczppbGx1c3RyYXRvcj0iaHR0cDovL25zLmFkb2JlLmNvbS9pbGx1c3RyYXRvci8xLjAvIiB4bWxuczp4bXBUUGc9Imh0dHA6Ly9ucy5hZG9iZS5jb20veGFwLzEuMC90L3BnLyIgeG1sbnM6c3REaW09Imh0dHA6Ly9ucy5hZG9iZS5jb20veGFwLzEuMC9zVHlwZS9EaW1lbnNpb25zIyIgeG1sbnM6eG1wRz0iaHR0cDovL25zLmFkb2JlLmNvbS94YXAvMS4wL2cvIiB4bWxuczpwZGY9Imh0dHA6Ly9ucy5hZG9iZS5jb20vcGRmLzEuMy8iIHhtbG5zOnBob3Rvc2hvcD0iaHR0cDovL25zLmFkb2JlLmNvbS9waG90b3Nob3AvMS4wLyIgZGM6Zm9ybWF0PSJpbWFnZS9wbmciIHhtcDpNZXRhZGF0YURhdGU9IjIwMjQtMDItMTNUMTg6MTA6MDFaIiB4bXA6TW9kaWZ5RGF0ZT0iMjAyNC0wMi0xM1QxODoxMDowMVoiIHhtcDpDcmVhdGVEYXRlPSIyMDI0LTAyLTEzVDE3OjQzOjUwWiIgeG1wOkNyZWF0b3JUb29sPSJBZG9iZSBJbGx1c3RyYXRvciAyOC4yIChNYWNpbnRvc2gpIiB4bXBNTTpJbnN0YW5jZUlEPSJ4bXAuaWlkOjU4YTE1MzZjLThlZWYtNDcxOC1hMTFhLWI2Yjc3ZmVhYzc4ZCIgeG1wTU06RG9jdW1lbnRJRD0iYWRvYmU6ZG9jaWQ6cGhvdG9zaG9wOjY4MzZjNWE3LWQ3OGQtNGE0OS04YjVlLTA4OTI1OTQ3YTk0ZiIgeG1wTU06T3JpZ2luYWxEb2N1bWVudElEPSJ1dWlkOjVEMjA4OTI0OTNCRkRCMTE5MTRBODU5MEQzMTUwOEM4IiB4bXBNTTpSZW5kaXRpb25DbGFzcz0icHJvb2Y6cGRmIiBpbGx1c3RyYXRvcjpUeXBlPSJEb2N1bWVudCIgaWxsdXN0cmF0b3I6U3RhcnR1cFByb2ZpbGU9IlByaW50IiBpbGx1c3RyYXRvcjpDcmVhdG9yU3ViVG9vbD0iQUlSb2JpbiIgeG1wVFBnOkhhc1Zpc2libGVPdmVycHJpbnQ9IkZhbHNlIiB4bXBUUGc6SGFzVmlzaWJsZVRyYW5zcGFyZW5jeT0iVHJ1ZSIgeG1wVFBnOk5QYWdlcz0iMSIgcGRmOlByb2R1Y2VyPSJBZG9iZSBQREYgbGlicmFyeSAxNy4wMCIgcGhvdG9zaG9wOkNvbG9yTW9kZT0iMyI+IDxkYzp0aXRsZT4gPHJkZjpBbHQ+IDxyZGY6bGkgeG1sOmxhbmc9IngtZGVmYXVsdCI+c3Rhcmlvbi1zb2xvLWxvZ28tcmdiPC9yZGY6bGk+IDwvcmRmOkFsdD4gPC9kYzp0aXRsZT4gPHhtcE1NOkRlcml2ZWRGcm9tIHN0UmVmOmluc3RhbmNlSUQ9InhtcC5paWQ6ZWZkNmU2ZDQtOTVjZC00MWNhLTgyMTktMTU1OTEzOWMwMmQzIiBzdFJlZjpkb2N1bWVudElEPSJ4bXAuZGlkOmVmZDZlNmQ0LTk1Y2QtNDFjYS04MjE5LTE1NTkxMzljMDJkMyIgc3RSZWY6b3JpZ2luYWxEb2N1bWVudElEPSJ1dWlkOjVEMjA4OTI0OTNCRkRCMTE5MTRBODU5MEQzMTUwOEM4IiBzdFJlZjpyZW5kaXRpb25DbGFzcz0icHJvb2Y6cGRmIi8+IDx4bXBNTTpIaXN0b3J5PiA8cmRmOlNlcT4gPHJkZjpsaSBzdEV2dDphY3Rpb249InNhdmVkIiBzdEV2dDppbnN0YW5jZUlEPSJ4bXAuaWlkOmJiZmMzM2M0LTE1NzgtNDQ0ZS1iM2VlLTkyZGVjZDA4ZjVjYSIgc3RFdnQ6d2hlbj0iMjAyNC0wMS0xOFQxMjozMzoxMVoiIHN0RXZ0OnNvZnR3YXJlQWdlbnQ9IkFkb2JlIElsbHVzdHJhdG9yIDI4LjEgKE1hY2ludG9zaCkiIHN0RXZ0OmNoYW5nZWQ9Ii8iLz4gPHJkZjpsaSBzdEV2dDphY3Rpb249InNhdmVkIiBzdEV2dDppbnN0YW5jZUlEPSJ4bXAuaWlkOmViYWEwNjQ3LWNiMGUtNGU1MC04NjczLWNlM2RjNWQ3NWMwZiIgc3RFdnQ6d2hlbj0iMjAyNC0wMi0xM1QxNzo0Mjo0MVoiIHN0RXZ0OnNvZnR3YXJlQWdlbnQ9IkFkb2JlIElsbHVzdHJhdG9yIDI4LjIgKE1hY2ludG9zaCkiIHN0RXZ0OmNoYW5nZWQ9Ii8iLz4gPHJkZjpsaSBzdEV2dDphY3Rpb249ImNvbnZlcnRlZCIgc3RFdnQ6cGFyYW1ldGVycz0iZnJvbSBhcHBsaWNhdGlvbi9wZGYgdG8gYXBwbGljYXRpb24vdm5kLmFkb2JlLnBob3Rvc2hvcCIvPiA8cmRmOmxpIHN0RXZ0OmFjdGlvbj0ic2F2ZWQiIHN0RXZ0Omluc3RhbmNlSUQ9InhtcC5paWQ6ZWZkNmU2ZDQtOTVjZC00MWNhLTgyMTktMTU1OTEzOWMwMmQzIiBzdEV2dDp3aGVuPSIyMDI0LTAyLTEzVDE4OjEwOjAxWiIgc3RFdnQ6c29mdHdhcmVBZ2VudD0iQWRvYmUgUGhvdG9zaG9wIDI1LjQgKE1hY2ludG9zaCkiIHN0RXZ0OmNoYW5nZWQ9Ii8iLz4gPHJkZjpsaSBzdEV2dDphY3Rpb249ImNvbnZlcnRlZCIgc3RFdnQ6cGFyYW1ldGVycz0iZnJvbSBhcHBsaWNhdGlvbi9wZGYgdG8gaW1hZ2UvcG5nIi8+IDxyZGY6bGkgc3RFdnQ6YWN0aW9uPSJkZXJpdmVkIiBzdEV2dDpwYXJhbWV0ZXJzPSJjb252ZXJ0ZWQgZnJvbSBhcHBsaWNhdGlvbi92bmQuYWRvYmUucGhvdG9zaG9wIHRvIGltYWdlL3BuZyIvPiA8cmRmOmxpIHN0RXZ0OmFjdGlvbj0ic2F2ZWQiIHN0RXZ0Omluc3RhbmNlSUQ9InhtcC5paWQ6NThhMTUzNmMtOGVlZi00NzE4LWExMWEtYjZiNzdmZWFjNzhkIiBzdEV2dDp3aGVuPSIyMDI0LTAyLTEzVDE4OjEwOjAxWiIgc3RFdnQ6c29mdHdhcmVBZ2VudD0iQWRvYmUgUGhvdG9zaG9wIDI1LjQgKE1hY2ludG9zaCkiIHN0RXZ0OmNoYW5nZWQ9Ii8iLz4gPC9yZGY6U2VxPiA8L3htcE1NOkhpc3Rvcnk+IDx4bXBUUGc6TWF4UGFnZVNpemUgc3REaW06dz0iMTAwLjAwMDAwMCIgc3REaW06aD0iMTAwLjAwMDAwMCIgc3REaW06dW5pdD0iTWlsbGltZXRlcnMiLz4gPHhtcFRQZzpQbGF0ZU5hbWVzPiA8cmRmOlNlcT4gPHJkZjpsaT5DeWFuPC9yZGY6bGk+IDxyZGY6bGk+TWFnZW50YTwvcmRmOmxpPiA8cmRmOmxpPlllbGxvdzwvcmRmOmxpPiA8cmRmOmxpPkJsYWNrPC9yZGY6bGk+IDwvcmRmOlNlcT4gPC94bXBUUGc6UGxhdGVOYW1lcz4gPHhtcFRQZzpTd2F0Y2hHcm91cHM+IDxyZGY6U2VxPiA8cmRmOmxpPiA8cmRmOkRlc2NyaXB0aW9uIHhtcEc6Z3JvdXBOYW1lPSJEZWZhdWx0IFN3YXRjaCBHcm91cCIgeG1wRzpncm91cFR5cGU9IjAiPiA8eG1wRzpDb2xvcmFudHM+IDxyZGY6U2VxPiA8cmRmOmxpIHhtcEc6c3dhdGNoTmFtZT0iUj0yNTUgRz02NSBCPTAgMSIgeG1wRzptb2RlPSJSR0IiIHhtcEc6dHlwZT0iUFJPQ0VTUyIgeG1wRzpyZWQ9IjI1NSIgeG1wRzpncmVlbj0iNjUiIHhtcEc6Ymx1ZT0iMCIvPiA8cmRmOmxpIHhtcEc6c3dhdGNoTmFtZT0iV2hpdGUiIHhtcEc6bW9kZT0iUkdCIiB4bXBHOnR5cGU9IlBST0NFU1MiIHhtcEc6cmVkPSIyNTUiIHhtcEc6Z3JlZW49IjI1NSIgeG1wRzpibHVlPSIyNTUiLz4gPHJkZjpsaSB4bXBHOnN3YXRjaE5hbWU9IlI9MCBHPTAgQj0wIDEiIHhtcEc6bW9kZT0iUkdCIiB4bXBHOnR5cGU9IlBST0NFU1MiIHhtcEc6cmVkPSIwIiB4bXBHOmdyZWVuPSIwIiB4bXBHOmJsdWU9IjAiLz4gPC9yZGY6U2VxPiA8L3htcEc6Q29sb3JhbnRzPiA8L3JkZjpEZXNjcmlwdGlvbj4gPC9yZGY6bGk+IDwvcmRmOlNlcT4gPC94bXBUUGc6U3dhdGNoR3JvdXBzPiA8L3JkZjpEZXNjcmlwdGlvbj4gPC9yZGY6UkRGPiA8L3g6eG1wbWV0YT4gPD94cGFja2V0IGVuZD0iciI/Pn5PNI8AAEsySURBVHic7Z13nB1V2ce/z9x7dzcFiAgICkpJaEk2oYiAqAxIL6IUkSJJlqCoL4IvqIANBQRsoIK0EBARUJqIIKjvAQtFRCAFBEPvEE0oKdvu8/4xd8kSNptb5syZc+/5fj75ZPfunXN+yc6dOfM7TxFVJRAIBAKBQCAQCAQCgUAgSyLXAgKBQCAQCAQCgUAgEAi0HsGQCAQCgUAgEAgEAoFAIJA5wZAIBAKBQCAQCAQCgUAgkDnBkAgEAoFAIBAIBAKBQCCQOcGQCAQCgUAgEAgEAoFAIJA5xeF+KCJZ6RgSjYloH7EOyLsoFEag2u5UUCAQ8AuRXiSaIze9uiDLafUT7xpF95KJaHnkSt8cFZ6Um159PANZgQq6z5j16e/b0LWOQM4ol18lirqBl+TmN15xJUN3H7EeUWGcq/lzQbm8gO7FD4qh7FqKTTSmjfYRayLRGmh5NFEhrHNrQ4kKr6L6GqW2l+SG+a+7FpQVuvuI9xAVNkllMIkW0d/XA7xE9+KXxNCfyriBTNGYtRkxenPXOlaI6ityy6LZyZdv7fIpw7X9zNKQ0GN3LPLa/B2Q6COIbItEmxJF7wFKmYkIBALNyGs8et/aYlhieyI9YrNxlNrOICrsjUhb1QeWy0/Q33eGXDL7QovyWh6dNmFDCsVriApbuNYSyD2L0fKzqM6jXP475f6/0NP9N7liXrftifXja32ZtdY70/Y8uadcns1r//mIXP10poayDfTg9demfcR2FApbUShOQGQDlPWIone41tZkLEX1GbT8FKoPo/oPtPw3uWTOY66FpYkeOenHFIpfAGw8qPWg5XmUy3ej5Wt4fPatzW4MNgu67+pHss4GF7nWMSzl/jt5feHOXPnE0sEvOzckdOr43SgUDycq7IlIuDAHAoF0KZfvZd79HxDDii92KaBTxx9FW8fZwIi6Byn3X8OoMZ+Ss2/vS01YAKhE3I3dYg5RtJlrLQFPUV2Elm+nXP4VheI1cuE/F1uZJhgSy3j9v6fJL5/4mmsZtaLTJo6i3Lc3UWEvCqXtiKKxrjW1NKrPg/6F3p6bUb1OLn3oDdeS6kW7Ju5Jse132U2oz9PfdxHdi38ov5j3WmbzBmrGC0MCYOHLR3PV0+cPfmnYlA1b6Ge2KtHT3UWxdExYHAYCAWuoPkxfz+7WzYhpE79Oqe3bDQ8UFQ7gjQX9wMGNqwq8hfXH7xXuN4GGEBmFFPYiKuyF6o+1q/MyyuXvy8w5z7iW1rzIJNcKqkUPHdtOW/v+RIXDKRRjpC2kX+QFkXeDfJK2jk+iepFOn/wnyuVLeHzWdd7t/kt0QLbzybsplr5JYdVjtWviORRKZ9oyYwMtgkSdy7+UeVFLnTbh46g+TFv7z8LiMBAIWKNcfpKeJTvLzLn/tTmNTpv4pVTMiAEKxU9qV+eJqY0XSIgKH3YtIdBEiKxGsXQMbe2Pa1fnedo1MUR4WmGYMN6coIduNFa7Os9l1Cov0tZxBcXS7ogEMyKviLQRFfagWPo147Z8TrsmnqLTJ49xLatqRDZwNO9qFNu+AczTrs6jNQ6NEQJ1ovq2cyezk0m7Jq6l0yffTKn9OkQ2ymreQCDQgqg+T7l/J7n04ResTjN1wjRKbd9LfeBi6dva1blz6uO2MklNokAgbYoUS0cTFefp1AmfdS2mCbFqKDeCTtl8C5024beMWu0RiqXPIdEY15oCNSKyNsW2byDRM9rVeZYeNnZV15JWisgYx/OvQ7F0HuO2fEi7Jn7MqZaAr7ytLlAmhoR2de5OoTSbqLBHFvMFAoEWRnU+vd27yIxZT1idpqvzANraL8DOdbRIoXiVTp2wnoWxWxPVsIMdsEcUrU5b+890+uSbvdptzTuquStoqYdsOE67Om+kfcR9lNr3RiTsFPuOyGiKpRMYuerjOm3CFzW2UiwyHZQxriUAILIJxbYbdPrkv2lX57au5QQ8QuRtRrP1i6h2dR5NsfRbRNayPVcgEGh5XqWvZw+ZOfchm5PotAm7Uij+Apt1eETWoFi6TqeOr75bR2DFRGH3MpABUWEPkPu1qzOddnyB3BgSevjGq+i0CecxesxciqV9sNPhIOASkXdSaj+bsVv8Qz+9ydvy3HOByGquJbyFqLA9xdKdOn3y9Tp1fCjeGqiGbA0JPXLSdyiWzsNR8cxAINBSLKK3ez+5ZM4/bE6iXRO3o9h2XSY5wlG0NYXiz6zP0xKELk6BjIii9YkKd+q0CVvXc7hc//JZlPvfwdJFa9Dfty49SybT17MLvT2H0df7Nfr7ZlLuvx0tP5u29NwxxE6aC/SwcZ+gY9S/KLUfjUhoR9/sRNGWdIz6u3ZN/GruoiVE8phWIkSF/WjrmKtHTrpAp2+xpmtBrYjc+N+L37x3dC9+Nz1LB+4dh9LXe/Kye4c+5VSolv+z/EvW2n5qV+cJFEtn1T1AIBAIVItqN309B8glc26yOk3XxIkUSn/OPIezr+comTE7/62ccowetcWLSPQu1zoCLYTqQnq7P2gzYku7Jq6F6o5Ehd2JCnsgsratuZzw2n8OkSufvNLV9PrpjVeh1H4+xbZDXGkIOKa/7zYWv36Q/PLxV11L0emTxxAVchM1tEJU36C/94fAWTJj9iLXcgJvR6eOX52osBOwK4XiXkknmoxY8PKHufrpvwx+yYohodMmHEap/TIcdPEIBAItRx99vZ+WGbOsLlp12sQNKZbucpR+tpS+nh1kxuz7HMzdFOhntloMjHCtI9BiqD5Df+/WMmP2y9anionYYOK+FAonEhW2sT1fJrz2313lyif+4GJqPWzslowYfR1R4X0u5g/kiHL/43Qv2VN+/sgjLmXo9MnjiAqPutRQE6ov0t/3HR6fdb537VVbCI0RNpy4O4XiiUj0IesTLnxlPFc99RajPnXDQKdsPp5i2/k2xg4EAoHlKNPb83nrZsSUzdahWDIOa+F0UChdp0ds+k5H83uNHjq2nWBGBFwgsh4SXZNF2LcYynLJ7Bvkogc+QG/PUaj6vzOp5flOpv30JtMYuerfghkRACAqbEjHyDv1iE23d6qjv8+vVAiRtSmWzmXcFg/rtAkfdy0nMDRiUJkx+xa58P4P09tzKPCa1QmjyG4NCT10bDtt7dchMirNcQOBQGBI+nq/IpfMvtDmFDp1/Oq0jTCIvNfmPCtF5L20j/hV7vJZfaC9IxRVDrijUPwQG3aelOWUcsnsi+jt3hfoyXLe1JG3L1xtojGiUzb/HiNGz0CkI8u5AzlHotVpH3mbTpuwo0MNazibuxEk2phS+3V61BZ36rQJbk2dwLDIJbN/Sc/SXYAl1iZ51/pvM5rTjWIYMerbSLRxqmMGAoHAUPT3nSozZn3f5hQ6ZfPRFNv+gEg+KuZLtBMbdp7pWoZ3qIbIkoBbiqWTddqEjbKcUmbO/T/6+y7Pcs7U6e1+JaupNKbA+za/mvYRx2c1Z8AzREZRbLtJj9j0I07m9/1eJtF2lNr/qtMn36BHbDbOtZzA0MjMuX+nr9dO3TLVRXL27X3Lv5yaIaHTJmxGVDg2rfECgUBghfT3/UQufvDrNqeoRHzdTBRtaXOemimW/lenTviEaxleEXm6qxRoJkYQFX6U+az9/TdnPmdaqPbINc8vzmSqQ8e2s8GEm2kfcWAW8wU8RmQU7SNv1MM3nuRgbr8NiQQhKnyMjpFztavzQu2aGCIY88mNVkZVXTjUy+lFSBSK30OkLbXxAoFAYHlUy/T1niYXP3iM1WmO3bHIyNHXZVLcp3Yi2tpn6hGbhmi0avF9VynQHBSK+9TbCrRuIlma6XzpYjePuYLGtNE+4neU2nfNYr5AEyCyKh2jbtHDxq6b8cyrZzyfTUoUS9MplB7TromnaNfEkO6fL+yk+wkLh3q5mMbYOm3iRKLCnmmMlTFlyuVHQJ9ENRMXPmCZqLAJIhNcy6iLcnk2WvanenLWqD5BuX+mzRZ6UKk2/MaCyykU83xNW5W2Eb/Rrolbh5ZaVSCRv4aE6vOU++9yLcMibYiMQGQ0yJqIvAdo3tz9qHAykF1xN1V/C4yvYCct1SliCqw//hpKbTvbnss6Wl4MPE25/Boir6G6FOh2rKoDkXbK5VUpFEeguh5RNMaxpnSIonUYMfoGnTp+e5k5N5taLSLNZEgkiIym2PYNVI/Srs7QkSMv2NrIUR2yfW4qhgRRdDJ4Vmitv++39Pd9SWbOnedaSiA9tKvzRxRLnhoS/ZfIjFlnu5bR8mw06XwKxYNdy1gpUbQpGl0GHOBaigf4VZl8MOX+v8jFD+b/fEwR7ercAPgwIh8lKuyOSPOk3ESFPfWITd8pl/3rP5nMJ7JaJvPYYaH1GdYfP5O2jn2sz2ODcv9c+vtvR8u30dv9T/nFvGddS6oGPWTD1RgxejNEPojIjkSFjwCruNZVF1FhK6TvZ0BXRjOOyWie7FnWkeOLun7PSTJz7rWuJbU09u67C4Z6sWFDQqdPHkNU+Fij42RKf98v5OIHD3ctI2CBKPLXPdZyNgvUwArRIyedQaF4lGsdVVMo7q9dnSfIjFnfcy0l57zDtYAGGPLm3czIjFlPAE8Al+lntirR13sIUeFkosj/ImgibRTbpgEZfWZ9zjm3GyGhn97k67R1+LUWVH0DLf+ccvnHMmPWI67l1IP88vFXgbsrf36gn992BN1LPkVU+CIinY7l1U6pfZoesenv5LJ/XWd9LhGf72XVIdHGtHVco0dtcTe9PcfLzLl/cy2pRbFzrqkOuaZpPJSvXJ6CX+GV/6V7yedciwhYQtXfi7VIMCQcol0Tv0yh+BXXOmqmWDpdp46PXcvINVHk73VhBTfvVkEuuK9XZsy6jCgaT1/v6dAEobxR9KnsJvO4foqqtZafeti4/ekY9S1b41ugTLl8Cf29G8lFD3zeVzNiKOTcu5fIxQ9eIhf+cxL9fYcDL7vWVDNtHRfpoRtlUJyxBQyJASTalraOv+r0yb/Rrs58dDprJewVULVkSBQKBzU8Rpb09/1OLn/0ddcyApbwOTdR1b+bcJOg0yZ+hmKbr+00i5Tar9auzqyLa/mDz0YlWHso84mKMXEyfb2HAW9rGeYVEk3SronZnJPisRlnKWVDD9lwHCNXmYmIH/U1VF+mXN5NLrq/S2bMbup1glz84C+A8aj+xbWWmogKq9Mx8twMZhqTwRz5IirsS7E0R7s6L9Sp49/lWk7LoGon4lzL6RsSevjGqyBRthWjG0V1lmsJAYso/ubLShQiJBygXZ2fotSWxULCHiJrEkXX6me2KrmWkkt8NirR+a4V5AmZMetK+vu+6lpHQ4hEqGbV0cFfQ6JcTt2M05g2OkZdj4gfNQtU/0VU2Fouuv+PrqVkhVxw33xGrrITqnbaDtqi2HaAHr7xHlbnEBljdfz8UqRYmk6pfZ52dZ4aOnJkgLV109DR4I25w20dewN+LYC17LricMAmPl+s+/tecS2h1dBpE/amUJwJFFxraZiosA19vX4bK7ZQn3eVJERILIdc/OAP0LJfO6jLExV2ymQen3PObaQxvnezH1JqG5/6uDZQ/TeF4g5y/r3PuJaSNXL2HX28Y62DSOpM+EP7iB9pnEL0+YpZ1eLY+UdkNMXSyUTFx3TaxC9Y/r9ubWylbOjQmyyN/iJ3aPD47JFoU9cSAlbxNUKiRy596A3XIloJnTbxIxTbrkKk3bWW1CiWpuu0iVNdy8gdPhuVWg4REkPR1+t7lERWa5ExGc2TPqqpGhJ62NhdaR/hRw0x1fmo7iI/+3vLRk7Kmb/vplA8kCy6raRFobgJ79308zaG1qO2HNlU65VGiKJ3UWr7CeO2eFi7OkOnMRtYizi3YUhE0eSGjndBoXhQZrmbgewR8dM9Vn3NtYRWQrs6t6RYugGR5gv7K7Wdq12dW7qWkTN8NSpDbZkVIJfMuZNyea5rHfUjYzOaZ0w281hA0qufogetO4KOURci4kOL+jJwuFx0/1OuhbhGzrvnWVS/7lpHTZTaT9KYttTH7e1unvbHaSHRxhRLv9ajtrhLp47/oGs5TYWtjRyJLBgSEvkR9jYYkTWICtfqUVuOdC0lkC7aNXEtwIfFxlC86lpAq6DTJm5KoXiL17vmwzOCQvG6YLwmaIx4a1QCFEshQmJFaPl3riXUTRSto3EmHcrGZDCHHcopRgd1jPouheL7UhvPJv39M+TCf/7etYzcsP0+5wHzXMuomkJxbd4zNv0oiShaM/Uxm4XQkcMGdjZyyv3pGhK616qrI+LnrlNUiEHv1anjt3EtJZAi6nV7s4WuJbQCOnXz91Is3YZIBu25HCLyPqLCrzT21qBLj9XX9nlXqV8uemChaxG5Rct3uJbQAEL7CPvXIZ+N16iQiiGhh40dT8coK2H0qaM6n7b2413LyBMy5ZQyqme71lET7SOOS72+gc9r3KwY6Mhx5KQZOnX82q7leI2tjZxSe8oREm0dfreYk2hz2jru1umTr9cpm2/hWk4gDcRf91jLC11LaHb08I3XoNj+R0TWc60lE6LCR9lo0nddy3CORHZaV2VDiJwajnJ5jmsJDWG5Jaceu2PR77S0lNKV2jp+gkgxlbFs09fzIznvnpDCuTzvXGcmIv78vxTb1mPdjQ9Md1CP17jZUqRQnEap/d/a1Xl66MhROzpl89FgIe1ItVsu/OfioX5UvyGh5ffWfWx+EKLCfrSPuE+nT75Np2z+IdeCAo3gsXssoZK+TXTK5qPpGPUnomicay2ZUiieoF0T93Mtwyn9ff5eF7TszwLcATJz7tMk+fZ+YjvKdOFL/j7AqJZlxuwh+9XXNMzB79uLUnuchiTrqL5I99IfuJaRR+S7v1tMuXyrax01UWo7JtXxbHU9aFaSjhwnUig9rl2dx4SOHDVQKNq6d6xwTVP/L6e5Qp6FqLAL7SP+rNMn/1W7Ju7pWlCgHsTf0GzVhhdegaHRQ8e2U2r/A1HU6VqLAyIKpUt1ymatZcQMxu9F3ELXAnKP6pC7LZ5gd9e+UPT3njjMwrVaNEYYteppaYjJhHL5ArliXmhNvyJUb3ItoSaKbdvpQettlN6AHm+6uURkLYqlcxi7xb902oSDXMvxgnK/nXvHMOnpDbhFUqr/2BwTFT5Ise13On2LB3Xq+INDDrZHCD4X8QuGhAX02B2LjBz9W6JoW9danCGyGqWO61u2kK+IvykbobZMoBHKZX8NiTTO/feMO5hi26TGxWSAai/9Pee7lpFrepf+wbWEmhARRoz6bHrjeZ1+6J4oGkep/WqdPvlunTp+B9dyco29AqoLVzhlA4P6WdCyWqKok7aOKxm7xSM6beJ0/cxWzWnANBMS+esep9xvPVDZHXtjwVVEhV1ca3FOFI1Hy5e6luEEnw2JECFRDf5uGojY3Q2XyF9DQlKon9LecWIKSrJB9fcy86EXXcvIM3Lpwy/gU7cNgFL7/imONibFsVqXqPAB2jr+okdOulG7Jm7qWk4+sRVxvuJo8EbCBVuj2FYUjSNquxDVr2tX549ZuvgnIaQup6j6GyGh5WBIpM1Gk2ZQKKa5GPCbqHCgdnUeLzNmfd+1lEwpl6szJMr9K/6ZKugwpQr6hzkWHf7nWk7GH1JTOZ2ifk2KxhR5/b/DFyyTCKQKzyIqVPGeKBmvmrFWOqVAf/+SlQ/WEP6acQ1GSOjB79uDYtvElNTYp9x3uWsJXqDlB5BorGsZVVMobqAHv29LueqpfzY8loi/a9w8UijuA+yhR076Of19J8vMucEQXIade8cw6ekNGBLaW/+xHiKyHsXS9xi16le0q/Ncuhf/UH4xLxQcyxM+74SKBEMiRfTIST+gUJzqWkfuKBRP14+vdZdc//LfXEvJjAUvjWLBS65V1MtzrgXknHfx4pOuNTSC3ev+s492EFUMlOUNl5V9X6jx/cMeL7ypY6jvRd5q9CQGUmOFnjtGfrmh47NEdQmLXv+taxleoPqIdzFRbR0HA40bEnidlpxXko4cUeEg7er8CehpMmP2IteinGOv9tbCFf2gfkNC1dsVXkOIrEGx9E0Kqx6rR06agZbPlBmzwy5WHvDZkCiHCIm00K7OkykUv5TZhAM76+UyoKCDXtNy5fXlXlNN/gz8bPAu+eBjln994OvBu/mDd9/7+96u661fl4CrNGYrMbTKdcvfsPVGH8qan/VdC2gABZ63OkNv9xir49vl2XoP1JiNeOnpjxBFy4ySwaZHFAGSvDbUz980UwYZJ4PfN/B1VIm+0UHHVBuRM5hy/x1y1ZNLa/xntiaq/3ItoWaKpV2Bxg0y2115WpmBjhyqXdrVeTqPz/qpGIYLfWxuVG1FSKxwTVO/IREVnqr72GZAZLXKQ8/ReuSky+nvPU1mPvS0a1ktzhjXAuomiua7ltAM6O4jp/H6f09984F/IMx+KFMABpkClfcXitfR17stqu9+i3GALhtnsEHgJ+sCV2vMR1vkhuuvURkMiZUxwbWABnhJDLYjTf2tq9RY9MjRLF3kfh99sHExsK1fKLDMDBkwQErXuJDnJYXiQ64l1EyxbaIe8O415JrnG1znyZhU9ARWTNKR42zGbfEF3aD3a3LJnKtdS3JCFI2xNLIFQwKeIOn/3ep9XUdQKB5FoThVj5z0K8r9p8klcx52Laolkchf9zjkijeMxnyc7sUX8UrdXQB/B3wSeD9wB0k0QbOyI3AmcLxjHVngc5hrMCSGZ2vXAhrgiQzmaDkzTmNKwBEpa6mPN6PnBvm+fUO+06/uES4ptT9Lr2dl3EQiOkbuBlzR4EhjUlATqAaJxlJqv0qnT/4S/f0nyCWz/+xaUsbYWTcNU8C/bjNBrntpEdncUH2hRKF4KMW2OZXKrVu5FtSC+GpIlGXm3PDg0QAaszNwNfVf0/4KHCSGPjHcBZyQmrj88r8ac4BrERng80NZaAc8PB91LaABZmUwRyuacXviV5rW02II0bVVIj+982V6e/oo9y+LfPSBQvFDjRyuMQVEhi/gG0ifqLANpbY7dPrkm3TahM1cy8kMWwVUh6mX10iEBPT3PUihuFFDYzQbIlGlcus+euSkP9Hfd5rMnGtcy2oJfMuvG0gp6O9rjY41ltCYDwC/pf6IhlnA3mJ4M7RCDOdozAeBA1OQmGdmasxDYvAvDLZ6fDYkglG5AjRmEn7XkLgvgzl8PvfrNeMOT1WFff7iWoB3PDH7FWCdN7+PCss64Lzl68r3A/VBCoVKjY9BXw8+TiR5PSrUVwtkOArFbRs6fsRon9Ov/Ccq7EVU2C1J0e87qek7ciirWSkeq+UVpi01ZkiI3Ap8oqExmplCcWcKxZ11+uR7KPd/V2bM/o1rSc2KfnqTVWj0fF4ZA458ub9iJCz398DPykN8Xy4ve+/Az5e1+nvFqu4mRmMmAr8HRtQ5xGPArmKGbGPcBXQCm9Q5tg+MBq7TmPeL4XXXYizRirvErYDvXXT+kcEcPhsSNZ/7GjMa2MuCFpu0Tsej9JjPYENiYJ2VNgNGxlAmx5CvRW81PKJBpgdsqjFFMStI2lk5wZBwT5FCcSpR4SA9ctJP0fJ3mrYjh60ICdUVpqc39gDX13MjbSPOA6po4N3CRIUPEBVu0OlbzKbcdyaPz75SDB7FmnlAsbTmkK8PGAHl/mVmwGBjYUXfv2kyDPraHiEsuw40ZixwG/XnVb5AYkYM2TFIDK9rzP7A34GRdc7hA5sAl2nM/mLQlb7bIyoPKD7XAgnXhiHQmDWAI13raIAFwOwM5mk1M25PoCNtIZZJox1kq5HNQ6AqaGpmRzuwMdQZjVjufwc9S99qhgTcIDKKQvErqE7Trs7TWGX1c+Xs2+s1mvKJyKpWxi2W7ERIyMyHXtSjtrgDiXZqZJyWIYomErX9gnFbfls37Ps+xdLFcsF9tqtstwbPP74aUZQYC/19y8wE9eL5KuyC1ojGrEtiRqxd5xCvAruJ4fHh3iSGuRpzFPCLOufxhY8DXwHOcC0kZXzeIV4QjOsV8g3A53zqWxrYKa0Fr8//Oo7ZL20RllFgjmsRHuJZVcs3mUS9hkT3kjE8OXfZ9wPtZwf+DERkFIpDv7781wMpKoH6EVmTYulsFr36BZ02oWk6cujU8W3Y2YTrl4seWLiiHzYe4t7XeyGl9mBI1ILIhhRL56H6Ne3qPBv0vKYN+8mK7sWtthPUsmjMmsCtwAZ1DrEE2FNMdTuUYriiUk/i6Drn84XTNOYfYvijayEp0moPZE2PxuwIfMG1jga50fYEGrMqfkev1nRf1JgCsJslLbb4t5iMdvubiyWuBdTJxg0c+9Z7mWqy+dbfgK85OLVkSAOjuJLXQ5QGAFE0lqiJOnJEhbWsjKv62nA/btyQeGLOrxm35emIbNjwWK2GyLspls5C9cva1XkBUfT94dyjwLCEB48WQGNWI2nPuXmdQ/QC+4vhzhqPO46kxeD765zXByLgSo3ZqomqvvucdxuMyuWopGldA1bKbWXFYpK6N7bx+Z74mhhqjZN/P/79mx90LcBTfI2QGNvAselvumkZ+soky6I6EEnMiQGDYvmvB79WGHit2LxGRlTYhqhwh06ffAt9vcfLzLl+Fgsv969hJ9NVhy3g37AhIYaybtD7HUptMxsdq2URWYNi6WRUv6hdnTMo95/R9BVc08e3hchgVtgGJ7AMjRkJXE9jpsARYril1oPE0K0xBwL343de9spYA7hWY3YQ4+2ibzA+/66CITGISleNm/HbZAK4cgVFdNPG5/+neu6JPraAfcS1gECmNGJI5O/zrAp9vcmfWhgwMoYyLga/VqwYGIVBr/lAVNiDtsIueuSkX9DXc5Jc+vALriXVRFSwda4tHO6H6XQleGL2ZYzb4nNI1My7h/YRGU2x9EUoHaVHTroS1VNlxqwnXMvyhPDg0cRoTAm4CogbGOYYMVxZ78FieEpjDiWJ0PB5h3ZlbA2ci99FAwfw2agMkVOAxkTAZ4HvU383nTxxbkbztNo9cce0RWTAPNcCApnyngaO9fle9lYGjIx6IjPejLgoQrE0yMgoJgbG4O8LTqMxihSKU4gKB+qRk86lr/c7culDb7gSUxNaXsPOuLpwuB+nYkiIQXX9nqMotd+DSFsaY7Yk/X3Jh7S/dwT9fdPo6f607tZxOT1LTxcTblwrweeLdTAkhkFjBLgU2KeBYU4Rw08a1SKGWzTmVODrjY6Vc7o05m4xXOxaSIOE64KnaEwR+BjJZ22SYzlp8Wcx3J/RXD6f+zWZcZVzZVtLWmwS1nWtRb1FuMHvz3N61Fo3Q6K3mheDTYw3vx70WtqFPpOOHF8mKiQdOYqlc3PfzEAijyMkAJk59wE9ctI3KBSbrUp7Ywx8eHp7oDxgOPQtC3Pq7132nrd3hCiS9FqfojG/As4QwwNZ/xM8weeLdUs/eFTBucAhDRz/UzF8KyUtAKcA2+FniHAtnKsxD4rhXtdCGqDVdom9RmPWIvls7UbSMWEdp4LS58QM52qle2InfnZdedS1gECmlDTmnWLqSkny+fPsDi1DX0/ypxqGMiveNDPalv2sWGONhSQ1/0eofkGnTTg51x05VO2ca6rDGs2pGRIAcvGDZ+qRk7ahUPxEmuPmjoFwo/7exGgY+PpNk6FvmdGQTttJAT4JfFJjbgZOF8Pf0hi4iQgPHk2IxpxGY90trgKOSUkOAGLo15hDSOpJNBKCmXfaSOpJbCWGV1yLqROfF3G1dhnYiSRs3U7/8PQRYDUSvWsD40hqmDQrN9ZRTLcRWubcx89iw697fF11TbtrAQ0whvpqpNha486nua+7tTGwQdyzdOXvLZaWRVcMmBQDBkapbdn3g6MuRDai1H6VTt/iePr7jpdLZt9h7x9TJyK2UjaGPe9TNSQAWLLoEEatcjsS+Rg+B+WKm9bbM8hk6FlmNgx87Y49gT015s/Ad8VkUq3bB3xefIVc8SHQmOOBkxoY4vckRSxTcQUHI4ZXKkUu78BOOeK8sB5J543d6qh6nwd8vi5U/VCmMWcCX7aoJdAY3cD/ZjxnK5n0W1tRYZfnXAvwGJ9ryYyp8zhb97KdSKLSvgm829IczUm1BT3fEnXxpoGxNcXS7frJ9/6WBS/9r9zW/W/7gqskimzdO4a9rqduSMgV87p1yua70NbxR0Q+kPb4DVHur0Q09Cz7e3mjoezNmvvDwIc15n7gdOA6MZQda3KJzw5viJBYDo2ZDnyvgSHuImnvWWWcXu2I4S6NOQE429YcOWFn4DTgq66F1IHPhkRVu2gaswFwgmUtgcb4hoM6UD6f+7Wa9D7WGGmW1souWMW1gAaoV7utz/PLYrhQYy4H/ofkPu+zmZk/ho+62AfYXWMuAL6di6gpVTu/f9Vhn3WslB+VSx96g56lH6Xcf7uN8VdIXy8sXQSv/Rf++yK8/DQ8Nw+eegjmPZD8eeqh5LWXn07e89p/YPFryYnijxkxmC2AXwMPacwUjWnVoqI+X0CDITEIjTkIOL+BIeYAe4phcUqSVogYziH5/DU7X9EYH1Px8tcqrXqqfSj7MM3d9cV3/kTSISRrfDYkar0nbmpFhV2edy3AY3xe59b73GXr87wAQAxLxHAWsCHwXWCJpfkCb6cEfAF4TGO+rrHjejhRNMbKuCLDbrJY64cilz70BqPG7EJ/38zUBi2XoXsJvLEQFrwELz+TmAtPzoV/3w+Pz4Kn/wUvPgHzn4OFr8CiV5Nj/DQbamETYCYwT2P+R2OvQ9rqwdfF1+uehsJbQWN2B35B/demJ4DdxAxfzTdlumiNfvKXaezdwt/X6wJU/1DWSOX2gF2eBj7lKHrRZzOu6hx7jXkvfu6YP+tagMf4+PseoOYaPxqzKnae1xYtH0UqhoViOAnYCPgZUENLi0CDrAJ8m+Q5bnqle1D2KKvZGbc8f7gfW23QKmff3icXPziNvt4pqC6q6qByP3QvhtcXwH9egBefhGceScyGefcnEQ7PPwavPAsLX04Mh56lSSXVACQ53z8GntaYEzWuO1/NGzSmHRjpWkedDPsBbSU0ZgfgOuqvyfAysKuYbHeexPA6sD/Yj8hwzGjgOo29Wgy2QuSUz6ZLM/MasJfDEFyfz4taIiQ2tqbCLqGGRP202oabrZTkFX7OxPCCGD4HbAZcCenX4gqskLWBC4HZGrNv5rOLjLE0rpsIibdomDHrMvp6JlHu/+ubL/Z2J2bCgpfgpafg2UfhsQcraRUPwwuPw3+eT1IqlrzhupCkj6xBUlviSY35rsas6VqQRVrhoaOp0ZjJwO+of6HxGokZ4aSvuxjmAke5mDtjNgNmapz/FAHPjUqoPmXD5wfPZmXgejTHoYZWuS+ub0uEZV52LcBjfOkklBa2PssrjUQSwzwxHAJsBaGIfsZsCvxGY/6iMdk1ilj48qoserX6VqnVUi4Pa85nFg4il8x5DPiQ7lw4hHL/WTR3u7w8sRpJkZpjNeZi4Htimq6Yks8L8pbvsKEx44A/UP8iYwmwtxgeTE9V7YjhCo35II21KfWB/YHjaazoaBb4fF1YLIbuKt/r84NnMzKf5Hp0j2MdPp//tdwX17clwjIvuRbgIxWjucO1jgaoop/k27D1Wa7a+BPD/cAeGvMR4AzI8AE5sANwl8ZcC5woBrsdOV55dlnKhkTQPgLaOt76d7GOMi5Pzh3WhM0kQmIw8qf+X5KE2J0EvJr1/C1MB0nRlHkac6mHueDD4fPCq6UjJDRmXeD/qD8ksR84SAx/SU9VQxwH3OtaRAacoTGxaxErwecH9VquC24LYAUG8wjwQddmRKWGlM8PbbWc/+tZU2GXqutkBN7CGNcCGsRLQ2IAMdwhhu2AjwMPpS8pMAz7kzQw+KnGrGVjAo1ZncFFsrVcaRbxn6RUwnPz4PHZSd3Gp/+VlFVY8HKSyTBcrUbVN1ZWSylzQwJADIvF8F0SZ/sbhAtzlpSAI0hO6l9rzJauBaVAqzx4NBWVNKL/A9ZtYJhpYrgpJUkNU9nVPpDmj3yJgKs1zvXDQKsYldVGUgTscjWwjRgedS0Ev++JS8TU9ND2LmtK7BLqR9WHnYJ72VFPrSlbn+e61yliuAGYCEwltLDNkiLweex15Khu3fQWo+KZpNbjvAfgiTlJyYX/vgiLXhtkUujClQ3pxJAYoFLN9TskxsSXgBdc6mkxBDgAuE9jfl8Jw/IVn6uJN/uD65BozGrAbcC4BoY5Tgw/T0lSaojhKeBQmr8I1JrANZUQ2jzisyFRi0n/lDUVgWp4EThQDAeL4TXXYir4fO7Xek/0sT5WWUwwJOpkjGsBDfJ6HcfkJkJiMGIoi+FSknXccYTN5SwZjZ2OHI2ZX73dSVOK+c/Bc/9OTIqkNuRKU9ScGhIDiOENMfyIxJg4GnjMraKWYzfgdo35m8bs6UPBuuXw2ZBouQgJjRkJ3ARMbmCYU8VwdiqCLCCGW4BTXevIgG1IuvrkEZ8fymq5LlxhTUVgOHqBnwCbiuEa12KWo1XOffAzQqLl7vsp4nP0D1CXaZlLQ2IAMfRU1mPrA6cA1XVVDKRB2h050j/Xyv3Qs3Sl51ouDIkBKif1+SSVRQ8DHnYsqdXYnqTTwf0ac7DG+To/hsHnG1RLLUw0pg24lqRIT71cIIavpyTJJqcAf3QtIgOO0phprkUMgc9GZdW7xGL4O61hfuWFHuACYKwYjhGTy1pYPhsSte6yjraiwi55iaTxER8jYgZTTxtgW2vcVNeflc3lb5EYE+eQmLaBbBjoyPFXjdm+gXGcmV+5fOAUQ58YrgDGkxROaYUicXliEknf4Uc1ZorGFFwLWgmttPjylsp5dDmwewPD/Jokfy73iKEfOITW6Dd/nsZs7VrEcvh8XahpoVgx6L5pSUsgYQ5wLLCOGD6b825VPptxtT4k+VhToJ6w/UDCOq4FNMACMdTTS9HW59lKyrAY5ovhWJJUjsto/vTVPPFB4G8ac63GbFzH8c7Mr1waEgOIQcVwgxi2AXYF7nCtqcXYCJhJEgq0n2Mtw9EyDx6+UkkD+hlwUAPD/AE4rPKg7wVieIWkyGWz7xS0A9dqnKsHoZaKnBLDt4HpMHwl60DVLAUMcAKwuRgmiuEcMV5cs1vi3NeYVWwKschC1wI8pt6OXHlg2LaHw2BrjWt1Q0wMT4lhCknxy9/YnCvwNj5B0rzgXI1rSmuzda6t1PzKtSExGDH8QQw7AtuRpBUEsmMz4HqNubVOx802LbH48pyzSB6W6uXvwH517i44RQx3kTzUNDvvBa7MUUSVz0ZlXTtXYriYZCGyJF05TclSktbjz5BcX64Bfgh0kUQJriKGncTwfTHepY/6fO7Xck/My7WmVkKERP34WDNkgCfrPC7XNSRWhhjmimE/krTwP2cxZwBIro+fI+nI8Q2Nq0pvc3aupVWVMzPEcDewt8ZMBr5KsuPqWxFGX9kVeEBjTgJ+vLKeshni8+Kr6btsVM6X4xsY4iFgTzF1tcvKBWI4R2M+SBIt0czsQlL5+WTXQvD7ulD3QlEMv9GYXYDf4rdZC4lpcJQYLnctxDN8Pveb/p5IqCHRCGu5FtAAT9Z5nNeGxACVzZmPaMwewOk0Vtg8UD2jSGqaHa0x3wJmiKFvBe8NNSRqRQwPiOFgYBOStIJmD4nOCyOAHwG3aZybG4PPi6+mjpDQmKOB0xoY4mlgNzFNUWujC3jEtYgMOCknKV4+P4w32o7tb8CH8L9+SQfwc435YY4ib3ygZc99Twjr1fpZ17WABni8zuOawpAYoNKFbCuSGluhq2J2rA2cD8wZZo1mK+12pWt4bw2JAcTwbzFMA8aStOBa6lhSq7AzSTeOrVwLwV9DYomY5j1fNeZQ4NwGhpgPfFQMz6YkySlieB3YH/yN9KiBn+cgvcvX6wKkkNsrhrnAtiQRRr5zHIkJnqcaJXnG53M/GBKB4VjftYAGeLTWAzRmBEmNprTpdhl1KoayGK4kSQn/PPCiKy0tyCYkafhDdeQIRS0bRQxPi+EYkjzmMyGXrbiajXcDd1TCr5xQaU06xtX8DdK0oakasw9J5FK96VSvkURG/Ds9Ve6pPCQe5VpHBqxCcsNz2ZKv5R/KKmbeDsCdaYznmJ2A+yrpmoHh8fncr+W+6E2B4+VY5FqAj2jM6uBtIVOAuXUc46zIYBaIoVcM55EU0T+Z8OyWJUN15AhFLdNCDK+I4askLurXaKG2io4YRdL7dl9H8/u88GrKnSCN2RG4GijVOUQ38DEx/DM1UTmi0tL4Z651ZMDmwCWVDiuZ4rlRCSleG8SwgKS2x41pjemQ9wF3aswhroXknJa4L1aizgKtw/quBTTAUupL2WiqdI0VIYbFYjgd2AD4HiHaPUsGOnKch72isa0TIbE8YlgohtNIFjDH4X8ubZ4pAddozM4O5vY5V7bpzDKNeT9Je6cRdQ5RBg4Ww+2piconxwH3uhaRAQeS/FuzxucHsl4x6e6gVkJzPwHMSHNcR4wArtCYH4S6EivE59SWWu+LIdqgdXifawEN8GCdLcudhdC7QAwLxPBlkjT8i/A3Cso3CsDRhKKW9hDDIjGcDWwIfIZQQMUWA6bEJhnP6/ODRy5vCPWiMZsDNwOrNjDMkWK4IR1F+UUM3SQP67kIm7TMWZWomSzx2ai0cl0QQ78YjgS+Y2N8B3yJUFfibWhMEb/D2ms9/xfaEBHIJWNdC2iAejcg1khVxTJyvfYQw3NiOIok0vIa13oCDbGksuYdlqY3JAYQQ48YLgQ2JansOsexpGZkDHCtxnRkOGcwJHKAxqwP3EZjN8/jxTAzHUX5RwxPAYcC6lqLZQrA1RrzngznDNeFFSCGb5AUEctL2+ZG2An4h8Z0uhaSI3w24/rqSMNomvtoYKWMdy2gAf5e53G2Ps/zLY2bKmJ4VAwHAlsDf3StJ1AXVV2jW8aQGEAMfZXKrp3AfsA9bhU1HeOBMzKcLzx4OEZj1ia5UTTywHmmGH6QkiRvqLS/OtW1jgxYi8SsbMtoPp+vC9Z3ripFxA6Cle9aeMD6wF0a80nXQnJCq537z6euwj6jXAvwlImuBTTAX+o8riVqSKwMMdwnhl1IOvy1QrprMxEMieEQg4rhN2LYFvgoYFxraiKO0ZgtM5rL592gXIfMVYPGjAH+QFIhuV5mACemIshPTqE1nP8PAOdkNJfP14VMFopiuBbYjaSjje+MBK7SmLNCXQmvDYl6zn0f64PVW/C5ZakUKt7MtY46eVoMT9Z5bFN32agVMfwfyVriAOBfjuUEqqOq63rRtgofEMOfgD9pzLbAScA+jiX5jgA/IWkpY5tWW3zlBo0ZCfwemNDAMEsqf36kcSqybFEGXiBpn3inmPTSLMTQX+kacD+NRZn4wGc15h4xXGp5Hp+vC5kVuxXDHRrzIeAWkjbOvnMCMFljDhbj9/W1AVrNjHsmdRX2CYZE7WxA/cWyXXNHA8e2VFHLaqisv67VmN8ARwDfBNZzqyowDFWtaYIhMQgx3A3sW8lHPYmk6FzLRpE0yPYa81Ex1nd+fS5o5u0NoRJ6fyOJU90II4AvNK4oU+7UmIPEpLczJ4ZXNOZAkoVLsy9Wf6Yxsyy3dfXZkMj0uiCGWRqzPUkNmI1X9n4P2IWkrsR+YpjlWowDWu3cn5e6Cvv4bBq5YmvXAhrglgaODSkbK0AMfcAMjfkl8DmSSFufnwmalaqiccLD9hCIYZYYDgY2IQkn73UsyVe+ksEcrbb4ck4lJPoqcNLmNQ9sTxJRleqiUgx3kezwNjsdJLsbNj+7Pi9KMr8uVAqs7kDz1FTagNatK+HzPbGeMPJHUldhH1udE5qZ7VwLqJMyidlbLyFlYyWIYUmlBtlYkppcoRVwvgg1JBpFDPMqbdI2Isl9XuJYkm/sXOm+YJNWW3w5RWMEuBj4uGstjtmE5P8hVcRwDvDrtMfNIesDv7SY7+/zdcGJUSmGV0i6VjSym5cnBupKnN5idSV8PvfrSVfy0ZDw2TB1ha+GxJ1iGkrDCxESVSKGhWL4Ookx8VPCZnJeCIZEWojhGTEcC7wX+C7wqltF3iAkbQ1t4nPooxdtl5bjR8AU1yJywic05mgL43bh5yK7VnYDvmVpbJ8fypwZlWJYDOwLXOZKgwVOBG5KO6Ipx/j8sFvzQ5IYXsO/tI21XAvwiUor+S1c66iTXzV4fDAkakQML4rhf4BNgSto/tbqeScYEmkjhvliOIlkd+8kMiw+5jF7Wx4/PHhkhMZ8E/iiax0540cap9uKTAyvA/sDi9McN6d8TWP2tTCuzw+fTheKlbzcqcCZLnWkzO7AvRo3VIDXF1rx3H8gTREZMFrj0PqzBrbFz9pKClzb4Bi2DMamf34Rw+NiOAyYDPzOsZxWJtSQsEUlLOi7JFVdj8PPKs9ZsU2lNaQtfDUk+ioPnl6gMcdgbzfbZ9qBq9NeXIphLnBUmmPmmJ9rzLiUx/T1ugA52LmqtMX+KnAszbO7tBFwt8Yc4FqIZVrx3Pex9slY1wI8Yg/XAurkz2J4vt6DNaYIjE5RzwBlMa0T6V2pC7g38CHgb671tCAhQsI2lUIqZ5PcWKYDj7lVlEsiYEuL4/u6+HL+0FEtGnMESQ2VwNBshoX/HzFcAfws7XFzyGrA9SmbOr5eFyBHkVOVmiafonlycUcBv27yuhKteO7/NVUV2bCRawEe4ashcWmDx4d0jRQRw1/FsANJWuJs13paiGBIZIUYesRwMUnLtE9BS7YaGw4ruX8aswp4u6jMzUPHcGjMfsAlrnV4QJfGHGxh3OOAey2MmzfGk3Q0SotWDFu3ghiuBvYEXnOtJUWaua6Ez/+mes/9f+Bf0fFgSFSBxqwL6aZFZsQbwDUNjhE6bFhADL8lSeP4NPCEWzUtQVXpQVUZEhrzY43RFfy5vSGZTYQYymK4iuRE3xc/wwhtYCs0saWKd2WNxuxEUpApGJfVcYHG6S4yxdANHEhrLCA+qTHHNjpIxagsNi7HCSomf9cGMfwR2BF42bGUNNkduEdjNnctJGV8jpCo69yv1D35v5S12KbTtQBP8LWj1+VieKPBMWyZi7m7x2RN5XntcpLCl8fQXPe2vJFqhMSYOn/WklTyb38rhm1J2qj9ybUmx6xradyWW3hlhcZ8ALgRPwtJuWJV4EqN0/0/E8NTJN1qmiWXfzi+pzEfbnAMn68LuTWexHA/sD3NlZo4jsSU8PWhZyha9fz/fWoqsmEb1wI84XDXAurk3BTGCCkblqlEuP+EJGLpGzRXJGAe6KvWmEvDkAgMgxiMGD5K0kP5N671OGINS+P6vPDK7Q2h0jXiFghVwOvg/cDpaQ8qhluAU9MeN4cUgV9pzLsbGCNETllCDI+R3Mvuc60lRUYD12nMdzT2OxpMY1bF74i2Rs5/36rob9ykKUOpoTGbkNxTfeOPlcLUjRJSNjJCDG+I4TskxsSPgKWOJTULVV/T0zAk2qudrJURw91i2I8kF+5KoN+tokwZYWncYEikjMaMBW7F7zxk1xyvMbtbGPcU4I8Wxs0b7wKu0Zi2Oo8P1wWLiOEVkvSNPziWkjZfA2603BXKNrbM/yxYIIZyvQeL4Qn8M8q2dS0g50xxLaBOzkhpnJCykTFimC+GLwGbADNprWc1G2RqSIQHlxoQwxwxHEKSt3QhzVO9fDjqfbBYGT4/eOSuB3SleNStwDqutTQBNqIk+oFDgOfSHjuHbAf8sM5jfb4ueLFzVQnB3Bv4pWstKbMX8HeP60q0+rl/ZQpjZMlergXkFY0ZjZ+tr+8Rk1qati2DMXfrz7whhqfFMI1kE/l613o8purrejAkHCGGeWL4DLABScvARY4l2aTH0rg+n3u5evDQmDVJcnA3dK2lSbAS7lfZnT6Q1jAyP68xn67jOJ+vC97sXImhBziMJLy1mRioK7GfayF10Orn/pVQf5SFA/Z1LSDHTMNPg+1bKY4VIiQcI4aHxfAJkmgm41qPh6QeIbHaMD9rC3lw9SOG58RwLLA+cBrwqlNBdrDVjsvHm9UAubkhVPKObyJpvRhonBeBz9kaXAx3ASfYGj9nXKAxk2o8JlwXMqJSwPlLwPGutaTMaOB6jfmWxohrMTXQ0ue+GJ4nqX/kC+tpzFauReSNSmHo/3Wtow7+LCbV4qqhqGVOEMM9YtgJ2A34p2s9HlH1ubbS1miVm/GqK3nbhviXu5crxDAf+JrGfA84GvgSsKZbVamx0NK4Lb34SgONGQHcQGMVvx8DfpGKIP95DLg+hXZfwyKGczTmgyTREs1MB8mD4VZiqo4q8vm6kKvIqWoRww805mVgBs3VmeebwJYac5gYL6qvh3M/SYX1KRViOmH9vDyfAd7rWkQdnJjyeMGQyBliuE1j/kCy9joNGOtYUt5Jz5Cgug4bGxAuqKkghleBMzTmHJIb1YnA2m5VNczTlsb1OTLH+Q1BY4rA1UDcwDDPATtXWlMGsqWLpJf9Jq6FWGYD4AqN2bvKonc+Xxe8ze0Vw+UVU+I6YKRrPSmyD0ldif3E8C/XYlaCz+d+WvfEm0iM4Y1SGs82h2vMVyprv5ZHY95JumkPWfFLMdyZ8pihy0YOEYOSdAO7jiS16FuE2msrouo1TTUpG2OqeE9wiFJGDEvE8GOS6JMzAXUsqRGetTSu1xXFXU5eiXy6lGSxXS//BXYPZoQbxPA6sD+w2LWWDNiDZLe6GnzeJfbWkAAQw60kHTjmO5aSNpuQmBJ5z/n3+dxPxZComJZnpzFWRowkiQgIJPwA/1o3LwK+bGHcUEMix4ihTwwXkpifX8FeNLjPpFrUckwV75lc7YSB2qgYE18lefDwqVjTYP5tadywG1Q/PwUObeD4JcCeYpiTkp5AHVR6nftYibwevqExe1fxPt8Ws4PxfudKDPcC2wNPuNaSMqsAv8l5XQmfDYk0z/0ZJLV8fOHLoRYbaMzHgSNc66iDk8VY6X4VUjY8oPKcdhZJNOcZ2Kub5yOpFrUcU8V7PlDthIH6EMP1JM6xjzxgaVyfF1/ObggacyqNFV3sBfYTwz0pSQo0gBiuAH7mWkdGXK7xSiPywnXBMWL4N4kp8aBrLRb4JokxsbLaWi7w+dxPLTpIDEtIIkt94Z1YaBXtExozDpjpWkcd3EuywWODYEh4hBgWiuFEkoiJ84E+x5LyQOaGxPoae5Ov5zM/di2gDt4AHrU0tq+LrwWVHLTM0Zj/BU5uYIgycJgYbktJUiAdjiNZGDU7Y4DrNB62RoGv1wVoooWiGF4EPkJztkrbB7hbYzZ2LWQ5fI4OSvvc/xnwZMpj2uSzGrObaxEuqLQdv5nhO/rlkaXAEWLoT3tgjRkDViKxXrehN7AMMbwghqOBzYCrXOtxTOYpG9BYLnqgCsTwLPC6ax01cneVhehqotIdoiPtcTPCyUOHxnQB329wmC+I4Vdp6Amkhxi6Sao+ex/yXwUTSSrprwifQ5+b6vdXKdS3O/Br11ossBlJXYlq0oiywudzP9X7YuWaaCOv3yZX5tDkskrFjPg//KxF92UxPGxpbFvmYrPV98ktYpgnhk8BW0Kq7WB9IvMICYDDq500UB8aEwHtrnXUiK2e4D4vvDJ/6NCYAxn+Ia4aviGmZVIDvKNSXPRQ/C6AWy2Haswxy7+oMR3ACAd60qJpIiQGEEMP8CngJ661WGA14EaN+XpO6kqE6KBBiOHX+BWh8w7gTxqzvmshWaAxmwB/Aya41lIHN2IvVQPsrXGbyvT2ATHcL4Y9SDra3e1aT8Y4MSS21Jgdq504UBebAm2uRdSILUMiLLyqpBIGegXVfd5XxDli+E5KkgKWEMMtwKmudWTEDzRmh+Ve8/m68IYYel2LsIEY+sVwDI2li+UVAb5Nkkq0imMtPp//th6UPgN0WxrbBuuSpANt51qITTTmMOAfwDjXWurgcWCK5dTbUD+iyRDD7WLYDvg4WIusyRtODAmA72tMqYb3B2pjimsBNTLLYjibzwuvzG4IGrM9cD009Lm8nKRGQcAPTgH+6FpEBhSBX2v8lv7fIXIqx4jhdJK+7b52jBqO/YB7XIXcV9IYfYugHIyV+2KlwOrXbIxtkXcBf9aYb1d+r02DxozXmN+TrCtGu9ZTB4uAj4uxfr0OhkSTIoYbSKKCpgLPuFVjlZrq5aVtSGwFnFXD+wNVojE7AV90raNGZlgcOxgSK0FjJpFEqDSyoPkd0OWqCGegdioFqw4BK23I8sbaJKbEgOHm83WhJXJ7xTAT2JfmbI02UFdiLwdz+3zuL67UfLDFD0nqFPhEEfg68KjGfFFj7wo+vonGFDTmoxpzHTAbvC3eWQY+JYZZGcxly1wPhkQOEENZDJeSRAgdR4pdhnJETeda2oYEwLEac7nGvKfG4wJDoDHrasy3SSoQ+5SusZQkTcAWPlcTt74TWmmN+EdoqDXdX4GDmjWMvJkRwyskRS5b4Xf3QZa1RPb5utAyC0Ux/A7YmeZchA3UlTgp47oSPhsSVs/9SmHtTwMv25zHEusCZwOvaMxtFXPiwxrn9/etMWM0ZluNOVJjriT5f/8DSah6Hmqt1MuxYvhtRnPZ+v02fSSeT4ihWwxnAxuQRLcucqsoVWo614pVvKceV/YwkqJjj5O0fQzUTgFYg2QH0EcuEGN1sZnbm3EVWF18acy6JLtBazQwzCxgbzEsTkdVIGvEcJfGnECymG12/kdj7sHvkPWWWihWzs8dgNuA9VzrSZkIOI2kttYUMZmsg0K60jCI4TmNOYjEqK9m7Zs3SsAulT8AaMzrwKsk62zXdTI6gFEkzwyua6nY4FtiMi3MG1I2WggxvA58S2POJUkxO5rGUq3zQE3nWjUX5TH16UCAjeo8NuA3S4EzLc/h8+LLmlFTaaH1Jxpb4D8G7Fpp2RfwGDGcozEfJImWaHYuBK51LaIBWm6hKIZ/Verc3IKflfZXxv7AphqznxjmWZ6rEQPaNZmkK4nhDo35H2iablGr0JwP/3njTDGckvGcwZBoQSrRrV/UmB+SFEs+HH+jipynbAQCPxLDC5bnCBESy1HJMb0VGiqq9gKwmxheSkdVIAd0AY+4FpEBI/G7/XRLLhTF8CywA/AX11osMR64V2P2sDyPzyZ9ZtFBYjgfOD2r+QLec6YYvupgXlvphy15n/ENMTwlhiOAiSQtZn2kput6MCQCafMEZNIeMhgSg9CYkcBvgS0aGOZVEjPisXRUBfJAJRRwfwjpNzmnpVI2BlOJxtqNpCNQMzIGuMlyXYlwT6yerwHnZzxnwD+Od2RGgL3PczPW7WlaxDBXDB8jqZX1Z9d6aiS9CAmNiaivhkSgNVHgKDGZVE/3eTco1cWXxrQB1wAfamCYJcCeYpidjqpAnhDDXOAo1zoCw9LSO1eV+8aBwAWutVhioK7ErzRmlIXxgyFRJZWuUZ8jmBKBoekGDhbzZrFkF4QuG4E3EcOdYvgIsBfwgGM51ZJqyobPD32B7DlVDH/MaC6fF1+p7YRqTAH4OTQUDtwL7C+GO9NRFcgjYriC5smdbkZafqEohn4xfBb4lmstFjkAuEtjNkx53HBPrIFBpsRpWc8dyDXPAh8Sw9WOdYQuG4G3IYabga2AQyH30cypGhI+3+AC2XIrZFr0x+dzM5UHj0ro73nAJxscaooYbklBUiD/HAfc61pEYEha3pAYoFJA7jNA2bUWS0wE/qExu6Y4ps8bSE7OfTGoGL4GfJbWaJEcGJ4/AVuLycU9MhS1DAyJGMpi+CWwOfB54EXHklZETelBIUIikAZ/Bz4hhv4M57RV8Mc2i8TQk9JYZ9B4GP4xlQtboAUQQzdJWHzYJckfIbd3EGK4kCSaIIsUQBe8A7hFY76cUl2Jljfp60UMFwA7QSjm3KL0AV8h6S7m/Byo1ARrszD0EjEstTBuwAFi6BHDecBY4GTIXWe8VIta+nyDC2TDP0kKIWZWME9jivjb6iqVB0GNORH4coPDnJJxX+1ADhDDUyThfupaS+AthJ2r5RDD9cCu5G+hlRYRSYvsq1KoK+Hzes25QSqGvwKTgJtdawlkyr3AFmI4S0xuIrJCukagasSwSAynAxsC34fcmE4hZSOQGTcDHxbDwozn9fm8bHgXVGM+S+Nty34qpqnztAPDUEnROdW1jsBbCIvFIag8KO4APOdai0UOovG6Ei19X0yDyu743iTpQs1qggUSFgDHANuJYY5rMcsR0jUCNSOG/4rhBJKIiYsh06j1oQhFLQPWUZJdnX3FsMjB/D6flw0tvDTmEODcBjVcBXyxwTEC/nMKZFaENjA83VlGmflG5YFhO+Bh11osMlBX4qN1Hu9rGiPkxJCAN+tKXAhsAvyCEEnWbCwFzgbGiuEnGacaV0swJAJ1I4bnxDCdpMbENQ6lhJSNgFWeAXYWw1cdXsh9Pi/r3gXVmN2BS1n553Y4fg8ckaPQxIAjKp/fQ2junWdfCAvFlSCGZ0haG9/lWotF3gHcqnFttYEqaYyj7UjKhNxFB4nhJTEcTlLR/lbXegINs5SkpfAmYjhOTK6vubbMxdwYfwH7iOFRMRwIvJ/sN58WV2qWVU2IkAhUy2KSHdVNxWAca/HZkGjkJngeUGrg+LtI2numVVQz4DlieIWkyGWoMO+W3D2Q5REx/Af4KHCday0WiYCfasy6NRzj8z2xVwxvuBaxIsRwvxh2B7YGfk1SADHgD88CXwPWE8NnxfC0a0FVYOvZK88mTMASYviHGHYhuXf+I6Npaza/VmZINLITG2gOFpB0cxgrhm/lJKzYZ6OsrhuCxrwb2KCBeecAe+bk9xfIEWK4i6QdaMAdee8nnhsq17ADgBOgth0YjygBe9T4fl95yrWAahDDfWI4CFiPpKL9I44lBVbMa8CVwG7A+8RwmhjmO9ZUC+2WxvXisxawgxj+BGxDcv+0nf5Y87lWXMnPmzlfM7BieoA/kOxCXe2oTsRwjHQtoAHq7Re8GChTn0n4ELCHg+KjAU8Qw7kaswaEQqeOcJnn6R1iUOD7GnMDcBrJAqvZNlBqKar4AjAfWMOSFpvc6FpALYjhRZKi0qdrzHjg4yQ7j9vjtzHkO3NJwtJ/D5haw8VzxgOWxvXqsxZIn8q981qNuZ6kgO8XSK5fabSeHsxvatamOky9np2kA7gJ2Ll+TQEPeA54FLgH+CvwVzH5rTBdWQTcAw23ScuaV4BtxPBkPQdrzGnASVW+vUxyU7sMuDD0ng5Ug8bEwDeBD5P+DSrwdhT4CXBsZaEQqAONWY+kU8UuwJbAmm4VNcxdwE61XLc15iCS632HNVXpcytwQJ5TNqpFY0aSpHVsDUwmqXQ/Dj9NojyzgCSi7N/AbOB+4B+eRUCsFI2ZAUxLabilwFfFcE5K4wWaCI1ZG9gH+AjJ9WssUGhgyF8Bh68sPXx5/2FYQ0JEBsSOx/8bfGAZZZKQtkXA0z46yRqzOrAZ/uxILAXmNLrw0pixMGxusZKkhTwW0jMC9aIxY0hCk32u3O8D/6rsuAZSRGNWAdYhiabrwK+H9EXAffUUHq7cFyfih5n4gpjmT3vQmHYSU2INYDWaL5LHNgPr1fnA/FbaXNGYTUiuY41QBmaLCXWKAtVRKZK8Nsk1q43aotKfrHbTtSZDIhAIBAKBQCAQCAQCgUDABsGpDQQCgUAgEAgEAoFAIJA5wZAIBAKBQCAQCAQCgUAgkDnBkAgEAoFAIBAIBAKBQCCQOcGQCAQCgUAgEAgEAoFAIJA5/w+K+rP4TZGGqQAAAABJRU5ErkJggg==" alt="Starion Group">
                         </a>
-                        <p class="small">Generated with <a href="https://ecorenetto.org/" target="_blank">EcoreNetto</a> version {{ this.Version }} on {{ DateTime.Now "yyyy-MM-dd HH:mm:ss" }} </p>
                     </div>
 
                     <table class="starion-table">
                         <tbody>
                             <tr>
                                 <td>Name:</td>
-                                <td>{{ this.RootPackage.Name }}</td>
+                                <td>{{ Payload.RootPackage.Name }}</td>
                             </tr>
                             <tr>
                                 <td>Namespace URI:</td>
-                                <td>{{ this.RootPackage.NsUri }}</td>
+                                <td>{{ Payload.RootPackage.NsUri }}</td>
                             </tr>
                             <tr>
                                 <td>Namespace Prefix:</td>
-                                <td>{{ this.RootPackage.NsPrefix }}</td>
+                                <td>{{ Payload.RootPackage.NsPrefix }}</td>
                             </tr>
                         </tbody>
                     </table>
 
+                    <div class="section-toolbar">
+                        <button id="expand-all">&#9660; Expand All</button>
+                        <button id="collapse-all">&#9650; Collapse All</button>
+                    </div>
+
                     <H2 id="Enumeration">1. Enumeration Types</H2>
-                        {{#each this.Enums as | enum |}}
-                        <H3 id="{{enum.Name}}">{{enum.Name}}</H3>
+                        {{#if (IEnumerable.IsEmpty Payload.Enums)}}
+                        <p class="empty-state">No enumeration types found.</p>
+                        {{else}}
+                        {{#each Payload.Enums as | enum |}}
+                        <H3 id="{{Anchor enum}}">{{enum.Name}} [Enumeration]</H3>
                         <H4>Definition</H4>
                             {{ #RawDocumentation enum }}
-                        <H4>Enumeration Literals</H4>
+                        <details class="collapsible-section" open>
+                        <summary><H4>Enumeration Literals</H4></summary>
                         <table class="starion-table">
                             <thead>
                                 <tr>
                                     <th>Name</th>
+                                    <th>Value</th>
+                                    <th>Literal</th>
                                     <th>Description</th>
                                 </tr>
                             </thead>
                             <tbody>
                                 {{#each enum.ELiterals as | enumerationLiteral |}}
                                 <tr>
-                                    <td id="{{enumerationLiteral.Name}}">{{enumerationLiteral.Name}}</td>
+                                    <td id="{{Anchor enumerationLiteral}}">{{enumerationLiteral.Name}}</td>
+                                    <td>{{ enumerationLiteral.Value }}</td>
+                                    <td>{{ enumerationLiteral.Literal }}</td>
                                     <td>
                                         {{ #RawDocumentation enumerationLiteral }}
                                     </td>
@@ -282,73 +253,290 @@
                                 {{/each}}
                             </tbody>
                         </table>
+                        </details>
                         {{/each}}
+                        {{/if}}
 
-                    <H2 id="DataTypes">2. Data Types</H2>
-                        {{#each this.DataTypes as | datatype |}}
-                        <H3 id="{{datatype.Name}}">{{datatype.Name}}</H3>
+                    <H2 id="PrimitiveTypes">2. Primitive Types</H2>
+                        {{#if (IEnumerable.IsEmpty Payload.PrimitiveTypes)}}
+                        <p class="empty-state">No primitive types found.</p>
+                        {{else}}
+                        {{#each Payload.PrimitiveTypes as | datatype |}}
+                        <H3 id="{{Anchor datatype}}">{{datatype.Name}} [Primitive Type]</H3>
+                        <table class="starion-table">
+                            <tbody>
+                                <tr><td>Instance Class Name</td><td>{{ datatype.InstanceClassName }}</td></tr>
+                                <tr><td>Serializable</td><td>{{#if datatype.Serializable}} TRUE {{else}} FALSE {{/if}}</td></tr>
+                                <tr><td>Definition</td><td>{{ #RawDocumentation datatype }}</td></tr>
+                            </tbody>
+                        </table>
+                        {{/each}}
+                        {{/if}}
+
+                    <H2 id="DataTypes">3. Data Types</H2>
+                        {{#if (IEnumerable.IsEmpty Payload.DataTypes)}}
+                        <p class="empty-state">No data types (other than enumerations and primitive types) found.</p>
+                        {{else}}
+                        {{#each Payload.DataTypes as | datatype |}}
+                        <H3 id="{{Anchor datatype}}">{{datatype.Name}} [Data Type]</H3>
                         <H4>Definition</H4>
                             {{ #RawDocumentation datatype }}
                         {{/each}}
-                    <H2 id="Classes">3. Classes</H2>
-                        {{#each this.Classes as | eClass |}}
-
-                        <H3 id="{{eClass.Name}}">{{eClass.Name}}</H3>
+                        {{/if}}
+                    {{#*inline "classDetail"}}
+                        <H3 id="{{Anchor this}}">{{this.Name}} {{#if this.Interface}}[Interface]{{else}}[Class]{{/if}}</H3>
                         <H4>Definition</H4>
-                            {{ #RawDocumentation eClass }}
-                        <H4>Features</H4>
+                            {{ #RawDocumentation this }}
+                        <details class="collapsible-section" open>
+                        <summary><H4>Features</H4></summary>
                         <table class="starion-table">
-                            <thead>
-                            <tr>
-                                <th>Name</th>
-                                <th>Description</th>
-                            </tr>
-                            </thead>
                             <tbody>
+                            <tr>
+                                <td>Fully Qualified Name</td>
+                                <td>{{ this.EPackage.Name }}.{{ this.Name }}</td>
+                            </tr>
                             <tr>
                                 <td>Is Abstract</td>
                                 <td> {{#if this.Abstract}} TRUE {{else}} FALSE {{/if}} </td>
                             </tr>
                             <tr>
+                                <td>Is Interface</td>
+                                <td> {{#if this.Interface}} TRUE {{else}} FALSE {{/if}} </td>
+                            </tr>
+                            <tr>
                                 <td>Generalizations</td>
                                 <td>
-                                    {{#each eClass.ESuperTypes as | superClass |}}
-                                    <a href="#{{superClass.Name}}">{{superClass.Name}}</a>
+                                    {{#each this.ESuperTypes as | superClass |}}
+                                    <a href="#{{Anchor superClass}}">{{superClass.Name}}</a>
+                                    {{/each}}
+                                </td>
+                            </tr>
+                            <tr>
+                                <td>Specializations</td>
+                                <td>
+                                    {{#each (Class.QuerySpecializations this @root.Payload.Classes) as | subClass |}}
+                                    <a href="#{{Anchor subClass}}">{{subClass.Name}}</a>
+                                    {{/each}}
+                                </td>
+                            </tr>
+                            <tr>
+                                <td>Containers</td>
+                                <td>
+                                    {{#each (Class.QueryContainers this @root.Payload.Classes) as | container |}}
+                                    <a href="#{{Anchor container}}">{{container.Name}}</a>
                                     {{/each}}
                                 </td>
                             </tr>
                             </tbody>
                         </table>
-                        <H4>Properties</H4>
+                        </details>
+                        {{#Class.RenderInheritanceDiagram this @root.ClassInheritanceDiagrams}}
+                        <details class="collapsible-section">
+                        <summary><H4>Inheritance Diagram</H4></summary>
+                        <div class="svg-scroll-container">{{{this}}}</div>
+                        </details>
+                        {{/Class.RenderInheritanceDiagram}}
+                        {{#Class.RenderAssociationDiagram this @root.ClassAssociationDiagrams}}
+                        <details class="collapsible-section">
+                        <summary><H4>Association Diagram</H4></summary>
+                        <div class="svg-scroll-container">{{{this}}}</div>
+                        </details>
+                        {{/Class.RenderAssociationDiagram}}
+                        <details class="collapsible-section" open>
+                        <summary><H4>Properties</H4></summary>
                         <table class="starion-table">
                             <thead>
                             <tr>
                                 <th>Name</th>
+                                <th>Kind</th>
                                 <th>Type</th>
                                 <th>Default</th>
                                 <th>Description</th>
-                                <th>Inheritance</th>
+                                <th>Owner</th>
                             </tr>
                             </thead>
                             <tbody>
                                 {{#each this.AllEStructuralFeaturesOrderByName as | structuralFeature |}}
                                 <tr>
-                                    <td>{{ structuralFeature.Name }}</td>
+                                    <td id="{{Anchor structuralFeature}}">{{ structuralFeature.Name }}</td>
+                                    <td>{{#if (StructuralFeature.QueryIsAttribute structuralFeature)}}Attribute{{else}}Reference{{/if}}</td>
                                     <td>
-                                        <a href="#{{StructuralFeature.QueryTypeName structuralFeature}}">{{StructuralFeature.QueryTypeName structuralFeature}}</a> [{{ structuralFeature.LowerBound }}..{{ structuralFeature.UpperBound }}]
-                                        {{#if structuralFeature.Derived }} {derived} {{/if}}
-                                        {{#if (StructuralFeature.QueryIsContainment structuralFeature) }} {composite} {{/if}}
+                                        {{#if structuralFeature.EType}}<a href="#{{Anchor structuralFeature.EType}}">{{StructuralFeature.QueryTypeName structuralFeature}}</a>{{else}}{{StructuralFeature.QueryTypeName structuralFeature}}{{/if}} [{{ structuralFeature.LowerBound }}..{{ structuralFeature.UpperBound }}]
+                                        {{#if structuralFeature.Ordered}}<span class="chip">{ordered}</span>{{/if}}
+                                        {{#if structuralFeature.Unique}}<span class="chip">{unique}</span>{{/if}}
+                                        {{#if (StructuralFeature.QueryIsId structuralFeature)}}<span class="chip">{id}</span>{{/if}}
+                                        {{#unless structuralFeature.Changeable}}<span class="chip">{readonly}</span>{{/unless}}
+                                        {{#if structuralFeature.Transient}}<span class="chip">{transient}</span>{{/if}}
+                                        {{#if structuralFeature.Volatile}}<span class="chip">{volatile}</span>{{/if}}
+                                        {{#if structuralFeature.Unsettable}}<span class="chip">{unsettable}</span>{{/if}}
+                                        {{#if structuralFeature.Derived}}<span class="chip">{derived}</span>{{/if}}
+                                        {{#if (StructuralFeature.QueryIsContainment structuralFeature)}}<span class="chip">{composite}</span>{{/if}}
+                                        <span class="chip">{{ StructuralFeature.WriteOpposite structuralFeature }}</span>
                                     </td>
                                     <td>{{ structuralFeature.DefaultValueLiteral }}</td>
                                     <td>{{ #RawDocumentation structuralFeature }}</td>
-                                    <td><a href="#{{structuralFeature.EContainingClass.Name}}">{{structuralFeature.EContainingClass.Name}}</a></td>
+                                    <td><a href="#{{Anchor structuralFeature.EContainingClass}}">{{structuralFeature.EContainingClass.Name}}</a></td>
                                  </tr>
                                 {{/each}}
                             </tbody>
                         </table>
+                        </details>
+                        {{#unless (IEnumerable.IsEmpty (Class.QueryConstraints this))}}
+                        <details class="collapsible-section" open>
+                        <summary><H4>Rules</H4></summary>
+                        <table class="starion-table">
+                            <thead>
+                            <tr>
+                                <th>Name</th>
+                                <th>Language</th>
+                                <th>Specification</th>
+                            </tr>
+                            </thead>
+                            <tbody>
+                                {{#each (Class.QueryConstraints this) as | constraint |}}
+                                <tr>
+                                    <td>{{ constraint.Name }}</td>
+                                    <td>{{ constraint.Language }}</td>
+                                    <td>{{ constraint.Body }}</td>
+                                </tr>
+                                {{/each}}
+                            </tbody>
+                        </table>
+                        </details>
+                        {{/unless}}
+                        {{#unless (IEnumerable.IsEmpty this.EOperations)}}
+                        <details class="collapsible-section" open>
+                        <summary><H4>Operations</H4></summary>
+                        <table class="starion-table">
+                            <thead>
+                            <tr>
+                                <th>Name</th>
+                                <th>Parameters</th>
+                                <th>Return Type</th>
+                                <th>Description</th>
+                            </tr>
+                            </thead>
+                            <tbody>
+                                {{#each this.EOperationsOrderByName as | operation |}}
+                                <tr>
+                                    <td id="{{Anchor operation}}">{{ operation.Name }}</td>
+                                    <td>
+                                        <ul>
+                                            {{#each operation.EParameters as | parameter |}}
+                                            <li>{{ Parameter.WriteTypeAndName parameter }}</li>
+                                            {{/each}}
+                                        </ul>
+                                    </td>
+                                    <td>{{ TypedElement.WriteReturnType operation }}</td>
+                                    <td>{{ #RawDocumentation operation }}</td>
+                                </tr>
+                                {{/each}}
+                            </tbody>
+                        </table>
+                        </details>
+                        {{/unless}}
+                    {{/inline}}
+
+                    <H2 id="Classes">4. Classes</H2>
+                        {{#if (IEnumerable.IsEmpty Payload.Classes)}}
+                        <p class="empty-state">No classes found.</p>
+                        {{else}}
+                        {{#each Payload.Classes as | eClass |}}
+                        {{#unless eClass.Interface}}
+                        {{> classDetail eClass}}
+                        {{/unless}}
                         {{/each}}
+                        {{/if}}
+
+                    <H2 id="Interfaces">5. Interfaces</H2>
+                        {{#if (IEnumerable.IsEmpty Payload.Interfaces)}}
+                        <p class="empty-state">No interfaces found.</p>
+                        {{else}}
+                        {{#each Payload.Interfaces as | eClass |}}
+                        {{> classDetail eClass}}
+                        {{/each}}
+                        {{/if}}
+
+                    <H2 id="Diagrams">6. Diagrams</H2>
+                        <details class="collapsible-section">
+                        <summary><H3 id="InheritanceDiagram">Inheritance Diagram</H3></summary>
+                        <div class="svg-scroll-container">{{{ InheritanceDiagramSvg }}}</div>
+                        <a class="download-svg" data-target="inheritance-diagram" download="inheritance-diagram.svg" href="#">Download Inheritance Diagram</a>
+                        </details>
+
+                    <div class="page-footer">
+                        Generated with <a href="https://ecorenetto.org/" target="_blank">EcoreNetto</a> version {{ Payload.Version }} on {{ DateTime.Now "yyyy-MM-dd HH:mm:ss" }}
+                    </div>
+
+                    <button id="go-to-diagram" class="nav-fab go-to-diagram" title="Go to diagram">&#9670;</button>
+                    <button id="back-to-top" class="nav-fab back-to-top" title="Back to top">&#9650;</button>
                 </article>
             </main>
         </div>
+        <script>
+            (function () {
+                document.querySelectorAll('.download-svg').forEach(function (link) {
+                    link.addEventListener('click', function (e) {
+                        e.preventDefault();
+                        var svg = document.getElementById(link.getAttribute('data-target'));
+                        if (!svg) { return; }
+                        var source = new XMLSerializer().serializeToString(svg);
+                        var blob = new Blob([source], { type: 'image/svg+xml' });
+                        link.href = URL.createObjectURL(blob);
+                        var temp = document.createElement('a');
+                        temp.href = link.href;
+                        temp.download = link.getAttribute('download') || 'diagram.svg';
+                        temp.click();
+                    });
+                });
+
+                var sidebar = document.getElementById('sidebar');
+                var sidebarToggle = document.getElementById('sidebar-toggle');
+                if (sidebarToggle && sidebar) {
+                    sidebarToggle.addEventListener('click', function () {
+                        sidebar.classList.toggle('collapsed');
+                    });
+                }
+
+                var article = document.querySelector('article');
+                var backToTop = document.getElementById('back-to-top');
+                var goToDiagram = document.getElementById('go-to-diagram');
+                if (article) {
+                    article.addEventListener('scroll', function () {
+                        var show = article.scrollTop > 300 ? 'block' : 'none';
+                        if (backToTop) { backToTop.style.display = show; }
+                        if (goToDiagram) { goToDiagram.style.display = show; }
+                    });
+                }
+                if (backToTop && article) {
+                    backToTop.addEventListener('click', function () {
+                        article.scrollTo({ top: 0, behavior: 'smooth' });
+                    });
+                }
+                if (goToDiagram) {
+                    goToDiagram.addEventListener('click', function () {
+                        var heading = document.getElementById('InheritanceDiagram');
+                        if (heading) {
+                            var details = heading.closest('details');
+                            if (details) { details.open = true; }
+                            heading.scrollIntoView({ behavior: 'smooth' });
+                        }
+                    });
+                }
+
+                var expandAll = document.getElementById('expand-all');
+                var collapseAll = document.getElementById('collapse-all');
+                if (expandAll) {
+                    expandAll.addEventListener('click', function () {
+                        document.querySelectorAll('details.collapsible-section').forEach(function (d) { d.open = true; });
+                    });
+                }
+                if (collapseAll) {
+                    collapseAll.addEventListener('click', function () {
+                        document.querySelectorAll('details.collapsible-section').forEach(function (d) { d.open = false; });
+                    });
+                }
+            })();
+        </script>
     </body>
 </html>

--- a/ECoreNetto.Tools/Program.cs
+++ b/ECoreNetto.Tools/Program.cs
@@ -24,8 +24,9 @@ namespace ECoreNetto.Tools
     using Serilog.Events;
     
     using ECoreNetto.Tools.Commands;
+    using ECoreNetto.Reporting.Drawing;
     using ECoreNetto.Reporting.Generators;
-    
+
     using ECoreNetto.Tools.Services;
 
     /// <summary>
@@ -94,6 +95,8 @@ namespace ECoreNetto.Tools
                     services.AddSingleton<IVersionChecker, VersionChecker>();
                     services.AddSingleton<IXlReportGenerator, XlReportGenerator>();
                     services.AddSingleton<IModelInspector, ModelInspector>();
+                    services.AddSingleton<IInheritanceDiagramRenderer, InheritanceDiagramRenderer>();
+                    services.AddSingleton<IAssociationDiagramRenderer, AssociationDiagramRenderer>();
                     services.AddSingleton<IHtmlReportGenerator, HtmlReportGenerator>();
                     services.AddSingleton<IMarkdownReportGenerator, MarkdownReportGenerator>();
                 });

--- a/TestData/report-features.ecore
+++ b/TestData/report-features.ecore
@@ -1,0 +1,48 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<ecore:EPackage xmi:version="2.0" xmlns:xmi="http://www.omg.org/XMI" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+    xmlns:ecore="http://www.eclipse.org/emf/2002/Ecore" name="features" nsURI="https://starion.group/ecorenetto/features"
+    nsPrefix="features">
+  <eClassifiers xsi:type="ecore:EDataType" name="Identifier" instanceClassName="java.lang.String"/>
+  <eClassifiers xsi:type="ecore:EDataType" name="Money" serializable="false"/>
+  <eClassifiers xsi:type="ecore:EEnum" name="Status">
+    <eLiterals name="ACTIVE" value="1" literal="active"/>
+    <eLiterals name="INACTIVE" value="2" literal="inactive"/>
+  </eClassifiers>
+  <eClassifiers xsi:type="ecore:EClass" name="Describable" abstract="true" interface="true">
+    <eOperations name="describe" eType="ecore:EDataType http://www.eclipse.org/emf/2002/Ecore#//EString"/>
+  </eClassifiers>
+  <eClassifiers xsi:type="ecore:EClass" name="Person" eSuperTypes="#//Describable">
+    <eAnnotations source="http://www.eclipse.org/emf/2002/Ecore">
+      <details key="constraints" value="hasFullName"/>
+    </eAnnotations>
+    <eAnnotations source="http://www.eclipse.org/emf/2002/Ecore/OCL">
+      <details key="hasFullName" value="self.fullName.notEmpty()"/>
+    </eAnnotations>
+    <eStructuralFeatures xsi:type="ecore:EAttribute" name="identifier" iD="true" eType="#//Identifier"/>
+    <eStructuralFeatures xsi:type="ecore:EAttribute" name="tags" upperBound="-1" ordered="true"
+        unique="true" eType="ecore:EDataType http://www.eclipse.org/emf/2002/Ecore#//EString"/>
+    <eStructuralFeatures xsi:type="ecore:EAttribute" name="fullName" changeable="false" transient="true"
+        volatile="true" unsettable="true" derived="true"
+        eType="ecore:EDataType http://www.eclipse.org/emf/2002/Ecore#//EString"/>
+    <eStructuralFeatures xsi:type="ecore:EReference" name="employer" eType="#//Company"
+        eOpposite="#//Company/employees"/>
+    <eStructuralFeatures xsi:type="ecore:EReference" name="addresses" upperBound="-1" containment="true"
+        eType="#//Address"/>
+    <eOperations name="greet" lowerBound="1"
+        eType="ecore:EDataType http://www.eclipse.org/emf/2002/Ecore#//EString">
+      <eParameters name="greeting" upperBound="-1"
+          eType="ecore:EDataType http://www.eclipse.org/emf/2002/Ecore#//EString"/>
+    </eOperations>
+  </eClassifiers>
+  <eClassifiers xsi:type="ecore:EClass" name="Company">
+    <eStructuralFeatures xsi:type="ecore:EReference" name="employees" upperBound="-1" eType="#//Person"
+        eOpposite="#//Person/employer"/>
+    <eOperations name="clear">
+      <eParameters name="target"/>
+    </eOperations>
+  </eClassifiers>
+  <eClassifiers xsi:type="ecore:EClass" name="Address">
+    <eStructuralFeatures xsi:type="ecore:EAttribute" name="street"
+        eType="ecore:EDataType http://www.eclipse.org/emf/2002/Ecore#//EString"/>
+  </eClassifiers>
+</ecore:EPackage>


### PR DESCRIPTION
﻿## Summary

Brings the EcoreNetto HTML report generator to parity with uml4net (fixes #91). The report is still a single self-contained `.html` file, now rendering substantially richer content driven from the existing Ecore model.

## What is delivered

- **Operations** table (parameters with type + multiplicity, return type, documentation).
- **Richer feature flags** as chips: `{ordered}`, `{unique}`, `{id}`, `{readonly}`, `{transient}`, `{volatile}`, `{unsettable}`, `{derived}`, `{composite}`, and `{opposite: <link>}`.
- **Attribute vs reference** distinction, plus **Specializations** and **Containers** per class.
- **OCL / constraints** (Rules) read from the Ecore constraint + OCL annotations.
- **Collapsible sections** with expand-all / collapse-all, sidebar toggle, back-to-top / go-to-diagram.
- **SVG diagrams**: a model-wide inheritance diagram and per-class inheritance + association diagrams, embedded inline and downloadable.
- **Custom-HTML injection point** and **stable, unique anchors** derived from `EObject.Identifier`.
- **Primitive types vs other data types** split; **Interfaces** section; enum **Value/Literal** columns.
- CSS clean-up (removed dead `.rectangle-list`, mid-stylesheet `@charset`, FontAwesome and IE6/7 hacks); a real page footer.

## New dependencies

- `Microsoft.Msagl` 1.1.6 (graph layout)
- `Svg` 3.4.7 (SVG output)

## Out of scope

UML-only concepts that do not map to Ecore are intentionally excluded: visibility, stereotypes, and redefinition/subsetting.

## Testing

- Full solution green (`dotnet test EcoreNetto.sln`): 325 tests.
- New feature-rich synthetic asset `TestData/report-features.ecore` plus unit tests for the new helpers, extensions and diagram renderers, and extended HTML report fixtures (feature rendering, custom HTML, overwrite, Open Graph, Capella at scale).
- New reporting code meets the >= 80% new-code coverage gate.
