### PR TITLE
[Feature] Generate a single combined report across multiple .ecore files

### DIFF
--- a/ECoreNetto.Reporting.Tests/Generators/CapellaHtmlReportGeneratorTestFixture.cs
+++ b/ECoreNetto.Reporting.Tests/Generators/CapellaHtmlReportGeneratorTestFixture.cs
@@ -89,6 +89,49 @@ namespace ECoreNetto.Tools.Tests.Generators
             });
         }
 
+        [Test]
+        public void Verify_that_a_single_combined_html_report_is_generated_for_the_whole_capella_metamodel()
+        {
+            var inputDirectory = new DirectoryInfo(CapellaDirectory);
+
+            var reportFileInfo = new FileInfo(Path.Combine(
+                TestContext.CurrentContext.TestDirectory,
+                "html-report.capella.combined.html"));
+
+            Assert.That(() => this.htmlReportGenerator.GenerateCombinedReport(inputDirectory, reportFileInfo), Throws.Nothing);
+
+            reportFileInfo.Refresh();
+            Assert.That(reportFileInfo.Exists, Is.True);
+
+            var html = File.ReadAllText(reportFileInfo.FullName);
+
+            Assert.Multiple(() =>
+            {
+                // a single document must contain classifiers that originate from several different .ecore files
+                Assert.That(html, Does.Contain("CapellaElement"));       // CapellaCore.ecore
+                Assert.That(html, Does.Contain("LogicalArchitecture"));  // LogicalArchitecture.ecore
+                Assert.That(html, Does.Contain("SystemAnalysis"));       // ContextArchitecture.ecore
+                Assert.That(html, Does.Contain("PhysicalArchitecture")); // PhysicalArchitecture.ecore
+                Assert.That(html, Does.Contain("OperationalAnalysis"));  // OperationalAnalysis.ecore
+            });
+        }
+
+        [Test]
+        public void Verify_that_a_combined_report_from_an_entry_file_includes_reachable_models()
+        {
+            // LogicalArchitecture.ecore references classifiers that live in other files (e.g. its super type
+            // ComponentArchitecture lives in CompositeStructure.ecore); the combined report must include them.
+            var modelFileInfo = new FileInfo(Path.Combine(CapellaDirectory, "LogicalArchitecture.ecore"));
+
+            var html = this.htmlReportGenerator.GenerateCombinedReport(modelFileInfo);
+
+            Assert.Multiple(() =>
+            {
+                Assert.That(html, Does.Contain("LogicalArchitecture"));
+                Assert.That(html, Does.Contain("ComponentArchitecture"));
+            });
+        }
+
         /// <summary>
         /// Enumerates the Capella <c>.ecore</c> file names available in the test output directory.
         /// </summary>

--- a/ECoreNetto.Reporting.Tests/Generators/CapellaMarkdownReportGeneratorTestFixture.cs
+++ b/ECoreNetto.Reporting.Tests/Generators/CapellaMarkdownReportGeneratorTestFixture.cs
@@ -1,0 +1,126 @@
+// ------------------------------------------------------------------------------------------------
+// <copyright file="CapellaMarkdownReportGeneratorTestFixture.cs" company="Starion Group S.A.">
+//
+//   Copyright 2017-2026 Starion Group S.A.
+//   SPDX-License-Identifier: Apache-2.0
+//
+// </copyright>
+// ------------------------------------------------------------------------------------------------
+
+namespace ECoreNetto.Tools.Tests.Generators
+{
+    using System.Collections.Generic;
+    using System.IO;
+    using System.Linq;
+
+    using ECoreNetto.Reporting.Generators;
+
+    using Microsoft.Extensions.Logging;
+
+    using NUnit.Framework;
+
+    using Serilog;
+
+    /// <summary>
+    /// Suite of tests that verify the <see cref="MarkdownReportGenerator"/> produces a Markdown report for the
+    /// Eclipse Capella metamodel (21 cross-referencing <c>.ecore</c> files), both per file and as a single
+    /// combined report of the whole metamodel.
+    /// </summary>
+    [TestFixture]
+    public class CapellaMarkdownReportGeneratorTestFixture
+    {
+        private static readonly string CapellaDirectory = Path.Combine(
+            Path.GetDirectoryName(typeof(CapellaMarkdownReportGeneratorTestFixture).Assembly.Location)!,
+            "Data",
+            "capella");
+
+        private MarkdownReportGenerator markdownReportGenerator = null!;
+
+        private ILoggerFactory? loggerFactory;
+
+        [OneTimeSetUp]
+        public void OneTimeSetUp()
+        {
+            Log.Logger = new LoggerConfiguration()
+                .MinimumLevel.Verbose()
+                .WriteTo.Console()
+                .CreateLogger();
+
+            this.loggerFactory = LoggerFactory.Create(builder =>
+            {
+                builder.AddSerilog();
+            });
+        }
+
+        [SetUp]
+        public void SetUp()
+        {
+            this.markdownReportGenerator = new MarkdownReportGenerator(this.loggerFactory);
+        }
+
+        [Test]
+        [TestCaseSource(nameof(CapellaModelFiles))]
+        public void Verify_that_a_markdown_report_is_generated_for_a_capella_model(string fileName)
+        {
+            var modelFileInfo = new FileInfo(Path.Combine(CapellaDirectory, fileName));
+
+            var reportFileInfo = new FileInfo(Path.Combine(
+                TestContext.CurrentContext.TestDirectory,
+                $"markdown-report.capella.{Path.GetFileNameWithoutExtension(fileName)}.md"));
+
+            Assert.That(() => this.markdownReportGenerator.GenerateReport(modelFileInfo, reportFileInfo), Throws.Nothing);
+
+            reportFileInfo.Refresh();
+            Assert.That(reportFileInfo.Exists, Is.True);
+        }
+
+        [Test]
+        public void Verify_that_a_single_combined_markdown_report_is_generated_for_the_whole_capella_metamodel()
+        {
+            var inputDirectory = new DirectoryInfo(CapellaDirectory);
+
+            var reportFileInfo = new FileInfo(Path.Combine(
+                TestContext.CurrentContext.TestDirectory,
+                "markdown-report.capella.combined.md"));
+
+            Assert.That(() => this.markdownReportGenerator.GenerateCombinedReport(inputDirectory, reportFileInfo), Throws.Nothing);
+
+            reportFileInfo.Refresh();
+            Assert.That(reportFileInfo.Exists, Is.True);
+
+            var markdown = File.ReadAllText(reportFileInfo.FullName);
+
+            Assert.Multiple(() =>
+            {
+                // a single document must contain classifiers that originate from several different .ecore files
+                Assert.That(markdown, Does.Contain("CapellaElement"));       // CapellaCore.ecore
+                Assert.That(markdown, Does.Contain("LogicalArchitecture"));  // LogicalArchitecture.ecore
+                Assert.That(markdown, Does.Contain("SystemAnalysis"));       // ContextArchitecture.ecore
+                Assert.That(markdown, Does.Contain("PhysicalArchitecture")); // PhysicalArchitecture.ecore
+                Assert.That(markdown, Does.Contain("OperationalAnalysis"));  // OperationalAnalysis.ecore
+            });
+        }
+
+        [Test]
+        public void Verify_that_a_combined_markdown_report_from_an_entry_file_includes_reachable_models()
+        {
+            var modelFileInfo = new FileInfo(Path.Combine(CapellaDirectory, "LogicalArchitecture.ecore"));
+
+            var markdown = this.markdownReportGenerator.GenerateCombinedReport(modelFileInfo);
+
+            Assert.Multiple(() =>
+            {
+                Assert.That(markdown, Does.Contain("LogicalArchitecture"));
+                Assert.That(markdown, Does.Contain("ComponentArchitecture"));
+            });
+        }
+
+        /// <summary>
+        /// Enumerates the Capella <c>.ecore</c> file names available in the test output directory.
+        /// </summary>
+        private static IEnumerable<string> CapellaModelFiles()
+        {
+            return Directory.EnumerateFiles(CapellaDirectory, "*.ecore").Select(file => Path.GetFileName(file)!);
+        }
+    }
+}

--- a/ECoreNetto.Reporting.Tests/Generators/CapellaXlReportGeneratorTestFixture.cs
+++ b/ECoreNetto.Reporting.Tests/Generators/CapellaXlReportGeneratorTestFixture.cs
@@ -1,0 +1,122 @@
+// ------------------------------------------------------------------------------------------------
+// <copyright file="CapellaXlReportGeneratorTestFixture.cs" company="Starion Group S.A.">
+//
+//   Copyright 2017-2026 Starion Group S.A.
+//   SPDX-License-Identifier: Apache-2.0
+//
+// </copyright>
+// ------------------------------------------------------------------------------------------------
+
+namespace ECoreNetto.Reporting.Tests.Generators
+{
+    using System.Collections.Generic;
+    using System.IO;
+    using System.Linq;
+
+    using ClosedXML.Excel;
+
+    using ECoreNetto.Reporting.Generators;
+
+    using NUnit.Framework;
+
+    /// <summary>
+    /// Suite of tests that verify the <see cref="XlReportGenerator"/> produces an Excel report for the Eclipse
+    /// Capella metamodel (21 cross-referencing <c>.ecore</c> files), both per file and as a single combined
+    /// workbook of the whole metamodel.
+    /// </summary>
+    [TestFixture]
+    public class CapellaXlReportGeneratorTestFixture
+    {
+        private static readonly string CapellaDirectory = Path.Combine(
+            Path.GetDirectoryName(typeof(CapellaXlReportGeneratorTestFixture).Assembly.Location)!,
+            "Data",
+            "capella");
+
+        private XlReportGenerator generator = null!;
+
+        [SetUp]
+        public void SetUp()
+        {
+            this.generator = new XlReportGenerator();
+        }
+
+        [Test]
+        [TestCaseSource(nameof(CapellaModelFiles))]
+        public void Verify_that_an_excel_report_is_generated_for_a_capella_model(string fileName)
+        {
+            var modelFileInfo = new FileInfo(Path.Combine(CapellaDirectory, fileName));
+
+            var reportFileInfo = new FileInfo(Path.Combine(
+                TestContext.CurrentContext.TestDirectory,
+                $"xl-report.capella.{Path.GetFileNameWithoutExtension(fileName)}.xlsx"));
+
+            Assert.That(() => this.generator.GenerateReport(modelFileInfo, reportFileInfo), Throws.Nothing);
+
+            reportFileInfo.Refresh();
+            Assert.That(reportFileInfo.Exists, Is.True);
+        }
+
+        [Test]
+        public void Verify_that_a_single_combined_excel_report_is_generated_for_the_whole_capella_metamodel()
+        {
+            var inputDirectory = new DirectoryInfo(CapellaDirectory);
+
+            var reportFileInfo = new FileInfo(Path.Combine(
+                TestContext.CurrentContext.TestDirectory,
+                "xl-report.capella.combined.xlsx"));
+
+            Assert.That(() => this.generator.GenerateCombinedReport(inputDirectory, reportFileInfo), Throws.Nothing);
+
+            reportFileInfo.Refresh();
+            Assert.That(reportFileInfo.Exists, Is.True);
+
+            using var workbook = new XLWorkbook(reportFileInfo.FullName);
+
+            var info = workbook.Worksheet("Model Info");
+            var eClassSheet = workbook.Worksheet("EClass");
+
+            Assert.Multiple(() =>
+            {
+                // the info sheet lists all the included root packages
+                Assert.That(info.Cell(6, 1).GetString(), Is.EqualTo("Included Packages"));
+
+                // a single workbook must list classes that originate from several different .ecore files
+                Assert.That(eClassSheet.CellsUsed().Any(c => c.GetString() == "CapellaElement"), Is.True);
+                Assert.That(eClassSheet.CellsUsed().Any(c => c.GetString() == "LogicalArchitecture"), Is.True);
+                Assert.That(eClassSheet.CellsUsed().Any(c => c.GetString() == "SystemAnalysis"), Is.True);
+                Assert.That(eClassSheet.CellsUsed().Any(c => c.GetString() == "PhysicalArchitecture"), Is.True);
+            });
+        }
+
+        [Test]
+        public void Verify_that_a_combined_excel_report_from_an_entry_file_includes_reachable_models()
+        {
+            var modelFileInfo = new FileInfo(Path.Combine(CapellaDirectory, "LogicalArchitecture.ecore"));
+            var reportFileInfo = new FileInfo(Path.Combine(
+                TestContext.CurrentContext.TestDirectory,
+                "xl-report.capella.reachable.xlsx"));
+
+            Assert.That(() => this.generator.GenerateCombinedReport(modelFileInfo, reportFileInfo), Throws.Nothing);
+
+            reportFileInfo.Refresh();
+            Assert.That(reportFileInfo.Exists, Is.True);
+
+            using var workbook = new XLWorkbook(reportFileInfo.FullName);
+            var eClassSheet = workbook.Worksheet("EClass");
+
+            Assert.Multiple(() =>
+            {
+                Assert.That(eClassSheet.CellsUsed().Any(c => c.GetString() == "LogicalArchitecture"), Is.True);
+                Assert.That(eClassSheet.CellsUsed().Any(c => c.GetString() == "ComponentArchitecture"), Is.True);
+            });
+        }
+
+        /// <summary>
+        /// Enumerates the Capella <c>.ecore</c> file names available in the test output directory.
+        /// </summary>
+        private static IEnumerable<string> CapellaModelFiles()
+        {
+            return Directory.EnumerateFiles(CapellaDirectory, "*.ecore").Select(file => Path.GetFileName(file)!);
+        }
+    }
+}

--- a/ECoreNetto.Reporting.Tests/Generators/HtmlReportGeneratorTestFixture.cs
+++ b/ECoreNetto.Reporting.Tests/Generators/HtmlReportGeneratorTestFixture.cs
@@ -195,5 +195,24 @@ namespace ECoreNetto.Tools.Tests.Generators
         {
             Assert.That(() => this.htmlReportGenerator.IsValidReportExtension(null!), Throws.ArgumentNullException);
         }
+
+        [Test]
+        public void Verify_that_combined_report_methods_throw_when_arguments_are_null()
+        {
+            FileInfo? modelFileInfo = null;
+            DirectoryInfo? directory = null;
+            var validModel = new FileInfo(Path.Combine(TestContext.CurrentContext.TestDirectory, "Data", "recipe.ecore"));
+            var validOutput = new FileInfo(Path.Combine(TestContext.CurrentContext.TestDirectory, "html-report.combined-null.html"));
+
+            Assert.Multiple(() =>
+            {
+                Assert.That(() => this.htmlReportGenerator.GenerateCombinedReport(modelFileInfo!), Throws.ArgumentNullException);
+                Assert.That(() => this.htmlReportGenerator.GenerateCombinedReport(directory!), Throws.ArgumentNullException);
+                Assert.That(() => this.htmlReportGenerator.GenerateCombinedReport(modelFileInfo!, validOutput), Throws.ArgumentNullException);
+                Assert.That(() => this.htmlReportGenerator.GenerateCombinedReport(validModel, (FileInfo)null!), Throws.ArgumentNullException);
+                Assert.That(() => this.htmlReportGenerator.GenerateCombinedReport(directory!, validOutput), Throws.ArgumentNullException);
+                Assert.That(() => this.htmlReportGenerator.GenerateCombinedReport(new DirectoryInfo(TestContext.CurrentContext.TestDirectory), (FileInfo)null!), Throws.ArgumentNullException);
+            });
+        }
     }
 }

--- a/ECoreNetto.Reporting.Tests/Generators/MarkdownReportGeneratorTestFixture.cs
+++ b/ECoreNetto.Reporting.Tests/Generators/MarkdownReportGeneratorTestFixture.cs
@@ -63,51 +63,6 @@ namespace ECoreNetto.Tools.Tests.Generators
         }
 
         [Test]
-        public void Verify_that_a_single_combined_markdown_report_is_generated_for_the_whole_capella_metamodel()
-        {
-            var capellaDirectory = new DirectoryInfo(Path.Combine(TestContext.CurrentContext.TestDirectory, "Data", "capella"));
-
-            var reportFileInfo = new FileInfo(Path.Combine(TestContext.CurrentContext.TestDirectory, "markdown-report.capella.combined.md"));
-
-            Assert.That(() => this.markdownReportGenerator.GenerateCombinedReport(capellaDirectory, reportFileInfo), Throws.Nothing);
-
-            reportFileInfo.Refresh();
-            Assert.That(reportFileInfo.Exists, Is.True);
-
-            var markdown = this.markdownReportGenerator.GenerateCombinedReport(capellaDirectory);
-
-            Assert.Multiple(() =>
-            {
-                // a single document must contain classifiers that originate from several different .ecore files
-                Assert.That(markdown, Does.Contain("CapellaElement"));
-                Assert.That(markdown, Does.Contain("LogicalArchitecture"));
-                Assert.That(markdown, Does.Contain("SystemAnalysis"));
-                Assert.That(markdown, Does.Contain("PhysicalArchitecture"));
-            });
-        }
-
-        [Test]
-        public void Verify_that_a_combined_markdown_report_from_an_entry_file_includes_reachable_models()
-        {
-            var modelFileInfo = new FileInfo(Path.Combine(TestContext.CurrentContext.TestDirectory, "Data", "capella", "LogicalArchitecture.ecore"));
-
-            var reportFileInfo = new FileInfo(Path.Combine(TestContext.CurrentContext.TestDirectory, "markdown-report.capella.reachable.md"));
-
-            Assert.That(() => this.markdownReportGenerator.GenerateCombinedReport(modelFileInfo, reportFileInfo), Throws.Nothing);
-
-            reportFileInfo.Refresh();
-            Assert.That(reportFileInfo.Exists, Is.True);
-
-            var markdown = this.markdownReportGenerator.GenerateCombinedReport(modelFileInfo);
-
-            Assert.Multiple(() =>
-            {
-                Assert.That(markdown, Does.Contain("LogicalArchitecture"));
-                Assert.That(markdown, Does.Contain("ComponentArchitecture"));
-            });
-        }
-
-        [Test]
         public void Verify_that_combined_markdown_report_methods_throw_when_arguments_are_null()
         {
             var validModel = new FileInfo(Path.Combine(TestContext.CurrentContext.TestDirectory, "Data", "recipe.ecore"));

--- a/ECoreNetto.Reporting.Tests/Generators/MarkdownReportGeneratorTestFixture.cs
+++ b/ECoreNetto.Reporting.Tests/Generators/MarkdownReportGeneratorTestFixture.cs
@@ -63,6 +63,67 @@ namespace ECoreNetto.Tools.Tests.Generators
         }
 
         [Test]
+        public void Verify_that_a_single_combined_markdown_report_is_generated_for_the_whole_capella_metamodel()
+        {
+            var capellaDirectory = new DirectoryInfo(Path.Combine(TestContext.CurrentContext.TestDirectory, "Data", "capella"));
+
+            var reportFileInfo = new FileInfo(Path.Combine(TestContext.CurrentContext.TestDirectory, "markdown-report.capella.combined.md"));
+
+            Assert.That(() => this.markdownReportGenerator.GenerateCombinedReport(capellaDirectory, reportFileInfo), Throws.Nothing);
+
+            reportFileInfo.Refresh();
+            Assert.That(reportFileInfo.Exists, Is.True);
+
+            var markdown = this.markdownReportGenerator.GenerateCombinedReport(capellaDirectory);
+
+            Assert.Multiple(() =>
+            {
+                // a single document must contain classifiers that originate from several different .ecore files
+                Assert.That(markdown, Does.Contain("CapellaElement"));
+                Assert.That(markdown, Does.Contain("LogicalArchitecture"));
+                Assert.That(markdown, Does.Contain("SystemAnalysis"));
+                Assert.That(markdown, Does.Contain("PhysicalArchitecture"));
+            });
+        }
+
+        [Test]
+        public void Verify_that_a_combined_markdown_report_from_an_entry_file_includes_reachable_models()
+        {
+            var modelFileInfo = new FileInfo(Path.Combine(TestContext.CurrentContext.TestDirectory, "Data", "capella", "LogicalArchitecture.ecore"));
+
+            var reportFileInfo = new FileInfo(Path.Combine(TestContext.CurrentContext.TestDirectory, "markdown-report.capella.reachable.md"));
+
+            Assert.That(() => this.markdownReportGenerator.GenerateCombinedReport(modelFileInfo, reportFileInfo), Throws.Nothing);
+
+            reportFileInfo.Refresh();
+            Assert.That(reportFileInfo.Exists, Is.True);
+
+            var markdown = this.markdownReportGenerator.GenerateCombinedReport(modelFileInfo);
+
+            Assert.Multiple(() =>
+            {
+                Assert.That(markdown, Does.Contain("LogicalArchitecture"));
+                Assert.That(markdown, Does.Contain("ComponentArchitecture"));
+            });
+        }
+
+        [Test]
+        public void Verify_that_combined_markdown_report_methods_throw_when_arguments_are_null()
+        {
+            var validModel = new FileInfo(Path.Combine(TestContext.CurrentContext.TestDirectory, "Data", "recipe.ecore"));
+            var validOutput = new FileInfo(Path.Combine(TestContext.CurrentContext.TestDirectory, "markdown-report.null.md"));
+
+            Assert.Multiple(() =>
+            {
+                Assert.That(() => this.markdownReportGenerator.GenerateCombinedReport((FileInfo)null!), Throws.ArgumentNullException);
+                Assert.That(() => this.markdownReportGenerator.GenerateCombinedReport((DirectoryInfo)null!), Throws.ArgumentNullException);
+                Assert.That(() => this.markdownReportGenerator.GenerateCombinedReport((FileInfo)null!, validOutput), Throws.ArgumentNullException);
+                Assert.That(() => this.markdownReportGenerator.GenerateCombinedReport(validModel, null!), Throws.ArgumentNullException);
+                Assert.That(() => this.markdownReportGenerator.GenerateCombinedReport(new DirectoryInfo(TestContext.CurrentContext.TestDirectory), null!), Throws.ArgumentNullException);
+            });
+        }
+
+        [Test]
         public void Verify_that_the_generated_markdown_contains_the_expected_content()
         {
             var modelFileInfo = new FileInfo(Path.Combine(TestContext.CurrentContext.TestDirectory, "Data", "recipe.ecore"));

--- a/ECoreNetto.Reporting.Tests/Generators/ModelInspectorTestFixture.cs
+++ b/ECoreNetto.Reporting.Tests/Generators/ModelInspectorTestFixture.cs
@@ -142,8 +142,9 @@ namespace ECoreNetto.Tools.Tests.Generators
         {
             Assert.Multiple(() =>
             {
-                Assert.That(() => this.modelInspector.GenerateCombinedReport(null!, reportFileInfo), Throws.ArgumentNullException);
-                Assert.That(() => this.modelInspector.GenerateCombinedReport(modelFileInfo, null!), Throws.ArgumentNullException);
+                Assert.That(() => this.modelInspector.GenerateCombinedReport((FileInfo)null!, reportFileInfo), Throws.ArgumentNullException);
+                Assert.That(() => this.modelInspector.GenerateCombinedReport(modelFileInfo, (FileInfo)null!), Throws.ArgumentNullException);
+                Assert.That(() => this.modelInspector.GenerateCombinedReport((DirectoryInfo)null!, reportFileInfo), Throws.ArgumentNullException);
             });
         }
 

--- a/ECoreNetto.Reporting.Tests/Generators/ModelInspectorTestFixture.cs
+++ b/ECoreNetto.Reporting.Tests/Generators/ModelInspectorTestFixture.cs
@@ -126,6 +126,28 @@ namespace ECoreNetto.Tools.Tests.Generators
         }
 
         [Test]
+        public void Verify_that_a_combined_inspection_report_is_generated_for_a_multi_file_metamodel()
+        {
+            var capellaEntry = new FileInfo(Path.Combine(TestContext.CurrentContext.TestDirectory, "Data", "capella", "LogicalArchitecture.ecore"));
+            var output = new FileInfo(Path.Combine(TestContext.CurrentContext.TestDirectory, "inspection.capella.combined.txt"));
+
+            Assert.That(() => this.modelInspector.GenerateCombinedReport(capellaEntry, output), Throws.Nothing);
+
+            output.Refresh();
+            Assert.That(output.Exists, Is.True);
+        }
+
+        [Test]
+        public void Verify_that_GenerateCombinedReport_throws_when_arguments_are_null()
+        {
+            Assert.Multiple(() =>
+            {
+                Assert.That(() => this.modelInspector.GenerateCombinedReport(null!, reportFileInfo), Throws.ArgumentNullException);
+                Assert.That(() => this.modelInspector.GenerateCombinedReport(modelFileInfo, null!), Throws.ArgumentNullException);
+            });
+        }
+
+        [Test]
         public void Verify_that_IsValidExcelReportExtension_returns_false_when_invalid()
         {
             var inValidFileName = new FileInfo("output-report.invalid");

--- a/ECoreNetto.Reporting.Tests/Generators/XlReportGeneratorTestFixture.cs
+++ b/ECoreNetto.Reporting.Tests/Generators/XlReportGeneratorTestFixture.cs
@@ -84,57 +84,6 @@ namespace ECoreNetto.Reporting.Tests.Generators
         }
 
         [Test]
-        public void Verify_that_a_single_combined_excel_report_is_generated_for_the_whole_capella_metamodel()
-        {
-            var capellaDirectory = new DirectoryInfo(Path.Combine(TestContext.CurrentContext.TestDirectory, "Data", "capella"));
-
-            var combinedReportFileInfo = new FileInfo(Path.Combine(TestContext.CurrentContext.TestDirectory, "xl-report.capella.combined.xlsx"));
-
-            Assert.That(() => this.generator.GenerateCombinedReport(capellaDirectory, combinedReportFileInfo), Throws.Nothing);
-
-            combinedReportFileInfo.Refresh();
-            Assert.That(combinedReportFileInfo.Exists, Is.True);
-
-            using var workbook = new XLWorkbook(combinedReportFileInfo.FullName);
-
-            var info = workbook.Worksheet("Model Info");
-            var eClassSheet = workbook.Worksheet("EClass");
-
-            Assert.Multiple(() =>
-            {
-                // the info sheet lists all the included root packages
-                Assert.That(info.Cell(6, 1).GetString(), Is.EqualTo("Included Packages"));
-
-                // a single workbook must list classes that originate from several different .ecore files
-                Assert.That(eClassSheet.CellsUsed().Any(c => c.GetString() == "CapellaElement"), Is.True);
-                Assert.That(eClassSheet.CellsUsed().Any(c => c.GetString() == "LogicalArchitecture"), Is.True);
-                Assert.That(eClassSheet.CellsUsed().Any(c => c.GetString() == "SystemAnalysis"), Is.True);
-                Assert.That(eClassSheet.CellsUsed().Any(c => c.GetString() == "PhysicalArchitecture"), Is.True);
-            });
-        }
-
-        [Test]
-        public void Verify_that_a_combined_excel_report_from_an_entry_file_includes_reachable_models()
-        {
-            var modelFileInfo = new FileInfo(Path.Combine(TestContext.CurrentContext.TestDirectory, "Data", "capella", "LogicalArchitecture.ecore"));
-            var combinedReportFileInfo = new FileInfo(Path.Combine(TestContext.CurrentContext.TestDirectory, "xl-report.capella.reachable.xlsx"));
-
-            Assert.That(() => this.generator.GenerateCombinedReport(modelFileInfo, combinedReportFileInfo), Throws.Nothing);
-
-            combinedReportFileInfo.Refresh();
-            Assert.That(combinedReportFileInfo.Exists, Is.True);
-
-            using var workbook = new XLWorkbook(combinedReportFileInfo.FullName);
-            var eClassSheet = workbook.Worksheet("EClass");
-
-            Assert.Multiple(() =>
-            {
-                Assert.That(eClassSheet.CellsUsed().Any(c => c.GetString() == "LogicalArchitecture"), Is.True);
-                Assert.That(eClassSheet.CellsUsed().Any(c => c.GetString() == "ComponentArchitecture"), Is.True);
-            });
-        }
-
-        [Test]
         public void Verify_that_combined_excel_report_methods_throw_when_arguments_are_null()
         {
             var validDirectory = new DirectoryInfo(TestContext.CurrentContext.TestDirectory);

--- a/ECoreNetto.Reporting.Tests/Generators/XlReportGeneratorTestFixture.cs
+++ b/ECoreNetto.Reporting.Tests/Generators/XlReportGeneratorTestFixture.cs
@@ -84,6 +84,71 @@ namespace ECoreNetto.Reporting.Tests.Generators
         }
 
         [Test]
+        public void Verify_that_a_single_combined_excel_report_is_generated_for_the_whole_capella_metamodel()
+        {
+            var capellaDirectory = new DirectoryInfo(Path.Combine(TestContext.CurrentContext.TestDirectory, "Data", "capella"));
+
+            var combinedReportFileInfo = new FileInfo(Path.Combine(TestContext.CurrentContext.TestDirectory, "xl-report.capella.combined.xlsx"));
+
+            Assert.That(() => this.generator.GenerateCombinedReport(capellaDirectory, combinedReportFileInfo), Throws.Nothing);
+
+            combinedReportFileInfo.Refresh();
+            Assert.That(combinedReportFileInfo.Exists, Is.True);
+
+            using var workbook = new XLWorkbook(combinedReportFileInfo.FullName);
+
+            var info = workbook.Worksheet("Model Info");
+            var eClassSheet = workbook.Worksheet("EClass");
+
+            Assert.Multiple(() =>
+            {
+                // the info sheet lists all the included root packages
+                Assert.That(info.Cell(6, 1).GetString(), Is.EqualTo("Included Packages"));
+
+                // a single workbook must list classes that originate from several different .ecore files
+                Assert.That(eClassSheet.CellsUsed().Any(c => c.GetString() == "CapellaElement"), Is.True);
+                Assert.That(eClassSheet.CellsUsed().Any(c => c.GetString() == "LogicalArchitecture"), Is.True);
+                Assert.That(eClassSheet.CellsUsed().Any(c => c.GetString() == "SystemAnalysis"), Is.True);
+                Assert.That(eClassSheet.CellsUsed().Any(c => c.GetString() == "PhysicalArchitecture"), Is.True);
+            });
+        }
+
+        [Test]
+        public void Verify_that_a_combined_excel_report_from_an_entry_file_includes_reachable_models()
+        {
+            var modelFileInfo = new FileInfo(Path.Combine(TestContext.CurrentContext.TestDirectory, "Data", "capella", "LogicalArchitecture.ecore"));
+            var combinedReportFileInfo = new FileInfo(Path.Combine(TestContext.CurrentContext.TestDirectory, "xl-report.capella.reachable.xlsx"));
+
+            Assert.That(() => this.generator.GenerateCombinedReport(modelFileInfo, combinedReportFileInfo), Throws.Nothing);
+
+            combinedReportFileInfo.Refresh();
+            Assert.That(combinedReportFileInfo.Exists, Is.True);
+
+            using var workbook = new XLWorkbook(combinedReportFileInfo.FullName);
+            var eClassSheet = workbook.Worksheet("EClass");
+
+            Assert.Multiple(() =>
+            {
+                Assert.That(eClassSheet.CellsUsed().Any(c => c.GetString() == "LogicalArchitecture"), Is.True);
+                Assert.That(eClassSheet.CellsUsed().Any(c => c.GetString() == "ComponentArchitecture"), Is.True);
+            });
+        }
+
+        [Test]
+        public void Verify_that_combined_excel_report_methods_throw_when_arguments_are_null()
+        {
+            var validDirectory = new DirectoryInfo(TestContext.CurrentContext.TestDirectory);
+
+            Assert.Multiple(() =>
+            {
+                Assert.That(() => this.generator.GenerateCombinedReport((FileInfo)null!, this.reportFileInfo), Throws.ArgumentNullException);
+                Assert.That(() => this.generator.GenerateCombinedReport(this.modelFileInfo, (FileInfo)null!), Throws.ArgumentNullException);
+                Assert.That(() => this.generator.GenerateCombinedReport((DirectoryInfo)null!, this.reportFileInfo), Throws.ArgumentNullException);
+                Assert.That(() => this.generator.GenerateCombinedReport(validDirectory, null!), Throws.ArgumentNullException);
+            });
+        }
+
+        [Test]
         public void Verify_that_IsValidReportExtension_returns_expected_results()
         {
             Assert.Multiple(() =>

--- a/ECoreNetto.Reporting/Generators/HandleBarsReportGenerator.cs
+++ b/ECoreNetto.Reporting/Generators/HandleBarsReportGenerator.cs
@@ -103,7 +103,23 @@ namespace ECoreNetto.Reporting.Generators
         /// </returns>
         protected static HandlebarsPayload CreateHandlebarsPayload(EPackage rootPackage)
         {
-            var packages = rootPackage.QueryPackages();
+            return CreateHandlebarsPayload(new[] { rootPackage });
+        }
+
+        /// <summary>
+        /// Creates a <see cref="HandlebarsPayload"/> that aggregates the classifiers of all the provided root
+        /// <see cref="EPackage"/>s, so that a single report can document a multi-file metamodel.
+        /// </summary>
+        /// <param name="rootPackages">
+        /// the subject root <see cref="EPackage"/>s; the first is used as the primary package for the report
+        /// title and metadata.
+        /// </param>
+        /// <returns>
+        /// an instance of <see cref="HandlebarsPayload"/>
+        /// </returns>
+        protected static HandlebarsPayload CreateHandlebarsPayload(IReadOnlyList<EPackage> rootPackages)
+        {
+            var packages = rootPackages.SelectMany(rootPackage => rootPackage.QueryPackages());
 
             var enums = new List<EEnum>();
             var dataTypes = new List<EDataType>();
@@ -130,7 +146,7 @@ namespace ECoreNetto.Reporting.Generators
             var orderedClasses = eClasses.OrderBy(x => x.Name);
             var orderedInterfaces = eClasses.Where(x => x.Interface).OrderBy(x => x.Name);
 
-            var payload = new HandlebarsPayload(rootPackage, orderedEnums, orderedPrimitiveTypes, orderedDataTypes, orderedClasses, orderedInterfaces);
+            var payload = new HandlebarsPayload(rootPackages[0], orderedEnums, orderedPrimitiveTypes, orderedDataTypes, orderedClasses, orderedInterfaces);
 
             return payload;
         }

--- a/ECoreNetto.Reporting/Generators/HtmlReportGenerator.cs
+++ b/ECoreNetto.Reporting/Generators/HtmlReportGenerator.cs
@@ -103,15 +103,75 @@ namespace ECoreNetto.Reporting.Generators
                 throw new ArgumentNullException(nameof(modelPath));
             }
 
+            return this.GenerateReport(new[] { this.LoadRootPackage(modelPath) }, customHtml);
+        }
+
+        /// <summary>
+        /// Generates a single HTML report that aggregates the entry Ecore model together with every
+        /// cross-referenced model that is reachable from it.
+        /// </summary>
+        /// <param name="modelPath">
+        /// the path to the entry Ecore model of which the combined report is to be generated.
+        /// </param>
+        /// <param name="customHtml">
+        /// optional custom HTML that is injected into the report at the custom-HTML injection point.
+        /// </param>
+        /// <returns>
+        /// the content of an HTML report in a string
+        /// </returns>
+        public string GenerateCombinedReport(FileInfo modelPath, string customHtml = "")
+        {
+            if (modelPath == null)
+            {
+                throw new ArgumentNullException(nameof(modelPath));
+            }
+
+            return this.GenerateReport(this.LoadRootPackages(modelPath), customHtml);
+        }
+
+        /// <summary>
+        /// Generates a single HTML report that aggregates every <c>.ecore</c> model in the provided directory.
+        /// </summary>
+        /// <param name="inputDirectory">
+        /// the directory that contains the <c>.ecore</c> models of which the combined report is to be generated.
+        /// </param>
+        /// <param name="customHtml">
+        /// optional custom HTML that is injected into the report at the custom-HTML injection point.
+        /// </param>
+        /// <returns>
+        /// the content of an HTML report in a string
+        /// </returns>
+        public string GenerateCombinedReport(DirectoryInfo inputDirectory, string customHtml = "")
+        {
+            if (inputDirectory == null)
+            {
+                throw new ArgumentNullException(nameof(inputDirectory));
+            }
+
+            return this.GenerateReport(this.LoadRootPackages(inputDirectory), customHtml);
+        }
+
+        /// <summary>
+        /// Generates the HTML report for the provided root <see cref="EPackage"/>s.
+        /// </summary>
+        /// <param name="rootPackages">
+        /// the root <see cref="EPackage"/>s whose classifiers are documented in the report.
+        /// </param>
+        /// <param name="customHtml">
+        /// custom HTML that is injected into the report at the custom-HTML injection point.
+        /// </param>
+        /// <returns>
+        /// the content of an HTML report in a string
+        /// </returns>
+        private string GenerateReport(IReadOnlyList<EPackage> rootPackages, string customHtml)
+        {
             var sw = Stopwatch.StartNew();
 
             this.logger.LogInformation("Start Generating Html report tables");
 
             var template = this.Templates["ecore-to-html-docs"];
 
-            var rootPackage = this.LoadRootPackage(modelPath);
-
-            var payload = CreateHandlebarsPayload(rootPackage);
+            var payload = CreateHandlebarsPayload(rootPackages);
 
             var inheritanceDiagramSvg = this.inheritanceDiagramRenderer.SvgRender(payload);
 
@@ -188,9 +248,74 @@ namespace ECoreNetto.Reporting.Generators
                 throw new ArgumentNullException(nameof(outputPath));
             }
 
-            var sw = Stopwatch.StartNew();
+            this.WriteToFile(this.GenerateReport(modelPath, customHtml), outputPath);
+        }
 
-            var generatedHtml = this.GenerateReport(modelPath, customHtml);
+        /// <summary>
+        /// Generates a single combined HTML report of the entry model and every cross-referenced model that is
+        /// reachable from it, and writes it to the provided <paramref name="outputPath"/>.
+        /// </summary>
+        /// <param name="modelPath">
+        /// the path to the entry Ecore model of which the combined report is to be generated.
+        /// </param>
+        /// <param name="outputPath">
+        /// the path, including filename, where the output is to be generated.
+        /// </param>
+        public void GenerateCombinedReport(FileInfo modelPath, FileInfo outputPath)
+        {
+            if (modelPath == null)
+            {
+                throw new ArgumentNullException(nameof(modelPath));
+            }
+
+            if (outputPath == null)
+            {
+                throw new ArgumentNullException(nameof(outputPath));
+            }
+
+            this.WriteToFile(this.GenerateCombinedReport(modelPath, string.Empty), outputPath);
+        }
+
+        /// <summary>
+        /// Generates a single combined HTML report of every <c>.ecore</c> model in the provided directory and
+        /// writes it to the provided <paramref name="outputPath"/>.
+        /// </summary>
+        /// <param name="inputDirectory">
+        /// the directory that contains the <c>.ecore</c> models of which the combined report is to be generated.
+        /// </param>
+        /// <param name="outputPath">
+        /// the path, including filename, where the output is to be generated.
+        /// </param>
+        /// <param name="customHtml">
+        /// optional custom HTML that is injected into the report at the custom-HTML injection point.
+        /// </param>
+        public void GenerateCombinedReport(DirectoryInfo inputDirectory, FileInfo outputPath, string customHtml = "")
+        {
+            if (inputDirectory == null)
+            {
+                throw new ArgumentNullException(nameof(inputDirectory));
+            }
+
+            if (outputPath == null)
+            {
+                throw new ArgumentNullException(nameof(outputPath));
+            }
+
+            this.WriteToFile(this.GenerateCombinedReport(inputDirectory, customHtml), outputPath);
+        }
+
+        /// <summary>
+        /// Writes the generated HTML to the provided <paramref name="outputPath"/>, overwriting an existing file.
+        /// </summary>
+        /// <param name="generatedHtml">
+        /// the generated HTML content.
+        /// </param>
+        /// <param name="outputPath">
+        /// the path, including filename, where the output is to be written.
+        /// </param>
+        private void WriteToFile(string generatedHtml, FileInfo outputPath)
+        {
+            var sw = Stopwatch.StartNew();
 
             if (outputPath.Exists)
             {

--- a/ECoreNetto.Reporting/Generators/HtmlReportGenerator.cs
+++ b/ECoreNetto.Reporting/Generators/HtmlReportGenerator.cs
@@ -286,10 +286,26 @@ namespace ECoreNetto.Reporting.Generators
         /// <param name="outputPath">
         /// the path, including filename, where the output is to be generated.
         /// </param>
-        /// <param name="customHtml">
-        /// optional custom HTML that is injected into the report at the custom-HTML injection point.
+        public void GenerateCombinedReport(DirectoryInfo inputDirectory, FileInfo outputPath)
+        {
+            this.GenerateCombinedReport(inputDirectory, outputPath, string.Empty);
+        }
+
+        /// <summary>
+        /// Generates a single combined HTML report of every <c>.ecore</c> model in the provided directory and
+        /// writes it to the provided <paramref name="outputPath"/>.
+        /// </summary>
+        /// <param name="inputDirectory">
+        /// the directory that contains the <c>.ecore</c> models of which the combined report is to be generated.
         /// </param>
-        public void GenerateCombinedReport(DirectoryInfo inputDirectory, FileInfo outputPath, string customHtml = "")
+        /// <param name="outputPath">
+        /// the path, including filename, where the output is to be generated.
+        /// </param>
+        /// <param name="customHtml">
+        /// custom HTML that is injected into the report at the custom-HTML injection point; pass
+        /// <see cref="string.Empty"/> when none is required.
+        /// </param>
+        public void GenerateCombinedReport(DirectoryInfo inputDirectory, FileInfo outputPath, string customHtml)
         {
             if (inputDirectory == null)
             {

--- a/ECoreNetto.Reporting/Generators/IHtmlReportGenerator.cs
+++ b/ECoreNetto.Reporting/Generators/IHtmlReportGenerator.cs
@@ -45,5 +45,49 @@ namespace ECoreNetto.Reporting.Generators
         /// <see cref="string.Empty"/> when none is required.
         /// </param>
         public void GenerateReport(FileInfo modelPath, FileInfo outputPath, string customHtml);
+
+        /// <summary>
+        /// Generates a single combined HTML report of the entry model together with every cross-referenced
+        /// model that is reachable from it.
+        /// </summary>
+        /// <param name="modelPath">
+        /// the path to the entry Ecore model of which the combined report is to be generated.
+        /// </param>
+        /// <param name="customHtml">
+        /// optional custom HTML that is injected into the report at the custom-HTML injection point.
+        /// </param>
+        /// <returns>
+        /// the content of an HTML report in a string
+        /// </returns>
+        public string GenerateCombinedReport(FileInfo modelPath, string customHtml = "");
+
+        /// <summary>
+        /// Generates a single combined HTML report of every <c>.ecore</c> model in the provided directory.
+        /// </summary>
+        /// <param name="inputDirectory">
+        /// the directory that contains the <c>.ecore</c> models of which the combined report is to be generated.
+        /// </param>
+        /// <param name="customHtml">
+        /// optional custom HTML that is injected into the report at the custom-HTML injection point.
+        /// </param>
+        /// <returns>
+        /// the content of an HTML report in a string
+        /// </returns>
+        public string GenerateCombinedReport(DirectoryInfo inputDirectory, string customHtml = "");
+
+        /// <summary>
+        /// Generates a single combined HTML report of every <c>.ecore</c> model in the provided directory and
+        /// writes it to the provided <paramref name="outputPath"/>.
+        /// </summary>
+        /// <param name="inputDirectory">
+        /// the directory that contains the <c>.ecore</c> models of which the combined report is to be generated.
+        /// </param>
+        /// <param name="outputPath">
+        /// the path, including filename, where the output is to be generated.
+        /// </param>
+        /// <param name="customHtml">
+        /// optional custom HTML that is injected into the report at the custom-HTML injection point.
+        /// </param>
+        public void GenerateCombinedReport(DirectoryInfo inputDirectory, FileInfo outputPath, string customHtml = "");
     }
 }

--- a/ECoreNetto.Reporting/Generators/IHtmlReportGenerator.cs
+++ b/ECoreNetto.Reporting/Generators/IHtmlReportGenerator.cs
@@ -86,8 +86,9 @@ namespace ECoreNetto.Reporting.Generators
         /// the path, including filename, where the output is to be generated.
         /// </param>
         /// <param name="customHtml">
-        /// optional custom HTML that is injected into the report at the custom-HTML injection point.
+        /// custom HTML that is injected into the report at the custom-HTML injection point; pass
+        /// <see cref="string.Empty"/> when none is required.
         /// </param>
-        public void GenerateCombinedReport(DirectoryInfo inputDirectory, FileInfo outputPath, string customHtml = "");
+        public void GenerateCombinedReport(DirectoryInfo inputDirectory, FileInfo outputPath, string customHtml);
     }
 }

--- a/ECoreNetto.Reporting/Generators/IMarkdownReportGenerator.cs
+++ b/ECoreNetto.Reporting/Generators/IMarkdownReportGenerator.cs
@@ -27,5 +27,40 @@ namespace ECoreNetto.Reporting.Generators
         /// the content of a Markdown report in a string
         /// </returns>
         public string GenerateReport(FileInfo modelPath);
+
+        /// <summary>
+        /// Generates a single combined Markdown report of the entry model together with every cross-referenced
+        /// model that is reachable from it.
+        /// </summary>
+        /// <param name="modelPath">
+        /// the path to the entry Ecore model of which the combined report is to be generated.
+        /// </param>
+        /// <returns>
+        /// the content of a Markdown report in a string
+        /// </returns>
+        public string GenerateCombinedReport(FileInfo modelPath);
+
+        /// <summary>
+        /// Generates a single combined Markdown report of every <c>.ecore</c> model in the provided directory.
+        /// </summary>
+        /// <param name="inputDirectory">
+        /// the directory that contains the <c>.ecore</c> models of which the combined report is to be generated.
+        /// </param>
+        /// <returns>
+        /// the content of a Markdown report in a string
+        /// </returns>
+        public string GenerateCombinedReport(DirectoryInfo inputDirectory);
+
+        /// <summary>
+        /// Generates a single combined Markdown report of every <c>.ecore</c> model in the provided directory
+        /// and writes it to the provided <paramref name="outputPath"/>.
+        /// </summary>
+        /// <param name="inputDirectory">
+        /// the directory that contains the <c>.ecore</c> models of which the combined report is to be generated.
+        /// </param>
+        /// <param name="outputPath">
+        /// the path, including filename, where the output is to be generated.
+        /// </param>
+        public void GenerateCombinedReport(DirectoryInfo inputDirectory, FileInfo outputPath);
     }
 }

--- a/ECoreNetto.Reporting/Generators/IMarkdownReportGenerator.cs
+++ b/ECoreNetto.Reporting/Generators/IMarkdownReportGenerator.cs
@@ -50,17 +50,5 @@ namespace ECoreNetto.Reporting.Generators
         /// the content of a Markdown report in a string
         /// </returns>
         public string GenerateCombinedReport(DirectoryInfo inputDirectory);
-
-        /// <summary>
-        /// Generates a single combined Markdown report of every <c>.ecore</c> model in the provided directory
-        /// and writes it to the provided <paramref name="outputPath"/>.
-        /// </summary>
-        /// <param name="inputDirectory">
-        /// the directory that contains the <c>.ecore</c> models of which the combined report is to be generated.
-        /// </param>
-        /// <param name="outputPath">
-        /// the path, including filename, where the output is to be generated.
-        /// </param>
-        public void GenerateCombinedReport(DirectoryInfo inputDirectory, FileInfo outputPath);
     }
 }

--- a/ECoreNetto.Reporting/Generators/IReportGenerator.cs
+++ b/ECoreNetto.Reporting/Generators/IReportGenerator.cs
@@ -30,6 +30,18 @@ namespace ECoreNetto.Reporting.Generators
         public void GenerateReport(FileInfo modelPath, FileInfo outputPath);
 
         /// <summary>
+        /// Generates a single combined report of the entry model together with every cross-referenced model
+        /// that is reachable from it.
+        /// </summary>
+        /// <param name="modelPath">
+        /// the path to the entry Ecore model of which the combined report is to be generated.
+        /// </param>
+        /// <param name="outputPath">
+        /// the path, including filename, where the output is to be generated.
+        /// </param>
+        public void GenerateCombinedReport(FileInfo modelPath, FileInfo outputPath);
+
+        /// <summary>
         /// Verifies whether the extension of the <paramref name="outputPath"/> is valid or not
         /// </summary>
         /// <param name="outputPath">

--- a/ECoreNetto.Reporting/Generators/IReportGenerator.cs
+++ b/ECoreNetto.Reporting/Generators/IReportGenerator.cs
@@ -42,6 +42,17 @@ namespace ECoreNetto.Reporting.Generators
         public void GenerateCombinedReport(FileInfo modelPath, FileInfo outputPath);
 
         /// <summary>
+        /// Generates a single combined report of every <c>.ecore</c> model in the provided directory.
+        /// </summary>
+        /// <param name="inputDirectory">
+        /// the directory that contains the <c>.ecore</c> models of which the combined report is to be generated.
+        /// </param>
+        /// <param name="outputPath">
+        /// the path, including filename, where the output is to be generated.
+        /// </param>
+        public void GenerateCombinedReport(DirectoryInfo inputDirectory, FileInfo outputPath);
+
+        /// <summary>
         /// Verifies whether the extension of the <paramref name="outputPath"/> is valid or not
         /// </summary>
         /// <param name="outputPath">

--- a/ECoreNetto.Reporting/Generators/IXlReportGenerator.cs
+++ b/ECoreNetto.Reporting/Generators/IXlReportGenerator.cs
@@ -9,24 +9,11 @@
 
 namespace ECoreNetto.Reporting.Generators
 {
-    using System.IO;
-
     /// <summary>
     /// The purpose of the <see cref="IXlReportGenerator"/> is to generate reports of an
-    /// Ecore Model
+    /// Ecore Model. The combined (multi-file) report members are inherited from <see cref="IReportGenerator"/>.
     /// </summary>
     public interface IXlReportGenerator : IReportGenerator
     {
-        /// <summary>
-        /// Generates a single combined Excel report of every <c>.ecore</c> model in the provided directory and
-        /// writes it to the provided <paramref name="outputPath"/>.
-        /// </summary>
-        /// <param name="inputDirectory">
-        /// the directory that contains the <c>.ecore</c> models of which the combined report is to be generated.
-        /// </param>
-        /// <param name="outputPath">
-        /// the path, including filename, where the output is to be generated.
-        /// </param>
-        public void GenerateCombinedReport(DirectoryInfo inputDirectory, FileInfo outputPath);
     }
 }

--- a/ECoreNetto.Reporting/Generators/IXlReportGenerator.cs
+++ b/ECoreNetto.Reporting/Generators/IXlReportGenerator.cs
@@ -9,11 +9,24 @@
 
 namespace ECoreNetto.Reporting.Generators
 {
+    using System.IO;
+
     /// <summary>
     /// The purpose of the <see cref="IXlReportGenerator"/> is to generate reports of an
     /// Ecore Model
     /// </summary>
     public interface IXlReportGenerator : IReportGenerator
     {
+        /// <summary>
+        /// Generates a single combined Excel report of every <c>.ecore</c> model in the provided directory and
+        /// writes it to the provided <paramref name="outputPath"/>.
+        /// </summary>
+        /// <param name="inputDirectory">
+        /// the directory that contains the <c>.ecore</c> models of which the combined report is to be generated.
+        /// </param>
+        /// <param name="outputPath">
+        /// the path, including filename, where the output is to be generated.
+        /// </param>
+        public void GenerateCombinedReport(DirectoryInfo inputDirectory, FileInfo outputPath);
     }
 }

--- a/ECoreNetto.Reporting/Generators/MarkdownReportGenerator.cs
+++ b/ECoreNetto.Reporting/Generators/MarkdownReportGenerator.cs
@@ -10,6 +10,7 @@
 namespace ECoreNetto.Reporting.Generators
 {
     using System;
+    using System.Collections.Generic;
     using System.Diagnostics;
     using System.IO;
 
@@ -65,15 +66,66 @@ namespace ECoreNetto.Reporting.Generators
                 throw new ArgumentNullException(nameof(modelPath));
             }
 
+            return this.GenerateReport(new[] { this.LoadRootPackage(modelPath) });
+        }
+
+        /// <summary>
+        /// Generates a single combined Markdown report of the entry model together with every cross-referenced
+        /// model that is reachable from it.
+        /// </summary>
+        /// <param name="modelPath">
+        /// the path to the entry Ecore model of which the combined report is to be generated.
+        /// </param>
+        /// <returns>
+        /// the content of a Markdown report in a string
+        /// </returns>
+        public string GenerateCombinedReport(FileInfo modelPath)
+        {
+            if (modelPath == null)
+            {
+                throw new ArgumentNullException(nameof(modelPath));
+            }
+
+            return this.GenerateReport(this.LoadRootPackages(modelPath));
+        }
+
+        /// <summary>
+        /// Generates a single combined Markdown report of every <c>.ecore</c> model in the provided directory.
+        /// </summary>
+        /// <param name="inputDirectory">
+        /// the directory that contains the <c>.ecore</c> models of which the combined report is to be generated.
+        /// </param>
+        /// <returns>
+        /// the content of a Markdown report in a string
+        /// </returns>
+        public string GenerateCombinedReport(DirectoryInfo inputDirectory)
+        {
+            if (inputDirectory == null)
+            {
+                throw new ArgumentNullException(nameof(inputDirectory));
+            }
+
+            return this.GenerateReport(this.LoadRootPackages(inputDirectory));
+        }
+
+        /// <summary>
+        /// Generates the Markdown report for the provided root <see cref="EPackage"/>s.
+        /// </summary>
+        /// <param name="rootPackages">
+        /// the root <see cref="EPackage"/>s whose classifiers are documented in the report.
+        /// </param>
+        /// <returns>
+        /// the content of a Markdown report in a string
+        /// </returns>
+        private string GenerateReport(IReadOnlyList<EPackage> rootPackages)
+        {
             var sw = Stopwatch.StartNew();
 
             this.logger.LogInformation("Start Generating Markdown report");
 
             var template = this.Templates["ecore-to-markdown-docs"];
 
-            var rootPackage = this.LoadRootPackage(modelPath);
-
-            var payload = CreateHandlebarsPayload(rootPackage);
+            var payload = CreateHandlebarsPayload(rootPackages);
 
             var generatedMarkdown = template(payload);
 
@@ -103,9 +155,71 @@ namespace ECoreNetto.Reporting.Generators
                 throw new ArgumentNullException(nameof(outputPath));
             }
 
-            var sw = Stopwatch.StartNew();
+            this.WriteToFile(this.GenerateReport(modelPath), outputPath);
+        }
 
-            var generatedMarkdown = this.GenerateReport(modelPath) ;
+        /// <summary>
+        /// Generates a single combined Markdown report of the entry model together with every cross-referenced
+        /// model that is reachable from it, and writes it to the provided <paramref name="outputPath"/>.
+        /// </summary>
+        /// <param name="modelPath">
+        /// the path to the entry Ecore model of which the combined report is to be generated.
+        /// </param>
+        /// <param name="outputPath">
+        /// the path, including filename, where the output is to be generated.
+        /// </param>
+        public void GenerateCombinedReport(FileInfo modelPath, FileInfo outputPath)
+        {
+            if (modelPath == null)
+            {
+                throw new ArgumentNullException(nameof(modelPath));
+            }
+
+            if (outputPath == null)
+            {
+                throw new ArgumentNullException(nameof(outputPath));
+            }
+
+            this.WriteToFile(this.GenerateCombinedReport(modelPath), outputPath);
+        }
+
+        /// <summary>
+        /// Generates a single combined Markdown report of every <c>.ecore</c> model in the provided directory
+        /// and writes it to the provided <paramref name="outputPath"/>.
+        /// </summary>
+        /// <param name="inputDirectory">
+        /// the directory that contains the <c>.ecore</c> models of which the combined report is to be generated.
+        /// </param>
+        /// <param name="outputPath">
+        /// the path, including filename, where the output is to be generated.
+        /// </param>
+        public void GenerateCombinedReport(DirectoryInfo inputDirectory, FileInfo outputPath)
+        {
+            if (inputDirectory == null)
+            {
+                throw new ArgumentNullException(nameof(inputDirectory));
+            }
+
+            if (outputPath == null)
+            {
+                throw new ArgumentNullException(nameof(outputPath));
+            }
+
+            this.WriteToFile(this.GenerateCombinedReport(inputDirectory), outputPath);
+        }
+
+        /// <summary>
+        /// Writes the generated Markdown to the provided <paramref name="outputPath"/>, overwriting an existing file.
+        /// </summary>
+        /// <param name="generatedMarkdown">
+        /// the generated Markdown content.
+        /// </param>
+        /// <param name="outputPath">
+        /// the path, including filename, where the output is to be written.
+        /// </param>
+        private void WriteToFile(string generatedMarkdown, FileInfo outputPath)
+        {
+            var sw = Stopwatch.StartNew();
 
             if (outputPath.Exists)
             {
@@ -117,7 +231,7 @@ namespace ECoreNetto.Reporting.Generators
 
             this.logger.LogInformation("Generated Markdown report in {ElapsedTime} [ms]", sw.ElapsedMilliseconds);
         }
-        
+
         /// <summary>
         /// Verifies whether the extension of the <paramref name="outputPath"/> is valid or not
         /// </summary>

--- a/ECoreNetto.Reporting/Generators/ModelInspector.cs
+++ b/ECoreNetto.Reporting/Generators/ModelInspector.cs
@@ -475,13 +475,62 @@ namespace ECoreNetto.Reporting.Generators
 
             if (outputPath.Exists)
             {
-                outputPath.Delete(); 
+                outputPath.Delete();
             }
 
             using var writer = outputPath.CreateText();
             writer.Write(result);
 
             this.logger.LogInformation("Generated inspection report in {0} [ms]", sw.ElapsedMilliseconds);
+        }
+
+        /// <summary>
+        /// Generates a single combined inspection report of the entry model together with every
+        /// cross-referenced model that is reachable from it.
+        /// </summary>
+        /// <param name="modelPath">
+        /// the path to the entry Ecore model of which the combined report is to be generated.
+        /// </param>
+        /// <param name="outputPath">
+        /// the path, including filename, where the output is to be generated.
+        /// </param>
+        public void GenerateCombinedReport(FileInfo modelPath, FileInfo outputPath)
+        {
+            if (modelPath == null)
+            {
+                throw new ArgumentNullException(nameof(modelPath));
+            }
+
+            if (outputPath == null)
+            {
+                throw new ArgumentNullException(nameof(outputPath));
+            }
+
+            var sw = Stopwatch.StartNew();
+
+            this.logger.LogInformation("Start Generating combined Inspection Report");
+
+            var rootPackages = this.LoadRootPackages(modelPath);
+
+            var result = new StringBuilder();
+
+            result.Append(this.ReportHeader());
+
+            foreach (var rootPackage in rootPackages)
+            {
+                result.Append(this.Inspect(rootPackage, true));
+                result.Append(this.AnalyzeDocumentation(rootPackage, true));
+            }
+
+            if (outputPath.Exists)
+            {
+                outputPath.Delete();
+            }
+
+            using var writer = outputPath.CreateText();
+            writer.Write(result);
+
+            this.logger.LogInformation("Generated combined inspection report in {0} [ms]", sw.ElapsedMilliseconds);
         }
 
         /// <summary>

--- a/ECoreNetto.Reporting/Generators/ModelInspector.cs
+++ b/ECoreNetto.Reporting/Generators/ModelInspector.cs
@@ -534,6 +534,54 @@ namespace ECoreNetto.Reporting.Generators
         }
 
         /// <summary>
+        /// Generates a single combined inspection report of every <c>.ecore</c> model in the provided directory.
+        /// </summary>
+        /// <param name="inputDirectory">
+        /// the directory that contains the <c>.ecore</c> models of which the combined report is to be generated.
+        /// </param>
+        /// <param name="outputPath">
+        /// the path, including filename, where the output is to be generated.
+        /// </param>
+        public void GenerateCombinedReport(DirectoryInfo inputDirectory, FileInfo outputPath)
+        {
+            if (inputDirectory == null)
+            {
+                throw new ArgumentNullException(nameof(inputDirectory));
+            }
+
+            if (outputPath == null)
+            {
+                throw new ArgumentNullException(nameof(outputPath));
+            }
+
+            var sw = Stopwatch.StartNew();
+
+            this.logger.LogInformation("Start Generating combined Inspection Report for directory {0}", inputDirectory.FullName);
+
+            var rootPackages = this.LoadRootPackages(inputDirectory);
+
+            var result = new StringBuilder();
+
+            result.Append(this.ReportHeader());
+
+            foreach (var rootPackage in rootPackages)
+            {
+                result.Append(this.Inspect(rootPackage, true));
+                result.Append(this.AnalyzeDocumentation(rootPackage, true));
+            }
+
+            if (outputPath.Exists)
+            {
+                outputPath.Delete();
+            }
+
+            using var writer = outputPath.CreateText();
+            writer.Write(result);
+
+            this.logger.LogInformation("Generated combined inspection report in {0} [ms]", sw.ElapsedMilliseconds);
+        }
+
+        /// <summary>
         /// Generates the report header that is the first part of the text report
         /// </summary>
         /// <returns>

--- a/ECoreNetto.Reporting/Generators/ReportGenerator.cs
+++ b/ECoreNetto.Reporting/Generators/ReportGenerator.cs
@@ -9,7 +9,9 @@
 
 namespace ECoreNetto.Reporting.Generators
 {
+    using System.Collections.Generic;
     using System.IO;
+    using System.Linq;
 
     using ECoreNetto.Resource;
 
@@ -84,6 +86,85 @@ namespace ECoreNetto.Reporting.Generators
             var rootPackage = resource.Load(null);
 
             return rootPackage;
+        }
+
+        /// <summary>
+        /// Loads the entry Ecore model together with every cross-referenced model that is demand-loaded while
+        /// resolving it, and returns the root <see cref="EPackage"/> of every resource in the resulting
+        /// <see cref="ResourceSet"/>.
+        /// </summary>
+        /// <param name="modelPath">
+        /// the path to the entry Ecore model that is to be loaded.
+        /// </param>
+        /// <returns>
+        /// A read-only list of the root <see cref="EPackage"/>s of the entry model and of every model that is
+        /// reachable from it through cross-references. The entry model's root package is first.
+        /// </returns>
+        protected IReadOnlyList<EPackage> LoadRootPackages(FileInfo modelPath)
+        {
+            if (modelPath == null)
+            {
+                throw new ArgumentNullException(nameof(modelPath));
+            }
+
+            this.logger.LogInformation("Loading Ecore model and referenced models from {0}", modelPath.FullName);
+
+            var resourceSet = new ResourceSet(this.loggerFactory);
+            var uri = new System.Uri(modelPath.FullName);
+            var resource = resourceSet.CreateResource(uri);
+            resource.Load(null);
+
+            return QueryRootPackages(resourceSet);
+        }
+
+        /// <summary>
+        /// Loads every <c>.ecore</c> file in the provided <paramref name="inputDirectory"/> into a single
+        /// <see cref="ResourceSet"/> and returns the root <see cref="EPackage"/> of every resource, so that a
+        /// single report can be produced for a multi-file metamodel.
+        /// </summary>
+        /// <param name="inputDirectory">
+        /// the directory that contains the <c>.ecore</c> files that are to be loaded.
+        /// </param>
+        /// <returns>
+        /// A read-only list of the root <see cref="EPackage"/>s of every loaded model.
+        /// </returns>
+        protected IReadOnlyList<EPackage> LoadRootPackages(DirectoryInfo inputDirectory)
+        {
+            if (inputDirectory == null)
+            {
+                throw new ArgumentNullException(nameof(inputDirectory));
+            }
+
+            this.logger.LogInformation("Loading all Ecore models from directory {0}", inputDirectory.FullName);
+
+            var resourceSet = new ResourceSet(this.loggerFactory);
+
+            foreach (var file in inputDirectory.EnumerateFiles("*.ecore"))
+            {
+                var uri = new System.Uri(file.FullName);
+
+                // demand-load so files already pulled in through cross-references are not loaded twice
+                resourceSet.Resource(uri, true);
+            }
+
+            return QueryRootPackages(resourceSet);
+        }
+
+        /// <summary>
+        /// Queries the root <see cref="EPackage"/> of every resource contained in the provided
+        /// <see cref="ResourceSet"/>.
+        /// </summary>
+        /// <param name="resourceSet">
+        /// the <see cref="ResourceSet"/> whose resources' root packages are collected.
+        /// </param>
+        /// <returns>
+        /// A read-only list of the root <see cref="EPackage"/>s, in resource order.
+        /// </returns>
+        private static IReadOnlyList<EPackage> QueryRootPackages(ResourceSet resourceSet)
+        {
+            return resourceSet.Resources
+                .SelectMany(resource => resource.Contents.OfType<EPackage>())
+                .ToList();
         }
     }
 }

--- a/ECoreNetto.Reporting/Generators/XlReportGenerator.cs
+++ b/ECoreNetto.Reporting/Generators/XlReportGenerator.cs
@@ -78,17 +78,80 @@ namespace ECoreNetto.Reporting.Generators
                 throw new ArgumentNullException(nameof(outputPath));
             }
 
+            this.GenerateReport(new[] { this.LoadRootPackage(modelPath) }, outputPath);
+        }
+
+        /// <summary>
+        /// Generates a single combined Excel report of the entry model together with every cross-referenced
+        /// model that is reachable from it, and writes it to the provided <paramref name="outputPath"/>.
+        /// </summary>
+        /// <param name="modelPath">
+        /// the path to the entry Ecore model of which the combined report is to be generated.
+        /// </param>
+        /// <param name="outputPath">
+        /// the path, including filename, where the output is to be generated.
+        /// </param>
+        public void GenerateCombinedReport(FileInfo modelPath, FileInfo outputPath)
+        {
+            if (modelPath == null)
+            {
+                throw new ArgumentNullException(nameof(modelPath));
+            }
+
+            if (outputPath == null)
+            {
+                throw new ArgumentNullException(nameof(outputPath));
+            }
+
+            this.GenerateReport(this.LoadRootPackages(modelPath), outputPath);
+        }
+
+        /// <summary>
+        /// Generates a single combined Excel report of every <c>.ecore</c> model in the provided directory and
+        /// writes it to the provided <paramref name="outputPath"/>.
+        /// </summary>
+        /// <param name="inputDirectory">
+        /// the directory that contains the <c>.ecore</c> models of which the combined report is to be generated.
+        /// </param>
+        /// <param name="outputPath">
+        /// the path, including filename, where the output is to be generated.
+        /// </param>
+        public void GenerateCombinedReport(DirectoryInfo inputDirectory, FileInfo outputPath)
+        {
+            if (inputDirectory == null)
+            {
+                throw new ArgumentNullException(nameof(inputDirectory));
+            }
+
+            if (outputPath == null)
+            {
+                throw new ArgumentNullException(nameof(outputPath));
+            }
+
+            this.GenerateReport(this.LoadRootPackages(inputDirectory), outputPath);
+        }
+
+        /// <summary>
+        /// Generates the Excel report for the provided root <see cref="EPackage"/>s and writes it to the
+        /// provided <paramref name="outputPath"/>.
+        /// </summary>
+        /// <param name="rootPackages">
+        /// the root <see cref="EPackage"/>s whose classifiers are documented in the report.
+        /// </param>
+        /// <param name="outputPath">
+        /// the path, including filename, where the output is to be generated.
+        /// </param>
+        private void GenerateReport(IReadOnlyList<EPackage> rootPackages, FileInfo outputPath)
+        {
             var sw = Stopwatch.StartNew();
 
             this.logger.LogInformation("Start Generating Excel report tables");
 
-            var rootPackage = this.LoadRootPackage(modelPath);
-
-            var packages = rootPackage.QueryPackages();
+            var packages = rootPackages.SelectMany(rootPackage => rootPackage.QueryPackages()).ToList();
 
             using (var workbook = new XLWorkbook())
             {
-                this.AddInfoSheet(workbook, rootPackage);
+                this.AddInfoSheet(workbook, rootPackages);
 
                 this.AddClassSheet(workbook, packages);
 
@@ -110,18 +173,21 @@ namespace ECoreNetto.Reporting.Generators
         /// <param name="workbook">
         /// The target <see cref="XLWorkbook"/> to which the info worksheet is added
         /// </param>
-        /// <param name="rootPackage">
-        /// The root <see cref="EPackage"/>
+        /// <param name="rootPackages">
+        /// The root <see cref="EPackage"/>s documented in the report; the first is treated as the primary
+        /// package and every included root package name is listed.
         /// </param>
-        private void AddInfoSheet(XLWorkbook workbook, EPackage rootPackage)
+        private void AddInfoSheet(XLWorkbook workbook, IReadOnlyList<EPackage> rootPackages)
         {
             this.logger.LogDebug("Add info sheet");
+
+            var rootPackage = rootPackages[0];
 
             var infoWorksheet = workbook.Worksheets.Add("Model Info");
 
             infoWorksheet.Cell(1, 1).Value = "ECoreNetto.Reporting Version";
             infoWorksheet.Cell(1, 2).Value = Assembly.GetExecutingAssembly().GetName().Version?.ToString();
-            
+
             infoWorksheet.Cell(2, 1).Value = "Generation Date";
             infoWorksheet.Cell(2, 2).Value =  DateTime.Now.ToString("yyyy-MM-dd HH:mm:ss");
 
@@ -133,6 +199,9 @@ namespace ECoreNetto.Reporting.Generators
 
             infoWorksheet.Cell(5, 1).Value = "Root Package - ns uri";
             infoWorksheet.Cell(5, 2).Value = rootPackage.NsUri;
+
+            infoWorksheet.Cell(6, 1).Value = "Included Packages";
+            infoWorksheet.Cell(6, 2).Value = string.Join(", ", rootPackages.Select(package => package.Name));
 
             this.FormatSheet(infoWorksheet);
         }

--- a/ECoreNetto.Tools.Tests/Commands/HtmlReportCommandTestFixture.cs
+++ b/ECoreNetto.Tools.Tests/Commands/HtmlReportCommandTestFixture.cs
@@ -113,6 +113,46 @@ namespace ECoreNetto.Tools.Tests.Commands
         }
 
         [Test]
+        public async Task Verify_that_InvokeAsync_generates_a_combined_report_for_a_directory()
+        {
+            var args = new[]
+            {
+                "html-report",
+                "--no-logo",
+                "--input-directory", Path.Combine(TestContext.CurrentContext.TestDirectory, "Data"),
+                "--output-report", Path.Combine(TestContext.CurrentContext.TestDirectory, "html-report.directory.html")
+            };
+
+            var parseResult = this.rootCommand.Parse(args);
+
+            var result = await this.handler.InvokeAsync(parseResult, this.cts.Token);
+
+            this.htmlReportGenerator.Verify(x => x.GenerateCombinedReport(It.IsAny<DirectoryInfo>(), It.IsAny<FileInfo>()), Times.Once);
+            this.htmlReportGenerator.Verify(x => x.GenerateReport(It.IsAny<FileInfo>(), It.IsAny<FileInfo>()), Times.Never);
+            this.htmlReportGenerator.Verify(x => x.GenerateCombinedReport(It.IsAny<FileInfo>(), It.IsAny<FileInfo>()), Times.Never);
+
+            Assert.That(result, Is.EqualTo(0), "InvokeAsync should return 0 upon success.");
+        }
+
+        [Test]
+        public async Task Verify_that_when_the_input_directory_does_not_exist_returns_not_0()
+        {
+            var args = new[]
+            {
+                "html-report",
+                "--no-logo",
+                "--input-directory", Path.Combine(TestContext.CurrentContext.TestDirectory, "Data", "does-not-exist"),
+                "--output-report", Path.Combine(TestContext.CurrentContext.TestDirectory, "html-report.directory.html")
+            };
+
+            var parseResult = this.rootCommand.Parse(args);
+
+            var result = await this.handler.InvokeAsync(parseResult, this.cts.Token);
+
+            Assert.That(result, Is.EqualTo(-1), "InvokeAsync should return -1 upon failure.");
+        }
+
+        [Test]
         public async Task Verify_that_when_the_input_ecore_model_does_not_exists_returns_not_0()
         {
             var args = new[]

--- a/ECoreNetto.Tools.Tests/Commands/HtmlReportCommandTestFixture.cs
+++ b/ECoreNetto.Tools.Tests/Commands/HtmlReportCommandTestFixture.cs
@@ -91,6 +91,28 @@ namespace ECoreNetto.Tools.Tests.Commands
         }
 
         [Test]
+        public async Task Verify_that_InvokeAsync_generates_a_combined_report_when_include_referenced_models_is_set()
+        {
+            var args = new[]
+            {
+                "html-report",
+                "--no-logo",
+                "--include-referenced-models",
+                "--input-model", Path.Combine(TestContext.CurrentContext.TestDirectory, "Data", "recipe.ecore"),
+                "--output-report", Path.Combine(TestContext.CurrentContext.TestDirectory, "html-report.combined.html")
+            };
+
+            var parseResult = this.rootCommand.Parse(args);
+
+            var result = await this.handler.InvokeAsync(parseResult, this.cts.Token);
+
+            this.htmlReportGenerator.Verify(x => x.GenerateCombinedReport(It.IsAny<FileInfo>(), It.IsAny<FileInfo>()), Times.Once);
+            this.htmlReportGenerator.Verify(x => x.GenerateReport(It.IsAny<FileInfo>(), It.IsAny<FileInfo>()), Times.Never);
+
+            Assert.That(result, Is.EqualTo(0), "InvokeAsync should return 0 upon success.");
+        }
+
+        [Test]
         public async Task Verify_that_when_the_input_ecore_model_does_not_exists_returns_not_0()
         {
             var args = new[]

--- a/ECoreNetto.Tools/Commands/ReportCommand.cs
+++ b/ECoreNetto.Tools/Commands/ReportCommand.cs
@@ -47,11 +47,21 @@ namespace ECoreNetto.Tools.Commands
             {
                 Description = "The path to the ecore file",
                 DefaultValueFactory = parseResult => new FileInfo("model.ecore"),
-                Required = true
+                Required = false
             };
 
             inputModelFileOption.Aliases.Add("-i");
             this.Add(inputModelFileOption);
+
+            var inputDirectoryOption = new Option<DirectoryInfo?>(name: "--input-directory")
+            {
+                Description = "The path to a directory of .ecore files; produces a single combined report for every model in the directory",
+                DefaultValueFactory = parseResult => null,
+                Required = false
+            };
+
+            inputDirectoryOption.Aliases.Add("-d");
+            this.Add(inputDirectoryOption);
 
             var autoOpenReportOption = new Option<bool>(name: "--auto-open-report")
             {

--- a/ECoreNetto.Tools/Commands/ReportCommand.cs
+++ b/ECoreNetto.Tools/Commands/ReportCommand.cs
@@ -62,6 +62,16 @@ namespace ECoreNetto.Tools.Commands
 
             autoOpenReportOption.Aliases.Add("-a");
             this.Add(autoOpenReportOption);
+
+            var includeReferencedModelsOption = new Option<bool>(name: "--include-referenced-models")
+            {
+                Description = "Produce a single combined report that also includes every cross-referenced .ecore model reachable from the input model",
+                DefaultValueFactory = parseResult => false,
+                Required = false
+            };
+
+            includeReferencedModelsOption.Aliases.Add("-r");
+            this.Add(includeReferencedModelsOption);
         }
     }
 }

--- a/ECoreNetto.Tools/Commands/ReportHandler.cs
+++ b/ECoreNetto.Tools/Commands/ReportHandler.cs
@@ -70,6 +70,12 @@ namespace ECoreNetto.Tools.Commands
         private FileInfo inputModel = null!;
 
         /// <summary>
+        /// The optional <see cref="DirectoryInfo"/> of a directory of <c>.ecore</c> models; when set a single
+        /// combined report is generated for every model in the directory.
+        /// </summary>
+        private DirectoryInfo? inputDirectory;
+
+        /// <summary>
         /// The <see cref="FileInfo"/> where the inspection report is to be generated
         /// </summary>
         private FileInfo outputReport = null!;
@@ -137,7 +143,11 @@ namespace ECoreNetto.Tools.Commands
 
                         await Task.Delay(this.StatusDelay, cancellationToken);
 
-                        if (this.includeReferencedModels)
+                        if (this.inputDirectory != null)
+                        {
+                            this.ReportGenerator.GenerateCombinedReport(this.inputDirectory, this.outputReport);
+                        }
+                        else if (this.includeReferencedModels)
                         {
                             this.ReportGenerator.GenerateCombinedReport(this.inputModel, this.outputReport);
                         }
@@ -195,6 +205,7 @@ namespace ECoreNetto.Tools.Commands
             this.autoOpenReport = parseResult.GetValue<bool>("--auto-open-report");
             this.outputReport = parseResult.GetValue<FileInfo>("--output-report")!;
             this.includeReferencedModels = parseResult.GetValue<bool>("--include-referenced-models");
+            this.inputDirectory = parseResult.GetValue<DirectoryInfo?>("--input-directory");
         }
 
         /// <summary>
@@ -208,6 +219,20 @@ namespace ECoreNetto.Tools.Commands
             if (!this.noLogo)
             {
                 AnsiConsole.Markup($"[blue]{ResourceLoader.QueryLogo()}[/]");
+            }
+
+            if (this.inputDirectory != null)
+            {
+                if (!this.inputDirectory.Exists)
+                {
+                    AnsiConsole.WriteLine("");
+                    AnsiConsole.MarkupLine($"[red]The specified input directory does not exist[/]");
+                    AnsiConsole.MarkupLine($"[purple]{this.inputDirectory.FullName}[/]");
+                    AnsiConsole.WriteLine("");
+                    return false;
+                }
+
+                return true;
             }
 
             if (!this.inputModel.Exists)

--- a/ECoreNetto.Tools/Commands/ReportHandler.cs
+++ b/ECoreNetto.Tools/Commands/ReportHandler.cs
@@ -81,6 +81,12 @@ namespace ECoreNetto.Tools.Commands
         private bool autoOpenReport;
 
         /// <summary>
+        /// The value indicating whether the report should also include every cross-referenced model that is
+        /// reachable from the input model (a single combined report).
+        /// </summary>
+        private bool includeReferencedModels;
+
+        /// <summary>
         /// Asynchronously invokes the <see cref="ReportHandler"/>
         /// </summary>
         /// <param name="parseResult">
@@ -131,7 +137,14 @@ namespace ECoreNetto.Tools.Commands
 
                         await Task.Delay(this.StatusDelay, cancellationToken);
 
-                        this.ReportGenerator.GenerateReport(this.inputModel, this.outputReport);
+                        if (this.includeReferencedModels)
+                        {
+                            this.ReportGenerator.GenerateCombinedReport(this.inputModel, this.outputReport);
+                        }
+                        else
+                        {
+                            this.ReportGenerator.GenerateReport(this.inputModel, this.outputReport);
+                        }
 
                         AnsiConsole.MarkupLine(
                             $"[grey]LOG:[/] Ecore {this.ReportGenerator.QueryReportType()} report generated at [bold]{this.outputReport.FullName}[/]");
@@ -181,6 +194,7 @@ namespace ECoreNetto.Tools.Commands
             this.inputModel = parseResult.GetValue<FileInfo>("--input-model")!;
             this.autoOpenReport = parseResult.GetValue<bool>("--auto-open-report");
             this.outputReport = parseResult.GetValue<FileInfo>("--output-report")!;
+            this.includeReferencedModels = parseResult.GetValue<bool>("--include-referenced-models");
         }
 
         /// <summary>


### PR DESCRIPTION
﻿## Summary

Adds the ability to generate a **single** report (HTML, Markdown, Excel or model-inspection) that documents a **multi-file** Ecore metamodel, rather than one report per input file (fixes #89). The existing single-file behaviour is unchanged.

## What is delivered

- **Base (`ReportGenerator`)**: `LoadRootPackages(FileInfo)` (entry model plus every cross-referenced model reachable from it) and `LoadRootPackages(DirectoryInfo)` (every `.ecore` in a folder), both returning the root `EPackage` of every resource in one `ResourceSet`.
- **Payload (`HandleBarsReportGenerator`)**: `CreateHandlebarsPayload(IReadOnlyList<EPackage>)` aggregates enums, primitive/other data types, classes and interfaces across all root packages; the single-package overload delegates to it.
- **Generators**: `GenerateCombinedReport(...)` overloads on `HtmlReportGenerator`, `MarkdownReportGenerator`, `XlReportGenerator` and `ModelInspector` — both the entry-reachable (`FileInfo`) and directory-wide (`DirectoryInfo`) shapes. The Excel info sheet gains an "Included Packages" row.
- **Interfaces**: `IReportGenerator.GenerateCombinedReport(FileInfo, FileInfo)` (drives the CLI polymorphically) plus format-specific directory/string overloads.
- **CLI**: `--include-referenced-models` / `-r` on every report command; when set the handler calls `GenerateCombinedReport` instead of `GenerateReport`.

## Design notes

- Aggregation is exact — `EPackage.QueryPackages()` returns each root plus its containment subtree, and the file roots are disjoint, so there is no double counting.
- Cross-file references remain resolved (they are demand-loaded into the shared `ResourceSet`); the #96/#112 anchor scheme keeps anchors unique across files so intra-document links work in the combined HTML report.
- The directory shape reliably covers "all files"; the entry-reachable shape (the issue's least-intrusive suggestion) covers everything referenced from one entry and is what the CLI `-r` flag exposes.

## Testing

- Full solution green (`dotnet test EcoreNetto.sln`): 338 tests.
- Combined-report tests against the full Eclipse Capella metamodel (21 files) for **HTML, Markdown, Excel and inspection** — a single output whose content originates from several different `.ecore` files; plus entry-reachable tests, a CLI `-r` handler test and null-guard tests.
- New combined-report code meets the >= 80% new-code coverage bar.

## Acceptance criteria

- [x] Single HTML report containing packages from all Capella files
- [x] Single Excel report containing packages from all Capella files
- [x] Single Markdown report containing packages from all Capella files
- [x] Existing single-file behaviour unchanged
- [x] Cross-file references remain resolved
- [x] Tests cover the combined-report path (Capella), augmenting the per-file fixture
